### PR TITLE
Improving docs

### DIFF
--- a/docs/source/experimental.rst
+++ b/docs/source/experimental.rst
@@ -82,7 +82,7 @@ Next, the following executes a Hydra Multirun [3]_ job from the CLI and sweeps o
 
 The equivalent ``hydra_multirun`` commands are
 
-.. code-block:: python
+.. code-block:: pycon
 
    >>> from my_app import MyExperiment, task_function
    >>> from hydra_zen.experimental import hydra_multirun
@@ -110,7 +110,7 @@ First let's demonstrate using ``builds``.
 As expected, ``hydra_run`` simply instantiates and creates a dictionary object with the desired key and value pairs.
 Next, launch a Hydra Multirun [3]_ job to sweep over configuration parameters:
 
-.. code:: python
+.. code:: pycon
 
    >>> job = hydra_multirun(
    ...     builds(dict, a=1, b=1),
@@ -127,7 +127,7 @@ Next, launch a Hydra Multirun [3]_ job to sweep over configuration parameters:
 Now let's demonstrate building a dictionary configuration.
 Here we build a configuration to square an input using the ``pow`` function:
 
-.. code:: python
+.. code:: pycon
 
    >>> from omegaconf import DictConfig
    >>> cfg = dict(f=builds(pow, exp=2, hydra_partial=True), x=10)
@@ -142,7 +142,7 @@ Also, this task function is responsible for instantiating the partial function a
 
 Here we perform a multi-run for a range of values of ``x``:
 
-.. code:: python
+.. code:: pycon
 
    >>> cfg = dict(f=builds(pow, exp=2, hydra_partial=True), x=1)
    >>> def task_function(cfg: DictConfig):
@@ -240,7 +240,7 @@ Notice that we have not set a default for the optimizer.
 This is the safest way to avoid Hydra raising a ``ConfigCompositionException``.
 To run the default experiment with ``SGD``, simply set the optimizer using ``overrides``:
 
-.. code:: python
+.. code:: pycon
 
     >>> jobs = hydra_run(
     ...     ConfigGradDesc,
@@ -256,7 +256,7 @@ To run the default experiment with ``SGD``, simply set the optimizer using ``ove
 
 Next run the experiment by varying the optimizer.
 
-.. code:: python
+.. code:: pycon
 
     >>> jobs, = hydra_multirun(
     ...     ConfigGradDesc,
@@ -398,7 +398,7 @@ Now we can use ``hydra_multirun`` to minimize this function via random search:
 
 The return value is the solution along with all the intermediate results:
 
-.. code:: python
+.. code:: pycon
 
     >>> job
     ({'best_evaluated_params': {'x': 1.4667823674518203, 'y': -1.193575968925213},

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -67,7 +67,7 @@ to dynamically generate a "structured configuration" for this function for us.
 This structured configuration can be "instantiated" by Hydra, which means that `repeat_text` will be "built" using the specified configuration values;
 this instantiation will recurse through
 
-.. code-block:: python
+.. code-block:: pycon
 
    >>> from hydra_zen import instantiate
    >>> config_instance = Config(num=3, text="world ")

--- a/docs/source/structured_configs.rst
+++ b/docs/source/structured_configs.rst
@@ -63,7 +63,7 @@ The following table compares the two standard approaches for configuring ``DNN``
 +-------------------------------+---------------------------------------------------+------------------------------------------------------+
 | (Hydra) Using a yaml file     | (Hydra) Using a structured config                 | (hydra-zen) Using `builds`                           |
 +===============================+===================================================+======================================================+
-| .. code:: yaml                | .. code:: python                                  | .. code:: python                                     |
+| .. code:: yaml                | .. code:: python                                  | .. code:: pycon                                      |
 |                               |                                                   |                                                      |
 |    _target_: vision.model.DNN |    from omegaconf import MISSING                  |    >>> from vision.model import DNN                  |
 |    input_size: ???            |    from dataclasses import dataclass              |    >>> from hydra_zen import builds                  |
@@ -95,7 +95,7 @@ Note that the result of ``builds(DNN, populate_full_signature=True)`` is equival
 
 And this dynamically generated configuration can still be serialized to a yaml file by Hydra:
 
-.. code:: python
+.. code:: pycon
 
    >>> from hydra_zen import to_yaml  # alias of `omegaconf.OmegaConf.to_yaml`
    >>> print(to_yaml(conf_instance))
@@ -238,7 +238,7 @@ Here is what `builds` effectively defines for us "under the hood"
 +---------------------------------------------------+--------------------------------------------------------------------------+
 | Example Using `builds`                            | Equivalent dataclass                                                     |
 +===================================================+==========================================================================+
-| .. code:: python                                  | .. code:: python                                                         |
+| .. code:: pycon                                   | .. code:: python                                                         |
 |                                                   |                                                                          |
 |    >>> from hydra_zen import builds               |    from dataclasses import dataclass, field                              |
 |    >>> builds(make_a_dict, x=2, y=[1, 2, 3])      |                                                                          |
@@ -256,7 +256,7 @@ As we study more of `builds`'s features, we will see that there are many "wins" 
 
 The resulting `dataclass object <https://docs.python.org/3/library/dataclasses.html>`_ is designed specifically to behave as `targeted structured configs  <https://hydra.cc/docs/next/advanced/instantiate_objects/overview>`_ that can be instantiated by Hydra.
 
-.. code:: python
+.. code:: pycon
 
    >>> from dataclasses import is_dataclass
    >>> Builds_dict = builds(make_a_dict, x=2, y=[1, 2, 3])  # signature: Builds_dict(x: Any = 2, y: Any = <factory>)
@@ -293,7 +293,7 @@ This optimizer has configurable parameters, such as a "learning rate" (``lr``), 
 The optimizer must *also* be initialized with the parameters that it will optimizing, however these parameters are typically created after we have started running our program and thus *they are not available to / cannot be part of our configuration*.
 Fortunately, we can use ``builds(..., hydra_partial=True)`` to configure ``Adam`` to be only partially-built using those values that we have access to at configuration time.
 
-.. code:: python
+.. code:: pycon
 
    >>> from torch.optim import Adam
    >>> from torch import tensor
@@ -306,7 +306,7 @@ Fortunately, we can use ``builds(..., hydra_partial=True)`` to configure ``Adam`
 
 As promised, instantiating this config only partially-builds the ``Adam`` optimizer; we can finish instantiating it once we have access to our model's parameters
 
-.. code:: python
+.. code:: pycon
 
    >>> model_params = [tensor(1.0), tensor(-2.0)]
    >>> partial_optim(model_params)
@@ -345,7 +345,7 @@ Or, we can intentionally exclude a target's parameter so that it is not availabl
 
 We can provide positional arguments as well
 
-.. code:: python
+.. code:: pycon
 
    >>> instantiate(builds(np.add, 1.0, 2.0))
    3.0
@@ -425,7 +425,7 @@ this function and then nest it within the target's configuration.
    def objective_function(prediction, score, reduction_fn=np.mean):
         ...
 
-.. code:: python
+.. code:: pycon
 
    >>> Builds_loss = builds(objective_function, populate_full_signature=True)
 
@@ -443,7 +443,7 @@ this function and then nest it within the target's configuration.
 
 User-specified parameters will automatically be transformed as well
 
-.. code:: python
+.. code:: pycon
 
    >>> print(to_yaml(builds(dict, io_fn=len, sequence=list)))
    _target_: builtins.dict
@@ -461,7 +461,7 @@ Creating immutable configs
 Dataclasses can be made to be "frozen" such that their instances are immutable.
 Thus we can use `builds` to create immutable configs.
 
-.. code:: python
+.. code:: pycon
 
    >>> RouterConfig = builds(dict, ip_address=None, frozen=True)
    >>> my_router = RouterConfig(ip_address="192.168.56.1")  # an immutable instance
@@ -475,7 +475,7 @@ Composing configs via inheritance
 
 The ``builds_bases`` argument enables us to compose configurations using inheritance
 
-.. code:: python
+.. code:: pycon
 
    >>> ParentConf = builds(dict, a=1, b=2)
    >>> ChildConf = builds(dict, b=-2, c=-3, builds_bases=(ParentConf,))
@@ -499,7 +499,7 @@ Runtime validation
 
 Misspelled parameter names and other invalid configurations for the target's signature will be caught by `builds`, so that the error surfaces immediately while creating the configuration.
 
-.. code:: python
+.. code:: pycon
 
    >>> def func(a_number: int): pass
    >>> builds(func, a_nmbr=2)  # misspelled parameter name
@@ -522,7 +522,7 @@ Misspelled parameter names and other invalid configurations for the target's sig
 Because `builds` automatically mirrors type annotations from the target's signature, we also benefit from Hydra's type-validation mechanism.
 
 
-.. code:: python
+.. code:: pycon
 
    >>> def func(parameter: int): pass
    >>> instantiate(builds(func, parameter="a string"))
@@ -559,7 +559,7 @@ For example, suppose that we want to configure
 
 In this way, we can still configure and build this function, but we also retain some level of type-validation
 
-.. code:: python
+.. code:: pycon
 
    >>> instantiate(Builds_func("not a list"))
    ---------------------------------------------------------------------------------

--- a/docs/source/structured_configs.rst
+++ b/docs/source/structured_configs.rst
@@ -319,6 +319,10 @@ As promised, instantiating this config only partially-builds the ``Adam`` optimi
        weight_decay: 0
    )
 
+.. note::
+   Leveraging ``builds(..., hydra_partial=True)`` will produce a config that depends explicitly
+   on hydra-zen. I.e. hydra-zen must be installed in order to instantiate the resulting config.
+
 .. _Auto:
 
 Combining Auto-Populated and User-Specified Default Values
@@ -453,6 +457,10 @@ User-specified parameters will automatically be transformed as well
    sequence:
      _target_: hydra_zen.funcs.get_obj
      path: builtins.list
+
+.. note::
+   Leveraging this feature will produce a config that depends explicitly
+   on hydra-zen. I.e. hydra-zen must be installed in order to instantiate the resulting config.
 
 
 Creating immutable configs

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -134,20 +134,20 @@ def hydrated_dataclass(
         The object to be instantiated/called.
 
     *pos_args: Any
-        Positional arguments passed to `target`.
+        Positional arguments passed to ``target``.
 
         Arguments specified positionally are not included in the dataclass' signature and
         are stored as a tuple bound to in the ``_args_`` field.
 
     populate_full_signature : bool, optional (default=False)
-        If True, then the resulting dataclass's __init__ signature and fields
+        If True, then the resulting dataclass's ``__init__`` signature and fields
         will be populated according to the signature of `target`.
 
-        Values specified in **kwargs_for_target take precedent over the corresponding
+        Values specified in ``**kwargs_for_target`` take precedent over the corresponding
         default values from the signature.
 
     hydra_partial : Optional[bool] (default=False)
-        If True, then hydra-instantiation produces `functools.partial(target, **kwargs)`
+        If True, then hydra-instantiation produces ``functools.partial(target, **kwargs)``
 
     hydra_recursive : bool, optional (default=True)
         If True, then upon hydra will recursively instantiate all other
@@ -158,10 +158,10 @@ def hydrated_dataclass(
     hydra_convert: Optional[Literal["none", "partial", "all"]] (default="none")
         Determines how hydra handles the non-primitive objects passed to `target` [3]_.
 
-        - `"none"`: Passed objects are DictConfig and ListConfig, default
-        - `"partial"`: Passed objects are converted to dict and list, with
+        - ``"none"``: Passed objects are DictConfig and ListConfig, default
+        - ``"partial"``: Passed objects are converted to dict and list, with
           the exception of Structured Configs (and their fields).
-        - `"all"`: Passed objects are dicts, lists and primitives without
+        - ``"all"``: Passed objects are dicts, lists and primitives without
           a trace of OmegaConf containers
 
         If ``None``, the ``_convert_`` attribute is not set on the resulting dataclass.
@@ -170,6 +170,13 @@ def hydrated_dataclass(
         If `True`, the resulting dataclass will create frozen (i.e. immutable) instances.
         I.e. setting/deleting an attribute of an instance will raise `FrozenInstanceError`
         at runtime.
+
+    Notes
+    -----
+    Using any of the following features will result in a config that depends explicitly on hydra-zen
+
+       - ``hydra_partial=True``
+       - Providing a class-object or function argument to target, which will automatically be wrapped by `just`.
 
     References
     ----------
@@ -271,8 +278,13 @@ def just(obj: Importable) -> Type[Just[Importable]]:
 
     Returns
     -------
-    types.JustObj
+    Type[Just[Importable]]
         The dataclass object that is designed as a structured config.
+
+    Notes
+    -----
+    The configs produced by `just` introduce an explicit dependency on hydra-zen. I.e.
+    hydra-zen must be installed in order to instantiate the config.
 
     Examples
     --------
@@ -281,7 +293,7 @@ def just(obj: Importable) -> Type[Just[Importable]]:
     >>> range is instantiate(just_range)
     True
     >>> just_range._target_
-    'hydra_zen.funcs.identity'
+    'hydra_zen.funcs.get_obj'
     >>> just_range.path
     'builtins.range'
     """
@@ -408,7 +420,9 @@ def builds(
     builds_bases: Tuple[Any, ...] = (),
     **kwargs_for_target,
 ) -> Union[Type[Builds[Importable]], Type[PartialBuilds[Importable]]]:
-    """Returns a dataclass object that configures `target` with user-specified and auto-populated parameter values.
+    """builds(target, /, *pos_args, populate_full_signature=False, hydra_partial=False, hydra_recursive=None, hydra_convert=None, frozen=False, dataclass_name=None, builds_bases=(), **kwargs_for_target)
+
+    Returns a dataclass object that configures ``target`` with user-specified and auto-populated parameter values.
 
     The resulting dataclass is specifically a structured config [1]_ that enables Hydra to initialize/call
     `target` either fully or partially. See Notes for additional features and explanation of implementation details.
@@ -416,23 +430,23 @@ def builds(
     Parameters
     ----------
     target : Union[Instantiable, Callable]
-        The object to be instantiated/called
+        The object to be instantiated/called.
 
     *pos_args: Any
-        Positional arguments passed to `target`.
+        Positional arguments passed to ``target``.
 
         Arguments specified positionally are not included in the dataclass' signature and
         are stored as a tuple bound to in the ``_args_`` field.
 
     **kwargs_for_target : Any
-        The keyword arguments passed to `target(...)`.
+        The keyword arguments passed to ``target(...)``.
 
         The arguments specified here solely determine the fields and init-parameters of the
-        resulting dataclass, unless `populate_full_signature=True` is specified (see below).
+        resulting dataclass, unless ``populate_full_signature=True`` is specified (see below).
 
     populate_full_signature : bool, optional (default=False)
-        If `True`, then the resulting dataclass's signature and fields will be populated
-        according to the signature of `target`.
+        If ``True``, then the resulting dataclass's signature and fields will be populated
+        according to the signature of ``target``.
 
         Values specified in **kwargs_for_target take precedent over the corresponding
         default values from the signature.
@@ -441,16 +455,16 @@ def builds(
         NumPy's various ufuncs.
 
     hydra_partial : bool, optional (default=False)
-        If True, then hydra-instantiation produces `functools.partial(target, **kwargs_for_target)`,
+        If True, then Hydra-instantiation produces ``functools.partial(target, *pos_args, **kwargs_for_target)``,
         this enables the partial-configuration of objects.
 
-        Specifying `hydra_partial=True` and `populate_full_signature=True` together will
+        Specifying ``hydra_partial=True`` and ``populate_full_signature=True`` together will
         populate the dataclass' signature only with parameters that are specified by the
         user or that have default values specified in the target's signature. I.e. it is
         presumed that un-specified parameters are to be excluded from the partial configuration.
 
     hydra_recursive : Optional[bool], optional (default=True)
-        If ``True``, then upon hydra will recursively instantiate all other
+        If ``True``, then Hydra will recursively instantiate all other
         hydra-config objects nested within this dataclass [2]_.
 
         If ``None``, the ``_recursive_`` attribute is not set on the resulting dataclass.
@@ -458,51 +472,54 @@ def builds(
     hydra_convert: Optional[Literal["none", "partial", "all"]], optional (default="none")
         Determines how hydra handles the non-primitive objects passed to `target` [3]_.
 
-        - `"none"`: Passed objects are DictConfig and ListConfig, default
-        - `"partial"`: Passed objects are converted to dict and list, with
+        - ``"none"``: Passed objects are DictConfig and ListConfig, default
+        - ``"partial"``: Passed objects are converted to dict and list, with
           the exception of Structured Configs (and their fields).
-        - `"all"`: Passed objects are dicts, lists and primitives without
+        - ``"all"``: Passed objects are dicts, lists and primitives without
           a trace of OmegaConf containers
 
         If ``None``, the ``_convert_`` attribute is not set on the resulting dataclass.
 
     frozen : bool, optional (default=False)
-        If `True`, the resulting dataclass will create frozen (i.e. immutable) instances.
-        I.e. setting/deleting an attribute of an instance will raise `FrozenInstanceError`
+        If ``True``, the resulting dataclass will create frozen (i.e. immutable) instances.
+        I.e. setting/deleting an attribute of an instance will raise ``FrozenInstanceError``
         at runtime.
 
     builds_bases : Tuple[DataClass, ...]
         Specifies a tuple of parent classes that the resulting dataclass inherits from.
-        A `PartialBuilds` class (resulting from `hydra_partial=True`) cannot be a parent
-        of a `Builds` class (i.e. where `hydra_partial=False` was specified).
+        A ``PartialBuilds`` class (resulting from ``hydra_partial=True``) cannot be a parent
+        of a ``Builds`` class (i.e. where `hydra_partial=False` was specified).
 
     dataclass_name : Optional[str]
         If specified, determines the name of the returned class object.
 
     Returns
     -------
-    builder : Builds[target]
-        The structured config (a dataclass with the field: _target_ populated).
+    builder : Union[Type[Builds[Importable]], Union[Type[Builds[Importable]]
+        A structured config that builds ``target``
 
     Raises
     ------
     TypeError
         One or more unexpected arguments were specified via **kwargs_for_target, which
-        are not compatible with the signature of `target`.
+        are not compatible with the signature of ``target``.
 
     Notes
     -----
+    Using any of the following features will result in a config that depends explicitly on hydra-zen
+
+       - ``hydra_partial=True``
+       - Providing a class-object or function argument to target, which will automatically be wrapped by `just`.
+
+    I.e. hydra-zen must be installed in order to instantiate the resulting config, including its yaml version
+
     Type annotations are inferred from the target's signature and are only retained if they are compatible
     with hydra's limited set of supported annotations; otherwise `Any` is specified.
 
     `builds` provides runtime validation of user-specified named arguments against the target's signature.
     This helps to ensure that typos in field names fail early and explicitly.
 
-    Mutable values are automatically specified using a default factory [4]_.
-
-    `builds(...)` is annotated to return the generic protocols `Builds` and `PartialBuilds`, which are
-    available in `hydra_zen.typing`. These are leveraged by `hydra_zen.instantiate` to provide static
-    analysis tooling with enhanced context.
+    Mutable values are automatically transformed to use a default factory [4]_.
 
     References
     ----------


### PR DESCRIPTION
- Documents features that introduce explicit hydra-zen dependencies, as mentioned in https://github.com/mit-ll-responsible-ai/hydra-zen/pull/102#issuecomment-922265666. 
- Introduces `pycon`-style codeblocks where appropriate
- Improves consistency of monospace formatting in docstrings