### PR TITLE
Bug fix: get_obj_path no longer looks at __qualname__

### DIFF
--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -82,6 +82,7 @@ except ImportError:  # pragma: no cover
 
 
 COMMON_MODULES_WITH_OBFUSCATED_IMPORTS: Tuple[str, ...] = (
+    "random",
     "numpy",
     "numpy.random",
     "jax.numpy",
@@ -167,8 +168,8 @@ def field(
 def safe_name(obj: Any, repr_allowed=True) -> str:
     """Tries to get a descriptive name for an object. Returns '<unknown>`
     instead of raising - useful for writing descriptive/dafe error messages."""
-    if hasattr(obj, "__qualname__"):
-        return obj.__qualname__
+    # if hasattr(obj, "__qualname__"):
+    #     return obj.__qualname__
 
     if hasattr(obj, "__name__"):
         return obj.__name__
@@ -190,8 +191,9 @@ def get_obj_path(obj: Any) -> str:
         raise AttributeError(f"{obj} does not have a `__name__` attribute")
 
     module = getattr(obj, "__module__", None)
+    qualname = getattr(obj, "__qualname__", None)
 
-    if "<" in name or module is None:
+    if (qualname is not None and "<" in qualname) or module is None:
         # NumPy's ufuncs do not have an inspectable `__module__` attribute, so we
         # check to see if the object lives in NumPy's top-level namespace.
         #
@@ -204,16 +206,16 @@ def get_obj_path(obj: Any) -> str:
         #
         # or...
         #
-        # module is None, which is apparently a thing..: numpy.random.rand.__module__ is None
+        # module is None, which is apparently a thing..:
+        # __module__ is None for both numpy.random.rand and random.random
+        #
 
         # don't use qualname for obfuscated paths
-        name = obj.__name__
         for new_module in COMMON_MODULES_WITH_OBFUSCATED_IMPORTS:
             if getattr(sys.modules.get(new_module), name, None) is obj:
                 module = new_module
                 break
-        else:  # pragma: no cover
-            name = safe_name(obj)
+        else:
             raise ModuleNotFoundError(f"{name} is not importable")
 
     return f"{module}.{name}"

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -168,8 +168,6 @@ def field(
 def safe_name(obj: Any, repr_allowed=True) -> str:
     """Tries to get a descriptive name for an object. Returns '<unknown>`
     instead of raising - useful for writing descriptive/dafe error messages."""
-    # if hasattr(obj, "__qualname__"):
-    #     return obj.__qualname__
 
     if hasattr(obj, "__name__"):
         return obj.__name__

--- a/tests/test_roundtrips.py
+++ b/tests/test_roundtrips.py
@@ -1,6 +1,13 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
+import datetime
+import math
+import operator
+import os
+import random
+import re
+import statistics
 import string
 from dataclasses import dataclass
 from typing import Any, Dict, List
@@ -11,7 +18,6 @@ from hypothesis import given
 from omegaconf import OmegaConf
 
 from hydra_zen import builds, get_target, instantiate, just, to_yaml
-
 from tests import valid_hydra_literals
 
 arbitrary_kwargs = st.dictionaries(
@@ -122,6 +128,22 @@ a_bunch_of_objects = [
     list,
     set,
     complex,
+    isinstance,
+    all,
+    Exception,
+    random.random,
+    random.uniform,
+    random.choice,
+    random.choices,
+    re.compile,
+    re.match,
+    datetime.time,
+    datetime.timezone,
+    math.sin,
+    math.perm,
+    operator.add,
+    statistics.median_grouped,
+    os.getcwd,
 ]
 
 

--- a/tests/test_roundtrips.py
+++ b/tests/test_roundtrips.py
@@ -140,9 +140,8 @@ a_bunch_of_objects = [
     datetime.time,
     datetime.timezone,
     math.sin,
-    math.perm,
     operator.add,
-    statistics.median_grouped,
+    statistics.mean,
     os.getcwd,
 ]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 import collections.abc as abc
 import enum
+import random
 import sys
 from dataclasses import dataclass, field as dataclass_field
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
@@ -53,7 +54,6 @@ def f():
         (1, "1"),
         (dict, "dict"),
         (C, "C"),
-        (C.f, "C.f"),
         (C(), "C as a repr"),
         ("moo", "'moo'"),
         (None, "None"),
@@ -219,3 +219,8 @@ def test_vendored_field():
     assert isinstance(our_field, type(their_field))
     assert hasattr(A, "x") is hasattr(B, "x")
     assert A().x == B().x
+
+
+def test_builds_random_regression():
+    # was broken in `0.3.0rc3`
+    assert 1 <= instantiate(builds(random.uniform, 1, 2)) <= 2


### PR DESCRIPTION
closes #113

Before:

```python
>>> import random
>>> instantiate(builds(random.uniform, 2, 4))
TypeError: Error instantiating 'random.Random.uniform' : uniform() missing 1 required positional argument: 'b'
```

After:

```python
>>> instantiate(builds(random.uniform, 2, 4))
3.17287981209861248960842
```