### PR TITLE
Move partial and identity so that they have legible module target paths

### DIFF
--- a/src/hydra_utils/funcs.py
+++ b/src/hydra_utils/funcs.py
@@ -1,0 +1,21 @@
+"""
+Simple helper functions used to implement `just` and `builds`. This module is designed specifically so
+that these functions have a legible module-path when they appear in configuration files.
+"""
+
+import functools as _functools
+import typing as _typing
+
+_T = _typing.TypeVar("_T")
+
+__all__ = ["partial", "identity"]
+
+
+def partial(_partial_target_: _typing.Callable, *args, **kwargs) -> _typing.Callable:
+    """Equivalent to ``functools.partial`` but provides a named parameter for the callable."""
+    return _functools.partial(_partial_target_, *args, **kwargs)
+
+
+def identity(obj: _T) -> _T:
+    """Returns ``obj`` unchanged."""
+    return obj

--- a/src/hydra_utils/structured_configs/_implementations.py
+++ b/src/hydra_utils/structured_configs/_implementations.py
@@ -1,10 +1,8 @@
-import functools
 import inspect
 from collections import defaultdict
 from dataclasses import Field, dataclass, field, fields, is_dataclass, make_dataclass
 from typing import (
     Any,
-    Callable,
     Dict,
     List,
     Mapping,
@@ -18,6 +16,7 @@ from typing import (
 
 from typing_extensions import Literal
 
+from hydra_utils.funcs import identity, partial
 from hydra_utils.structured_configs import _utils
 from hydra_utils.typing import Builds, Importable, Instantiable, Just, PartialBuilds
 
@@ -76,11 +75,6 @@ class hydrated_dataclass:
         )
 
 
-def partial(_partial_target_: Callable, *args, **kwargs) -> Callable:
-    """Provides a named parameter for using partial"""
-    return functools.partial(_partial_target_, *args, **kwargs)
-
-
 def just(obj: Importable) -> Just[Importable]:
     """Produces a structured config that, when instantiated by hydra, 'just'
     returns ``obj``.
@@ -113,7 +107,7 @@ def just(obj: Importable) -> Just[Importable]:
     >>> from hydra_utils import just, instantiate
     >>> just_str_conf = just(str)
     >>> just_str_conf._target_
-    'hydra_utils.structured_configs._utils.identity'
+    'hydra_utils.funcs.identity'
     >>> just_str_conf.obj
     '${get_obj:builtins.str}'
     >>> str is instantiate(just_str_conf)
@@ -130,7 +124,7 @@ def just(obj: Importable) -> Just[Importable]:
             (
                 "_target_",
                 str,
-                field(default=_utils.get_obj_path(_utils.identity), init=False),
+                field(default=_utils.get_obj_path(identity), init=False),
             ),
             (
                 "obj",

--- a/src/hydra_utils/structured_configs/_utils.py
+++ b/src/hydra_utils/structured_configs/_utils.py
@@ -90,10 +90,6 @@ def interpolated(func: Union[str, Callable], *literals: Any) -> str:
     return f"${{{name}:{','.join(str(i) for i in literals)}}}"
 
 
-def identity(obj: T) -> T:
-    return obj
-
-
 def get_obj(path: str) -> Union[type, Callable[..., Any]]:
     """Imports an object given the specified path."""
     try:


### PR DESCRIPTION
Before:

```python
>>> OmegaConf.to_yaml(builds(dict, hydra_partial=True))
_target_: hydra_utils.structured_configs._implementations.partial
_partial_target_:
  _target_: hydra_utils.structured_configs._utils.identity
  obj: ${hydra_utils_get_obj:builtins.dict}
_recursive_: true
_convert_: none
```

After:

```python
>>> OmegaConf.to_yaml(builds(dict, hydra_partial=True))
_target_: hydra_utils.funcs.partial
_partial_target_:
  _target_: hydra_utils.funcs.identity
  obj: ${hydra_utils_get_obj:builtins.dict}
_recursive_: true
_convert_: none
```