### PR TITLE
DONT MERGE: pyright CI should report failure

### DIFF
--- a/src/hydra_utils/_hydra_overloads.py
+++ b/src/hydra_utils/_hydra_overloads.py
@@ -34,7 +34,7 @@ def instantiate(config: Just[T], *args: Any, **kwargs: Any) -> T:  # pragma: no 
 
 @overload
 def instantiate(
-    config: PartialBuilds[Type[T]], *args: Any, **kwargs: Any
+    config: PartialBuilds[T], *args: Any, **kwargs: Any
 ) -> Partial[T]:  # pragma: no cover
     ...
 


### PR DESCRIPTION
Purposefully breaks our type annotations. Our CI should catch this now!