### PR TITLE
bump min typing-extensions dependency; test all minimum dependencies

### DIFF
--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Test with tox
       run: tox -e ml-env
 
-  test-minimum-hydra:
+  test-minimum-dependencies:
     runs-on: ubuntu-latest
 
     strategy:
@@ -113,7 +113,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
     - name: Test with tox
-      run: tox -e min-hydra
+      run: tox -e min-deps
 
 
   test-against-pre-releases-of-dependencies:

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,9 @@ commands = pytest \
            {posargs}
 
 
-[testenv:min-hydra]  # test against earliest supported version of hydra
-deps = hydra-core==1.1.0dev7
+[testenv:min-deps]  # test against minimum dependency versions
+deps = hydra-core==1.1.0
+       typing-extentsions==3.10.0.1
        {[testenv]deps}
 basepython = python3.7
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ commands = pytest \
 
 [testenv:min-deps]  # test against minimum dependency versions
 deps = hydra-core==1.1.0
-       typing-extentsions==3.10.0.1
+       typing-extensions==3.10.0.1
        {[testenv]deps}
 basepython = python3.7
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ CLASSIFIERS = [
 KEYWORDS = "machine learning research configuration scalable reproducible"
 INSTALL_REQUIRES = [
     "hydra-core >= 1.1.0",
-    "typing-extensions >= 3.7.4.1",
+    "typing-extensions >= 3.10.0.1",
 ]
 TESTS_REQUIRE = [
     "pytest >= 3.8",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -8,6 +8,7 @@ from itertools import zip_longest
 
 import hypothesis.strategies as st
 import pytest
+from hydra import __version__ as HYDRA_VERSION
 from hypothesis import assume, given
 from omegaconf import OmegaConf
 
@@ -42,6 +43,9 @@ def test_builds_target_as_kwarg_is_still_correct():
     assert out == {"a": 2, "b": 3}
 
 
+@pytest.mark.skipif(
+    HYDRA_VERSION < "1.1.1", reason="Hydra squatted on the name 'target' until v1.1.1"
+)
 def test_builds_with_target_as_named_arg_works():
     out = instantiate(builds(dict, target=1, b=2))
     assert out == {"target": 1, "b": 2}


### PR DESCRIPTION
The introduction of `TypeGuard` in #110  bumped our minimum dependency on typing-extensions, but our CI failed to catch it.

Also, we were testing `hydra-core==1.1.0dev7`, not `hydra-core==1.1.0`