### PR TITLE
run shed auto-formatter on everything

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -22,6 +22,9 @@ We will then launch multiple jobs – each on calls the function with a differen
 
 .. code-block:: python
 
+   from hydra_zen import builds, instantiate, to_yaml
+   from hydra_zen.experimental import hydra_multirun
+   
    # some code to configure and run
    def repeat_text(num: int, text: str) -> str:
        return text * num

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -22,9 +22,6 @@ We will then launch multiple jobs – each on calls the function with a differen
 
 .. code-block:: python
 
-   from hydra_zen import builds, instantiate, to_yaml
-   from hydra_zen.experimental import hydra_multirun
-
    # some code to configure and run
    def repeat_text(num: int, text: str) -> str:
        return text * num

--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -105,7 +105,7 @@ def instantiate(
 @overload
 def instantiate(
     config: Union[ListConfig, DictConfig, DataClass], *args, **kwargs
-) -> Any:   # pragma: no cover
+) -> Any:  # pragma: no cover
     ...
 
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -670,10 +670,10 @@ def builds(
 
     # these are the names of the only parameters in the signature of `target` that can
     # be referenced by name
-    nameable_params_in_sig: Set[str] = set(
+    nameable_params_in_sig: Set[str] = {
         p.name
         for p in chain(sig_by_kind[_POSITIONAL_OR_KEYWORD], sig_by_kind[_KEYWORD_ONLY])
-    )
+    }
 
     if not pos_args and builds_bases:
         # pos_args is potentially inherited
@@ -966,7 +966,7 @@ def get_target(obj: Builds[_T]) -> _T:  # pragma: no cover
 
 
 @overload
-def get_target(obj: Union[HasTarget, HasPartialTarget]) -> Any:   # pragma: no cover
+def get_target(obj: Union[HasTarget, HasPartialTarget]) -> Any:  # pragma: no cover
     ...
 
 

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -4,7 +4,7 @@
 import sys
 from dataclasses import is_dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
 
 from typing_extensions import Final
 

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 from dataclasses import Field
-from typing import Any, Callable, Dict, Generic, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, Tuple, TypeVar
 
 from typing_extensions import Protocol, runtime_checkable
 

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT
 
 from dataclasses import dataclass
-from typing import Any, Callable, Tuple, Type, Literal
+from typing import Any, Callable, Literal, Tuple, Type
 
 from hydra_zen import builds, get_target, instantiate, just
-from hydra_zen.typing import Builds, Just, Partial, PartialBuilds
+from hydra_zen.typing import Builds
 from hydra_zen.typing._implementations import DataClass
 
 

--- a/tests/experimental/test_logging.py
+++ b/tests/experimental/test_logging.py
@@ -23,13 +23,13 @@ def test_consecutive_logs():
     job2 = hydra_run(builds(dict, message="2"), task_function=task)
 
     if job1.working_dir == job2.working_dir:
-        with open(Path(job1.working_dir) / "hydra_run.log", "r") as f:
+        with open(Path(job1.working_dir) / "hydra_run.log") as f:
             line1, line2 = f.readlines()
         assert "message: 1" in line1
         assert "message: 2" in line2
 
     else:
         for n, job in enumerate([job1, job2]):
-            with open(Path(job.working_dir) / "hydra_run.log", "r") as f:
+            with open(Path(job.working_dir) / "hydra_run.log") as f:
                 (line,) = f.readlines()
             assert f"message: {n + 1}" in line

--- a/tests/test_hydrated_dataclass.py
+++ b/tests/test_hydrated_dataclass.py
@@ -5,7 +5,7 @@ from dataclasses import is_dataclass
 
 import pytest
 
-from hydra_zen import builds, hydrated_dataclass, instantiate
+from hydra_zen import hydrated_dataclass, instantiate
 
 
 def f1(x, y):

--- a/tests/test_roundtrips.py
+++ b/tests/test_roundtrips.py
@@ -11,7 +11,7 @@ from hypothesis import given
 from omegaconf import OmegaConf
 
 from hydra_zen import builds, get_target, instantiate, just, to_yaml
-from hydra_zen.typing._implementations import HasTarget
+
 from tests import valid_hydra_literals
 
 arbitrary_kwargs = st.dictionaries(

--- a/tests/test_signature_parsing.py
+++ b/tests/test_signature_parsing.py
@@ -14,6 +14,7 @@ from omegaconf.errors import ValidationError
 
 from hydra_zen import builds, hydrated_dataclass, instantiate, mutable_value, to_yaml
 from hydra_zen.typing import Just
+
 from tests import valid_hydra_literals
 
 Empty = Parameter.empty
@@ -234,7 +235,7 @@ def test_builds_partial_with_full_sig_excludes_non_specified_params(
         target,
         **user_specified_values,
         populate_full_signature=True,
-        hydra_partial=True
+        hydra_partial=True,
     )
 
     expected_sig = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,9 +7,8 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 import hypothesis.strategies as st
-import omegaconf
 import pytest
-from hypothesis import given, note
+from hypothesis import given
 from omegaconf import OmegaConf, ValidationError
 from omegaconf.errors import (
     ConfigIndexError,

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -85,7 +85,7 @@ def test_builds_raises_when_user_specified_args_violate_sig(
             *args,
             **kwargs,
             hydra_partial=partial,
-            populate_full_signature=full_sig
+            populate_full_signature=full_sig,
         )
 
     # test when **kwargs are inherited
@@ -96,7 +96,7 @@ def test_builds_raises_when_user_specified_args_violate_sig(
             *args,
             hydra_partial=partial,
             populate_full_signature=full_sig,
-            builds_bases=(kwarg_base,)
+            builds_bases=(kwarg_base,),
         )
 
     # test when *args are inherited
@@ -107,7 +107,7 @@ def test_builds_raises_when_user_specified_args_violate_sig(
             **kwargs,
             hydra_partial=partial,
             populate_full_signature=full_sig,
-            builds_bases=(args_base,)
+            builds_bases=(args_base,),
         )
 
     # test when *args and **kwargs are inherited

--- a/tests/test_validation_py38.py
+++ b/tests/test_validation_py38.py
@@ -9,6 +9,7 @@ from hypothesis import given
 from omegaconf import OmegaConf
 
 from hydra_zen import builds, instantiate, to_yaml
+
 from tests import valid_hydra_literals
 
 


### PR DESCRIPTION
[shed](https://pypi.org/project/shed/)

> shed canonicalises Python code. Shed your legacy, stop bikeshedding, and move on. Black++

We are already black & isort compliant, so the main changes are removing unused imports