### PR TITLE
typing: change overload priorities for instantiate (pyright compat)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,3 +20,36 @@ jobs:
         pip install tox tox-gh-actions
     - name: Test with tox
       run: tox -e pre-release
+  run-pyright:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-node@v2-beta
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+
+    - name: Get npm cache directory
+      id: npm-cache
+      run: |
+        echo "::set-output name=dir::$(npm config get cache)"
+    - uses: actions/cache@v2
+      with:
+        path: ${{ steps.npm-cache.outputs.dir }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - name: Install pyright
+      run: sudo npm install -g pyright@">=1.1.148"
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+    - name: Run pyright
+      run: pyright --lib tests/annotations/

--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -47,6 +47,20 @@ def instantiate(config: Just[T], *args: Any, **kwargs: Any) -> T:  # pragma: no 
 
 @overload
 def instantiate(
+    config: PartialBuilds[Callable[..., T]], *args: Any, **kwargs: Any
+) -> Partial[T]:  # pragma: no cover
+    ...
+
+
+@overload
+def instantiate(
+    config: Type[PartialBuilds[Callable[..., T]]], *args: Any, **kwargs: Any
+) -> Partial[T]:  # pragma: no cover
+    ...
+
+
+@overload
+def instantiate(
     config: Type[PartialBuilds[Type[T]]], *args: Any, **kwargs: Any
 ) -> Partial[T]:  # pragma: no cover
     ...
@@ -55,13 +69,6 @@ def instantiate(
 @overload
 def instantiate(
     config: PartialBuilds[Type[T]], *args: Any, **kwargs: Any
-) -> Partial[T]:  # pragma: no cover
-    ...
-
-
-@overload
-def instantiate(
-    config: PartialBuilds[Callable[..., T]], *args: Any, **kwargs: Any
 ) -> Partial[T]:  # pragma: no cover
     ...
 


### PR DESCRIPTION
`Callable[..., T]` has to be prioritized over `Type[T]` in the overloads

Add pyright run to nightly