### PR TITLE
Fix bare False in is_just

### DIFF
--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1002,7 +1002,7 @@ def is_just(x: Any) -> bool:
             return True
         else:
             # ensures we conver this branch in tests
-            False
+            return False
     return False
 
 


### PR DESCRIPTION
This didn't actually cause any bugs - ultimately `return False` was still reached - but it *looked* like a bug.