### PR TITLE
Support annotations of the form Tuple[x, ...]

### DIFF
--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -250,14 +250,18 @@ def sanitized_type(
             if not args:
                 return Any  # bare Tuple not supported by hydra
             unique_args = set(args)
+            has_ellipses = Ellipsis in unique_args
 
             _unique_type = (
                 sanitized_type(args[0], primitive_only=True)
-                if len(unique_args) == 1
+                if len(unique_args) == 1 or (len(unique_args) == 2 and has_ellipses)
                 else Any
             )
+            if has_ellipses:
+                return Tuple[_unique_type, ...]
+            else:
+                return Tuple[(_unique_type,) * len(args)]
 
-            return Tuple[(_unique_type,) * len(args)]
         return Any
 
     if (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -165,6 +165,8 @@ class Color(enum.Enum):
         (Dict[str, C], Dict[str, Any]),
         (Dict[C, C], Dict[Any, Any]),
         (Dict[str, List[int]], Dict[str, Any]),
+        (Tuple[str], Tuple[str]),
+        (Tuple[str, ...], Tuple[str, ...]),
         (Tuple[str, str, str], Tuple[str, str, str]),
         (Tuple[List[int]], Tuple[Any]),
     ],


### PR DESCRIPTION
```python
def f(x: Tuple[int, ...]): pass
```

Before:

```python
>>> inspect.signature(builds(f, populate_full_signature=True))
<Signature (x: Tuple[Any, Any]) -> None>
```

After:

```python
>>> inspect.signature(builds(f, populate_full_signature=True))
<Signature (x: Tuple[int, ...]) -> None>
```
