### PR TITLE
Implement just without custom resolver

### DIFF
--- a/src/hydra_zen/funcs.py
+++ b/src/hydra_zen/funcs.py
@@ -7,10 +7,14 @@ that these functions have a legible module-path when they appear in configuratio
 
 import functools as _functools
 import typing as _typing
+from typing import Any, Callable, Union
+
+from hydra._internal import utils as hydra_internal_utils
+from hydra.utils import log
 
 _T = _typing.TypeVar("_T")
 
-__all__ = ["partial", "identity"]
+__all__ = ["partial", "get_obj"]
 
 
 def partial(_partial_target_: _typing.Callable, *args, **kwargs) -> _typing.Callable:
@@ -18,6 +22,11 @@ def partial(_partial_target_: _typing.Callable, *args, **kwargs) -> _typing.Call
     return _functools.partial(_partial_target_, *args, **kwargs)
 
 
-def identity(obj: _T) -> _T:
-    """Returns ``obj`` unchanged."""
-    return obj
+def get_obj(path: str) -> Union[type, Callable[..., Any]]:
+    """Imports an object given the specified path."""
+    try:
+        cl = hydra_internal_utils._locate(path)
+        return cl
+    except Exception as e:  # pragma: no cover
+        log.error(f"Error getting callable at {path} : {e}")
+        raise e

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -19,7 +19,7 @@ from typing import (
 
 from typing_extensions import Final, Literal
 
-from hydra_zen.funcs import identity, partial
+from hydra_zen.funcs import get_obj, partial
 from hydra_zen.structured_configs import _utils
 from hydra_zen.typing import Builds, Importable, Instantiable, Just, PartialBuilds
 
@@ -260,13 +260,13 @@ def just(obj: Importable) -> Just[Importable]:
             (
                 _TARGET_FIELD_NAME,
                 str,
-                field(default=_utils.get_obj_path(identity), init=False),
+                field(default=_utils.get_obj_path(get_obj), init=False),
             ),
             (
-                "obj",
-                Any,
+                "path",
+                str,
                 field(
-                    default=_utils.interpolated("hydra_zen_get_obj", obj_path),
+                    default=obj_path,
                     init=False,
                 ),
             ),

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -5,9 +5,6 @@ from dataclasses import is_dataclass
 from enum import Enum
 from typing import Any, Callable, Tuple, TypeVar, Union
 
-import hydra._internal.utils as hydra_internal_utils
-from hydra.utils import log
-from omegaconf import OmegaConf
 from typing_extensions import Final
 
 from hydra_zen.typing import Importable
@@ -91,19 +88,6 @@ def interpolated(func: Union[str, Callable], *literals: Any) -> str:
         )
     name = func if isinstance(func, str) else func.__name__
     return f"${{{name}:{','.join(str(i) for i in literals)}}}"
-
-
-def get_obj(path: str) -> Union[type, Callable[..., Any]]:
-    """Imports an object given the specified path."""
-    try:
-        cl = hydra_internal_utils._locate(path)
-        return cl
-    except Exception as e:  # pragma: no cover
-        log.error(f"Error getting callable at {path} : {e}")
-        raise e
-
-
-OmegaConf.register_new_resolver("hydra_zen_get_obj", get_obj, use_cache=False)
 
 
 def sanitized_type(type_: type) -> type:


### PR DESCRIPTION
Simpler implementation and cleaner yamls!

Before:

```
  # just
  _target_: hydra_zen.funcs.identity
  obj: ${hydra_zen_get_obj:__main__.parabaloid}
  
   # partial
   _target_: hydra_zen.funcs.partial
   _partial_target_:
    _target_: hydra_zen.funcs.identity
    obj: ${hydra_zen_get_obj:torch.optim.sgd.SGD}
```

After:

```
  # just
  _target_: hydra_zen.funcs.get_obj
  path: __main__.parabaloid
  
  # partial
  _target_: hydra_zen.funcs.partial
  _partial_target_:
    _target_: hydra_zen.funcs.get_obj
    path: torch.optim.sgd.SGD
```

Need to update #21  to reflect the cleaner yaml.