### PR TITLE
add py.typed for PEP 561 compliance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,4 +68,5 @@ setup(
     python_requires=">=3.6",
     packages=find_packages(where="src", exclude=["tests", "tests.*"]),
     package_dir={"": "src"},
+    package_data={"hydra_zen": ["py.typed"]}
 )


### PR DESCRIPTION
Closes #96 

After PR:

```shell
$ echo "from hydra_zen import builds" > tmp.py
$ mypy tmp.py
Success: no issues found in 1 source file
```