### PR TITLE
builds and just: raise if target is not importable

### DIFF
--- a/tests/test_dataclass_semantics.py
+++ b/tests/test_dataclass_semantics.py
@@ -11,10 +11,12 @@ def f_three_vars(x, y, z):
     return x, y, z
 
 
+def f(x, y):
+    return x, y
+
+
 @given(full_sig=st.booleans(), partial=st.booleans())
 def test_builds_produces_dataclass(full_sig: bool, partial: bool):
-    def f(x, y):
-        return x, y
 
     if full_sig:
         Builds_f = builds(f, populate_full_signature=full_sig, hydra_partial=partial)
@@ -26,16 +28,18 @@ def test_builds_produces_dataclass(full_sig: bool, partial: bool):
     assert out.y == -1.0
 
 
+def f_2(x, y, z):
+    pass
+
+
 @pytest.mark.parametrize("full_sig", [True, False])
 @pytest.mark.parametrize("partial", [True, False])
 def test_chain_builds_of_targets_with_common_interfaces(full_sig, partial):
-    def f(x, y, z):
-        pass
 
     # Note that conf_1 and conf_2 target `f` whereas conf_3 targets `f_three_vars`,
     # which have identical interfaces.
-    conf_1 = builds(f, x=1)
-    conf_2 = builds(f, y=2, builds_bases=(conf_1,))
+    conf_1 = builds(f_2, x=1)
+    conf_2 = builds(f_2, y=2, builds_bases=(conf_1,))
     conf_3 = builds(
         f_three_vars,
         z=3,


### PR DESCRIPTION
Closes #5 

Before:

```python
def make_conf():
    def unimportable(): pass
    return builds(unimportable) 
conf = make_conf()
instantiate(conf)  # raises during instantiation
```

After:

```python
def make_conf():
    def unimportable(): pass
    return builds(unimportable)   
conf = make_conf()  # raises during construction
```