### PR TITLE
Fix typing behavior

### DIFF
--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -63,8 +63,8 @@ def instantiate(
 
 @overload
 def instantiate(
-    config: PartialBuilds[Callable_T], *args: Any, **kwargs: Any
-) -> Partial[Callable_T]:  # pragma: no cover
+    config: PartialBuilds[Callable[..., T]], *args: Any, **kwargs: Any
+) -> Partial[T]:  # pragma: no cover
     ...
 
 

--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -32,8 +32,6 @@ __all__ = ["instantiate", "to_yaml", "save_as_yaml", "load_from_yaml", "MISSING"
 
 T = TypeVar("T")
 
-Callable_T = TypeVar("Callable_T", bound=Callable)
-
 
 @overload
 def instantiate(

--- a/src/hydra_zen/typing.py
+++ b/src/hydra_zen/typing.py
@@ -46,6 +46,8 @@ class DataClass(Protocol):
 
 @runtime_checkable
 class Builds(DataClass, Protocol[_T]):  # pragma: no cover
+    def __init__(self, *args, **kwargs) -> None:
+        ...
     _target_: str
 
 

--- a/src/hydra_zen/typing.py
+++ b/src/hydra_zen/typing.py
@@ -48,6 +48,7 @@ class DataClass(Protocol):
 class Builds(DataClass, Protocol[_T]):  # pragma: no cover
     def __init__(self, *args, **kwargs) -> None:
         ...
+
     _target_: str
 
 

--- a/tests/annotations/behaviors.py
+++ b/tests/annotations/behaviors.py
@@ -85,7 +85,7 @@ b.x = 3
 
 # Check that `Builds` constructor can take arguments
 X = builds(dict, a=1)
-y = X(a=10)  # Error: Expected no arguments to Builds constructor
+y = X(a=10)
 
 
 def g(x: int, y: float) -> str:

--- a/tests/annotations/behaviors.py
+++ b/tests/annotations/behaviors.py
@@ -35,14 +35,12 @@ out_2: Tuple[int, str] = should_be_a_2.x
 
 conf_f_partial = builds(f, hydra_partial=True)
 partial_out_f = instantiate(conf_f_partial)
-should_be_f = partial_out_f()
-should_be_int_output_of_f: int = should_be_f(2)
+should_be_int_output_of_f: int = partial_out_f()
 
 
 conf_f_partial_instance = builds(f, hydra_partial=True)()
 partial_out_f_2 = instantiate(conf_f_partial_instance)
-should_be_f_2 = partial_out_f_2()
-should_be_int_output_of_f_2: int = should_be_f_2(2)
+should_be_int_output_of_f_2: int = partial_out_f_2()
 
 # test builds(..., hydra_partial=False)
 conf_A = builds(A)
@@ -87,4 +85,13 @@ b.x = 3
 
 # Check that `Builds` constructor can take arguments
 X = builds(dict, a=1)
-y = X(a=10)   # Error: Expected no arguments to Builds constructor
+y = X(a=10)  # Error: Expected no arguments to Builds constructor
+
+
+def g(x: int, y: float) -> str:
+    ...
+
+
+PartialBuild_g = builds(g, x=1, hydra_partial=True)
+partial_g = instantiate(PartialBuild_g)
+g_out: str = partial_g(y=10)

--- a/tests/annotations/behaviors.py
+++ b/tests/annotations/behaviors.py
@@ -81,5 +81,10 @@ class B:
     x: int
 
 
+# Check that @hydrated_dataclass reveals init/attr info
 b = B(x=2)
 b.x = 3
+
+# Check that `Builds` constructor can take arguments
+X = builds(dict, a=1)
+y = X(a=10)   # Error: Expected no arguments to Builds constructor

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -32,8 +32,8 @@ out_a: A = partial_out()
 f_sig = Callable[[int], int]
 conf_f_partial: Type[PartialBuilds[f_sig]] = builds(f, hydra_partial=True)
 conf_f_partial_instance = conf_f_partial()
-partial_out_f: Partial[f_sig] = instantiate(conf_f_partial)
-partial_out_f_via_instance: Partial[f_sig] = instantiate(conf_f_partial_instance)
+partial_out_f: Partial[int] = instantiate(conf_f_partial)
+partial_out_f_via_instance: Partial[int] = instantiate(conf_f_partial_instance)
 
 # test builds(..., hydra_partial=False)
 conf_A_1: Type[Builds[Type[A]]] = builds(A, hydra_partial=False)


### PR DESCRIPTION
### `Builds` protocol constructor should be able to accept arbitrary arguments

We don't know ahead of time what it should or shouldn't accept, since we don't have access to its true signature.

Before:

![image](https://user-images.githubusercontent.com/29104956/123026215-ca2fdc00-d3a9-11eb-9841-2487387b13b3.png)

After:

![image](https://user-images.githubusercontent.com/29104956/123026331-f9dee400-d3a9-11eb-8edb-cc0cb88a3595.png)


### Fix Bad Override for `instantiate(..., hydra_partial=True)`
Before:

![image](https://user-images.githubusercontent.com/29104956/123026511-53471300-d3aa-11eb-8c5c-d578e207dc8c.png)

After:

![image](https://user-images.githubusercontent.com/29104956/123026755-b173f600-d3aa-11eb-8921-b7a8c31baada.png)
