### PR TITLE
pin pyright

### DIFF
--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -159,7 +159,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install pyright
-      run: sudo npm install -g pyright@">=1.1.148"
+      run: sudo npm install -g pyright@1.1.151
     - uses: actions/checkout@v1
     - name: Set up Python
       uses: actions/setup-python@v2


### PR DESCRIPTION
There appears to be a regression in pyright post version `1.1.151` where it no longer handles:

```python
@overload
def instantiate(
    config: PartialBuilds[Callable[..., T]], *args: Any, **kwargs: Any
) -> Partial[T]:  # pragma: no cover
    ...
```

where the following is the appropriate behavior:

```python
x: PartialBuilds[(x: int -> int)]
instantiate(x)  # type: Partial[int]
```

but pyright > 1.1.151 produces:

```python
x: PartialBuilds[(x: int -> int)]
instantiate(x)  # type: Partial[(x: int -> int)]
```