### PR TITLE
Applies type auto-widening to accommodate Builds-as-default

### DIFF
--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -780,7 +780,7 @@ def builds(
             #    https://github.com/facebookresearch/hydra/issues/1759
             # Thus we will auto-broaden the annotation when we see that the user
             # has specified a `Builds` as a default value.
-            if not isinstance(value, Builds) else Any,
+            if not isinstance(value, Builds) or hydra_recursive is False else Any,
             sanitized_default_value(value),
         )
         for name, value in kwargs_for_target.items()

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
+from dataclasses import dataclass
 from functools import partial
 
 import pytest
@@ -31,3 +32,18 @@ def test_Builds_is_not_PartialBuilds():
 
     PConf = builds(dict, hydra_partial=True)
     assert isinstance(PConf, Builds)
+
+
+def test_targeted_dataclass_is_Builds():
+    @dataclass
+    class NonTargeted:
+        pass
+
+    @dataclass
+    class Targeted:
+        _target_: str = "hello"
+
+    assert not isinstance(NonTargeted, Builds)
+    assert not isinstance(NonTargeted(), Builds)
+    assert isinstance(Targeted, Builds)
+    assert isinstance(Targeted(), Builds)

--- a/tests/test_signature_parsing.py
+++ b/tests/test_signature_parsing.py
@@ -291,12 +291,14 @@ def expects_int(x: int) -> int:
         builds(returns_int)(),  # instance
     ],
 )
-def test_setting_default_with_Builds_widens_type(builds_as_default):
+@pytest.mark.parametrize("hydra_recursive", [True, None])
+def test_setting_default_with_Builds_widens_type(builds_as_default, hydra_recursive):
     # tests that we address https://github.com/facebookresearch/hydra/issues/1759
     # via auto type-widening
-    b = builds(expects_int, x=builds_as_default)
+    kwargs = {} if hydra_recursive is None else dict(hydra_recursive=hydra_recursive)
+    b = builds(expects_int, x=builds_as_default, **kwargs)
     instantiate(b)  # should not raise type
 
     with pytest.raises(ValidationError):
-        # ensure that non-Builds/int gets caught by type validation
-        instantiate(builds(expects_int, x="hi"))
+        # ensure that type validation is broadened only when hydra_recursive=False
+        instantiate(builds(expects_int, x=builds_as_default, hydra_recursive=False))

--- a/tests/test_signature_parsing.py
+++ b/tests/test_signature_parsing.py
@@ -281,7 +281,7 @@ def returns_int() -> int:
 
 
 def expects_int(x: int) -> int:
-    pass
+    return x
 
 
 @pytest.mark.parametrize(
@@ -297,8 +297,8 @@ def test_setting_default_with_Builds_widens_type(builds_as_default, hydra_recurs
     # via auto type-widening
     kwargs = {} if hydra_recursive is None else dict(hydra_recursive=hydra_recursive)
     b = builds(expects_int, x=builds_as_default, **kwargs)
-    instantiate(b)  # should not raise type
+    assert 1 == instantiate(b)  # should not raise ValidationError
 
     with pytest.raises(ValidationError):
-        # ensure that type validation is broadened only when hydra_recursive=False
+        # ensure that type annotation is broadened only when hydra_recursive=False
         instantiate(builds(expects_int, x=builds_as_default, hydra_recursive=False))


### PR DESCRIPTION
Hydra's type-checking occurs prior to recursive instantiation. This means that, e.g., passing a type-`Builds[int]` argument to a field `x: int` will trigger Hydra's type-checking upon recursive instantiation, even though the recursive instantiation will appropriately produce `int` for that argument.

To address this, hydra-zen now applies type auto-widening to accommodate a case where a user supplies a `Builds`-type argument to a non-`Any` field (addresses https://github.com/facebookresearch/hydra/issues/1759)

Given:

```python
def returns_int() -> int:
    return 1


def expects_int(x: int) -> int:
    returns x
```

Before:



```python
>>> instantiate(builds(expects_int, x=builds(returns_int))) 
---------------------------------------------------------------------------
ValidationError: Invalid type assigned: Builds_returns_int is not a subclass of int. value: <class 'types.Builds_returns_int'>
    full_key: x
    object_type=None
```

After:

```python
>>> instantiate(builds(expects_int, x=builds(returns_int))) 
1

>>> instantiate(builds(expects_int, x=builds(returns_int), hydra_recursive=False))  # type-broadening only occurs in recursive cases 
---------------------------------------------------------------------------
ValidationError: Invalid type assigned: Builds_returns_int is not a subclass of int. value: <class 'types.Builds_returns_int'>
    full_key: x
    object_type=None
```