### PR TITLE
Create SPDX.spdx

### DIFF
--- a/SPDX.spdx
+++ b/SPDX.spdx
@@ -1,0 +1,5 @@
+    SPDXVersion: SPDX-2.1
+    PackageName: hydra-zen
+    PackageOriginator: MIT Lincoln Laboratory
+    PackageHomePage: https://github.com/mit-ll-responsible-ai/hydra-zen/new/main
+    PackageLicenseDeclared: MIT

--- a/SPDX.spdx
+++ b/SPDX.spdx
@@ -1,5 +1,5 @@
     SPDXVersion: SPDX-2.1
     PackageName: hydra-zen
     PackageOriginator: MIT Lincoln Laboratory
-    PackageHomePage: https://github.com/mit-ll-responsible-ai/hydra-zen/new/main
+    PackageHomePage: https://github.com/mit-ll-responsible-ai/hydra-zen
     PackageLicenseDeclared: MIT


### PR DESCRIPTION
Adding a machine readable file (named SPDX.spdx) to your root directory enables services to properly locate and index your project. We recommend using the Software Package Data Exchange® (SPDX®) standard which readily communicates the components, licenses and copyrights associated with software packages.