### PR TITLE
add pyright test for  dataclass protocol

### DIFF
--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
-from dataclasses import Field, _DataclassParams
+from dataclasses import Field
 from typing import Any, Callable, Dict, Generic, Tuple, TypeVar
 
 from typing_extensions import Protocol, runtime_checkable
@@ -42,7 +42,6 @@ Importable = TypeVar("Importable")
 
 class DataClass(Protocol):
     __dataclass_fields__: Dict[str, Field]
-    __dataclass_params__: _DataclassParams
 
 
 @runtime_checkable

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: MIT
 
 from typing import Callable, Tuple, Type
-
+from dataclasses import dataclass
 from hydra_zen import builds, instantiate, just
 from hydra_zen.typing import Builds, Just, Partial, PartialBuilds
+from hydra_zen.typing._implementations import DataClass
 
 
 class A:
@@ -55,3 +56,14 @@ should_be_int_again: int = instantiate(conf_f_2)
 # test just(...)
 conf_just_f: Type[Just[f_sig]] = just(f)
 conf_just_A: Type[Just[Type[A]]] = just(A)
+
+
+@dataclass
+class SomeDataClass:
+    pass
+
+def requires_dataclass(x: DataClass):
+    pass
+
+some_dataclass = SomeDataClass()
+requires_dataclass(some_dataclass)  # should satisfy DataClass protocol

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -62,8 +62,4 @@ conf_just_A: Type[Just[Type[A]]] = just(A)
 class SomeDataClass:
     pass
 
-def requires_dataclass(x: DataClass):
-    pass
-
-some_dataclass = SomeDataClass()
-requires_dataclass(some_dataclass)  # should satisfy DataClass protocol
+some_dataclass: DataClass = SomeDataClass()


### PR DESCRIPTION
Fixes the `DataClass` protocol, which was too narrow, and adds a pyright test.

Our `DataClass` included a spurious field that is not recognized by pyright. This did not prevent `Builds` et al. from being seen broadly as dataclasses, since our protocol was overly narrow rather than broad.

 