### PR TITLE
New Feature: zen_wrappers

### DIFF
--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Measure coverage
       run: tox -e coverage
 
-  test-ml-envs:
+  test-third-party:
     runs-on: ubuntu-latest
 
     strategy:
@@ -91,7 +91,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
     - name: Test with tox
-      run: tox -e ml-env
+      run: tox -e third-party
 
   test-minimum-dependencies:
     runs-on: ubuntu-latest

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -6,5 +6,6 @@
         "**/node_modules",
         "**/__pycache__",
         "src/hydra_zen/_version.py",
+        "**/third_party",
     ],
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,8 @@ deps = {[testenv]deps}
        coverage
        pytest-cov
        numpy
+       beartype
+       pydantic
 commands = pytest --cov-report term-missing --cov-config=setup.cfg --cov-fail-under=100 --cov=hydra_zen tests
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,8 @@ basepython = python3.7
 [testenv:pre-release]  # test against pre-releases of dependencies
 pip_pre = true
 deps = {[testenv]deps}
+       beartype
+       pydantic
 basepython = python3.8
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ deps = {[testenv]deps}
        jaxlib
        jax
        pydantic
+       beartype
 
 
 [testenv:format]

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ deps = {[testenv]deps}
 commands = pytest --cov-report term-missing --cov-config=setup.cfg --cov-fail-under=100 --cov=hydra_zen tests
 
 
-[testenv:ml-env]
+[testenv:third-party]
 basepython = python3.8
 deps = {[testenv]deps}
        torch
@@ -72,6 +72,7 @@ deps = {[testenv]deps}
        numpy
        jaxlib
        jax
+       pydantic
 
 
 [testenv:format]

--- a/setup.py
+++ b/setup.py
@@ -68,5 +68,11 @@ setup(
     python_requires=">=3.6",
     packages=find_packages(where="src", exclude=["tests", "tests.*"]),
     package_dir={"": "src"},
-    package_data={"hydra_zen": ["py.typed"]}
+    package_data={"hydra_zen": ["py.typed"]},
+    extras_require={
+        "pydantic": [
+            "pydantic>=1.8.2"
+        ],  # don't reduce below 1.8.2 -- security vulnerability
+        "beartype": ["beartype>=0.8.0"],
+    },
 )

--- a/src/hydra_zen/experimental/coerce.py
+++ b/src/hydra_zen/experimental/coerce.py
@@ -1,3 +1,11 @@
+import sys
+
+if sys.version_info < (3, 7):  # pragma: no cover
+    raise NotImplementedError(
+        "Features that utilize `hydra_zen.experimental.coerce` "
+        "(e.g. beartype-validation) require Python 3.7 or greater."
+    )
+
 import inspect
 from collections import deque
 from functools import wraps

--- a/src/hydra_zen/experimental/third_party/beartype.py
+++ b/src/hydra_zen/experimental/third_party/beartype.py
@@ -11,6 +11,73 @@ __all__ = ["validates_with_beartype"]
 
 
 def validates_with_beartype(obj: _T) -> _T:
+    """Decorates a function or the init-method of an object with beartype [1]_.
+
+    This can be used with
+
+    Parameters
+    ----------
+    obj : Callable
+
+    Returns
+    -------
+    obj_w_validation : Callable
+        A wrapped function, or a class whose init-method has been
+        wrapped in-place
+
+    Notes
+    -----
+    ``beartype`` must be installed [2]_ as a separate dependency to leverage this validator.
+
+    hydra-zen adds a sequence-coercion step that is not performed by beartype.
+    This is implemented by `hydra_zen.experimental.coerce.coerce_sequences`. This
+    coercion is necessary as Hydra can only read sequence data in as a list. I.e.
+    without this coercion step, all non-list annotated sequence fields populated by
+    Hydra would get roared at (raised) by beartype.
+
+    See Also
+    --------
+    hydra_zen.experimental.coerce.coerce_sequences
+
+    References
+    ----------
+    .. [1] https://github.com/beartype/beartype
+    .. [2] https://github.com/beartype/beartype#install
+
+    Examples
+    --------
+    >>> from hydra_zen.experimental.third_party.beartype import validates_with_beartype
+    >>> from beartype.cave import ScalarTypes
+    >>> def f(x: ScalarTypes): return x  # a scalar is any real-valued number
+    >>> val_f = validates_with_beartype(f)
+    >>> f([1, 2])  # doesn't catch bad input
+    [1, 2]
+    >>> val_f([1, 2])
+    BeartypeCallHintPepParamException: @beartyped f() parameter x=[1, 2] violates type hint [...]
+
+    >>> class A:
+    ...     def __init__(self, x: ScalarTypes): ...
+    >>> validates_with_beartype(A)  # wrapping occurs in-place
+    __main__.A
+    >>> A([1, 2])
+    BeartypeCallHintPepParamException: @beartyped A.__init__() parameter x=[1, 2] violates type hint [...]
+
+    This is designed to be used with the ``zen_wrappers`` feature of `builds`.
+
+    >>> from hydra_zen import builds, instantiate
+    >>> # instantiations of `conf` will be validated by beartype
+    >>> conf = builds(f, populate_full_signature=True, zen_wrappers=validates_with_beartype)
+    >>> instantiate(conf, x=10)  # 10 is a scalar: ok!
+    10
+    >>> instantiate(conf, x=[1, 2])
+    BeartypeCallHintPepParamException: @beartyped f() parameter x=[1, 2] violates type hint [...]
+
+    Note that sequence-coercion is enabled to ensure smooth compatibility with Hydra.
+
+    >>> def g(x: tuple): return x  # note the annotation
+    >>> validates_with_beartype(g)([1, 2, 3])  # input: list, output: tuple
+    (1, 2, 3)
+    """
     if inspect.isclass(obj) and hasattr(type, "__init__"):
         obj.__init__ = bt.beartype(obj.__init__)
         target = obj

--- a/src/hydra_zen/experimental/third_party/beartype.py
+++ b/src/hydra_zen/experimental/third_party/beartype.py
@@ -2,6 +2,7 @@ import inspect
 from typing import Callable, TypeVar, cast
 
 import beartype as bt
+from beartype import beartype
 
 from hydra_zen.experimental.utils import convert_sequences
 

--- a/src/hydra_zen/experimental/third_party/beartype.py
+++ b/src/hydra_zen/experimental/third_party/beartype.py
@@ -2,7 +2,6 @@ import inspect
 from typing import Callable, TypeVar, cast
 
 import beartype as bt
-from beartype import beartype
 
 from hydra_zen.experimental.utils import convert_sequences
 

--- a/src/hydra_zen/experimental/third_party/beartype.py
+++ b/src/hydra_zen/experimental/third_party/beartype.py
@@ -3,7 +3,7 @@ from typing import Callable, TypeVar, cast
 
 import beartype as bt
 
-from hydra_zen.experimental.utils import convert_sequences
+from hydra_zen.experimental.utils import coerce_sequences
 
 _T = TypeVar("_T", bound=Callable)
 
@@ -16,5 +16,5 @@ def validates_with_beartype(obj: _T) -> _T:
         target = obj
     else:
         target = bt.beartype(obj)
-    target = convert_sequences(target)
+    target = coerce_sequences(target)
     return cast(_T, target)

--- a/src/hydra_zen/experimental/third_party/beartype.py
+++ b/src/hydra_zen/experimental/third_party/beartype.py
@@ -1,9 +1,9 @@
 import inspect
-from functools import wraps
-from typing import Callable, Sequence, TypeVar, cast, get_type_hints
+from typing import Callable, TypeVar, cast
 
 import beartype as bt
-from omegaconf import ListConfig
+
+from hydra_zen.experimental.utils import compose, convert_sequences
 
 _T = TypeVar("_T", bound=Callable)
 
@@ -12,55 +12,9 @@ __all__ = ["validates_with_beartype"]
 
 def validates_with_beartype(obj: _T) -> _T:
     if inspect.isclass(obj) and hasattr(type, "__init__"):
-        hints = get_type_hints(obj.__init__)
         obj.__init__ = bt.beartype(obj.__init__)
         target = obj
     else:
-        hints = get_type_hints(obj)
         target = bt.beartype(obj)
-
-    list_caster_by_pos = {}
-    list_caster_by_name = {}
-
-    if hints:
-        sig = inspect.signature(obj)
-        for n, name in enumerate(sig.parameters):
-            if name not in hints:
-                continue
-            annotation = hints[name]
-            if not isinstance(annotation, type):
-                caster = getattr(annotation, "__origin__", None)
-                if caster is None:
-                    continue
-            else:
-                caster = annotation
-
-            if (
-                not inspect.isabstract(caster)
-                and issubclass(caster, Sequence)
-                and caster is not list
-            ):
-                list_caster_by_pos[n] = caster
-                list_caster_by_name[name] = caster
-        min_pos = min(list_caster_by_pos) if list_caster_by_pos else 0
-
-    if not hints or not list_caster_by_name:
-        return cast(_T, target)
-
-    @wraps(obj)
-    def wrapper(*args, **kwargs):
-        if hints and list_caster_by_pos:
-            if min_pos < len(args):
-                args = list(args)
-                for pos in list_caster_by_pos:
-                    if pos < len(args) and isinstance(args[pos], (list, ListConfig)):
-                        args[pos] = list_caster_by_pos[pos](args[pos])
-            named = set(list_caster_by_name).intersection(kwargs)
-            if named:
-                for name in named:
-                    if isinstance(kwargs[name], (list, ListConfig)):
-                        kwargs[name] = list_caster_by_name[name](kwargs[name])
-
-        return target(*args, **kwargs)
-
-    return cast(_T, wrapper)
+    target = convert_sequences(target)
+    return cast(_T, target)

--- a/src/hydra_zen/experimental/third_party/beartype.py
+++ b/src/hydra_zen/experimental/third_party/beartype.py
@@ -3,7 +3,7 @@ from typing import Callable, TypeVar, cast
 
 import beartype as bt
 
-from hydra_zen.experimental.utils import coerce_sequences
+from hydra_zen.experimental.coerce import coerce_sequences
 
 _T = TypeVar("_T", bound=Callable)
 

--- a/src/hydra_zen/experimental/third_party/beartype.py
+++ b/src/hydra_zen/experimental/third_party/beartype.py
@@ -3,7 +3,7 @@ from typing import Callable, TypeVar, cast
 
 import beartype as bt
 
-from hydra_zen.experimental.utils import compose, convert_sequences
+from hydra_zen.experimental.utils import convert_sequences
 
 _T = TypeVar("_T", bound=Callable)
 

--- a/src/hydra_zen/experimental/third_party/beartype.py
+++ b/src/hydra_zen/experimental/third_party/beartype.py
@@ -1,0 +1,66 @@
+import inspect
+from functools import wraps
+from typing import Callable, Sequence, TypeVar, cast, get_type_hints
+
+import beartype as bt
+from omegaconf import ListConfig
+
+_T = TypeVar("_T", bound=Callable)
+
+__all__ = ["validates_with_beartype"]
+
+
+def validates_with_beartype(obj: _T) -> _T:
+    if inspect.isclass(obj) and hasattr(type, "__init__"):
+        hints = get_type_hints(obj.__init__)
+        obj.__init__ = bt.beartype(obj.__init__)
+        target = obj
+    else:
+        hints = get_type_hints(obj)
+        target = bt.beartype(obj)
+
+    list_caster_by_pos = {}
+    list_caster_by_name = {}
+
+    if hints:
+        sig = inspect.signature(obj)
+        for n, name in enumerate(sig.parameters):
+            if name not in hints:
+                continue
+            annotation = hints[name]
+            if not isinstance(annotation, type):
+                caster = getattr(annotation, "__origin__", None)
+                if caster is None:
+                    continue
+            else:
+                caster = annotation
+
+            if (
+                not inspect.isabstract(caster)
+                and issubclass(caster, Sequence)
+                and caster is not list
+            ):
+                list_caster_by_pos[n] = caster
+                list_caster_by_name[name] = caster
+        min_pos = min(list_caster_by_pos) if list_caster_by_pos else 0
+
+    if not hints or not list_caster_by_name:
+        return cast(_T, target)
+
+    @wraps(obj)
+    def wrapper(*args, **kwargs):
+        if hints and list_caster_by_pos:
+            if min_pos < len(args):
+                args = list(args)
+                for pos in list_caster_by_pos:
+                    if pos < len(args) and isinstance(args[pos], (list, ListConfig)):
+                        args[pos] = list_caster_by_pos[pos](args[pos])
+            named = set(list_caster_by_name).intersection(kwargs)
+            if named:
+                for name in named:
+                    if isinstance(kwargs[name], (list, ListConfig)):
+                        kwargs[name] = list_caster_by_name[name](kwargs[name])
+
+        return target(*args, **kwargs)
+
+    return cast(_T, wrapper)

--- a/src/hydra_zen/experimental/third_party/pydantic.py
+++ b/src/hydra_zen/experimental/third_party/pydantic.py
@@ -14,7 +14,7 @@ _default_validator = _pyd.validate_arguments(config={"arbitrary_types_allowed": 
 def validates_with_pydantic(
     obj: _T, validator: Callable[[_T], _T] = _default_validator
 ) -> _T:
-    """Decorates a function or the init-method of an objects with a pydantic
+    """Decorates a function or the init-method of an object with a pydantic
     validation decorator.
 
     This leverages `pydantic.validate_arguments`, which is currently in Beta [1]_.
@@ -36,23 +36,27 @@ def validates_with_pydantic(
 
     Notes
     -----
+    ``pydantic`` must be installed [2]_ as a separate dependency to leverage this validator.
+
     Users should be aware of pydantic's data conversion strategy [2]_; pydantic
     may cast data so that it will conform to its annotated type.
 
     References
     ----------
     .. [1] https://pydantic-docs.helpmanual.io/usage/validation_decorator/
-    .. [2] https://pydantic-docs.helpmanual.io/usage/models/#data-conversion
+    .. [2] https://pydantic-docs.helpmanual.io/install/
+    .. [3] https://pydantic-docs.helpmanual.io/usage/models/#data-conversion
 
     Examples
     --------
+    >>> from hydra_zen.experimental.third_party.pydantic import validates_with_pydantic
     >>> from pydantic import PositiveInt
     >>> def f(x: PositiveInt): return x
-    >>> val_f = validates_with_pydantic(needs_pos_int)
+    >>> val_f = validates_with_pydantic(f)
     >>> f(-100)
     -100
     >>> val_f(-100)
-    ValidationError: 1 validation error for F [...]
+    ValidationError: 1 validation error for F (...)
 
     >>> class A:
     ...     def __init__(self, x: PositiveInt): ...
@@ -60,6 +64,23 @@ def validates_with_pydantic(
     __main__.A
     >>> A(-10)
     ValidationError: 1 validation error for Init
+
+    This is designed to be used with the ``zen_wrappers`` feature of `builds`.
+
+    >>> from hydra_zen import builds, instantiate
+    >>> # instantiations of `conf` will be validated by pydantic
+    >>> conf = builds(f, populate_full_signature=True, zen_wrappers=validates_with_pydantic)
+    >>> instantiate(conf, x=10)
+    10
+    >>> instantiate(conf, x=-2)
+    ValidationError: 1 validation error for F (...)
+
+    Note that pydantic's data-coercion is ensures smooth compatibility with Hydra.
+    I.e. lists will be coerced to the appropriate annotated sequence type.
+
+    >>> def g(x: tuple): return x  # note the annotation
+    >>> validates_with_pydantic(g)([1, 2, 3])  # input: list, output: tuple
+    (1, 2, 3)
     """
     if inspect.isclass(obj) and hasattr(type, "__init__"):
         if hasattr(obj.__init__, "validate"):

--- a/src/hydra_zen/experimental/third_party/pydantic.py
+++ b/src/hydra_zen/experimental/third_party/pydantic.py
@@ -1,0 +1,57 @@
+import inspect
+from functools import wraps
+from typing import Callable, TypeVar, cast
+
+import pydantic as _pyd
+
+_T = TypeVar("_T", bound=Callable)
+
+__all__ = ["validates_with_pydantic"]
+
+
+def _validates_then_passes(obj):
+    # `pydantic.validate_arguments` doesn't support instance-methods.
+    # https://github.com/samuelcolvin/pydantic/issues/1222
+    # and it doesn't seem like this is going to get fixed any time soon.
+    #
+    # That's okay! We can handle this ourselves!
+    #
+    # The nice thing about `validate_arguments` is that it exposes
+    # a `.validate` method on the decorated object. We opt to use this
+    # to perform the validation, and then simply call/instantiation `obj`
+    # with the arguments as-is.
+    #
+    # This helps to ensure that `obj(*arg, **kwargs)` will always never
+    # be actually affected by pydantic, once the validation is complete.
+    #
+    # NOTE: This means that we *do not* gain the use of pydantic's coercion
+    # at this point.
+    if inspect.isclass(obj) and hasattr(type, "__init__"):
+        target = obj.__init__
+        NEEDS_SELF = True
+    else:
+        target = obj
+        NEEDS_SELF = False
+
+    pydantified = _pyd.validate_arguments(
+        target, config={"arbitrary_types_allowed": True}
+    )
+
+    @wraps(obj)
+    def wrapper(*args, **kwargs):
+        if NEEDS_SELF:
+            pydantified.validate(obj, *args, **kwargs)
+        else:
+            pydantified.validate(*args, **kwargs)
+        return obj(*args, **kwargs)
+
+    return wrapper
+
+
+def validates_with_pydantic(func: _T) -> _T:  # pragma: no cover
+    # NOTE: currently *does not* utilize pydantic's coercion mechanism
+    # https://pydantic-docs.helpmanual.io/usage/models/#data-conversion
+    #
+    # It should be straightforward to expose a version of this that does,
+    # but that will be riskier to use
+    return cast(_T, _validates_then_passes(func))

--- a/src/hydra_zen/experimental/third_party/pydantic.py
+++ b/src/hydra_zen/experimental/third_party/pydantic.py
@@ -1,5 +1,4 @@
 import inspect
-from functools import wraps
 from typing import Callable, TypeVar, cast
 
 import pydantic as _pyd
@@ -9,40 +8,68 @@ _T = TypeVar("_T", bound=Callable)
 __all__ = ["validates_with_pydantic"]
 
 
-def validates_with_pydantic(obj: _T) -> _T:  # pragma: no cover
-    # `pydantic.validate_arguments` doesn't support instance-methods.
-    # https://github.com/samuelcolvin/pydantic/issues/1222
-    # and it doesn't seem like this is going to get fixed any time soon.
-    #
-    # That's okay! We can handle this ourselves!
-    #
-    # The nice thing about `validate_arguments` is that it exposes
-    # a `.validate` method on the decorated object. We opt to use this
-    # to perform the validation, and then simply call/instantiation `obj`
-    # with the arguments as-is.
-    #
-    # This helps to ensure that the returned `obj(*arg, **kwargs)` will
-    # never be affected by pydantic.
-    #
-    # NOTE: This means that we *do not* gain the use of pydantic's coercion
-    # at this point.
+_default_validator = _pyd.validate_arguments(config={"arbitrary_types_allowed": True})
+
+
+def validates_with_pydantic(
+    obj: _T, validator: Callable[[_T], _T] = _default_validator
+) -> _T:
+    """Decorates a function or the init-method of an objects with a pydantic
+    validation decorator.
+
+    This leverages `pydantic.validate_arguments`, which is currently in Beta [1]_.
+
+    Parameters
+    ----------
+    obj : Callable
+
+    validator : pydantic.validate_arguments, optional
+        A configured instance of pydantic's validation decorator.
+        The default validator that we provide specifies:
+           - arbitrary_types_allowed: True
+
+    Returns
+    -------
+    obj_w_validation : Callable
+        A wrapped function or a class whose init-method has been
+        wrapped in-place
+
+    Notes
+    -----
+    Users should be aware of pydantic's data conversion strategy [2]_; pydantic
+    may cast data so that it will conform to its annotated type.
+
+    References
+    ----------
+    .. [1] https://pydantic-docs.helpmanual.io/usage/validation_decorator/
+    .. [2] https://pydantic-docs.helpmanual.io/usage/models/#data-conversion
+
+    Examples
+    --------
+    >>> from pydantic import PositiveInt
+    >>> def f(x: PositiveInt): return x
+    >>> val_f = validates_with_pydantic(needs_pos_int)
+    >>> f(-100)
+    -100
+    >>> val_f(-100)
+    ValidationError: 1 validation error for F [...]
+
+    >>> class A:
+    ...     def __init__(self, x: PositiveInt): ...
+    >>> validates_with_pydantic(A)  # wrapping occurs in-place
+    __main__.A
+    >>> A(-10)
+    ValidationError: 1 validation error for Init
+    """
     if inspect.isclass(obj) and hasattr(type, "__init__"):
-        target = obj.__init__
-        NEEDS_SELF = True
+        if hasattr(obj.__init__, "validate"):
+            # already decorated by pydantic
+            return cast(_T, obj)
+        obj.__init__ = validator(obj.__init__)
     else:
-        target = obj
-        NEEDS_SELF = False
+        if hasattr(obj, "validate"):
+            # already decorated by pydantic
+            return cast(_T, obj)
+        obj = cast(_T, validator(obj))
 
-    pydantified = _pyd.validate_arguments(  # type: ignore
-        target, config={"arbitrary_types_allowed": True}
-    )
-
-    @wraps(obj)
-    def wrapper(*args, **kwargs):
-        if NEEDS_SELF:
-            pydantified.validate(obj, *args, **kwargs)
-        else:
-            pydantified.validate(*args, **kwargs)
-        return obj(*args, **kwargs)
-
-    return cast(_T, wrapper)
+    return cast(_T, obj)

--- a/src/hydra_zen/experimental/third_party/pydantic.py
+++ b/src/hydra_zen/experimental/third_party/pydantic.py
@@ -21,8 +21,8 @@ def _validates_then_passes(obj):
     # to perform the validation, and then simply call/instantiation `obj`
     # with the arguments as-is.
     #
-    # This helps to ensure that `obj(*arg, **kwargs)` will always never
-    # be actually affected by pydantic, once the validation is complete.
+    # This helps to ensure that the returned `obj(*arg, **kwargs)` will
+    # never be affected by pydantic.
     #
     # NOTE: This means that we *do not* gain the use of pydantic's coercion
     # at this point.

--- a/src/hydra_zen/experimental/third_party/pydantic.py
+++ b/src/hydra_zen/experimental/third_party/pydantic.py
@@ -9,7 +9,7 @@ _T = TypeVar("_T", bound=Callable)
 __all__ = ["validates_with_pydantic"]
 
 
-def _validates_then_passes(obj):
+def validates_with_pydantic(obj: _T) -> _T:  # pragma: no cover
     # `pydantic.validate_arguments` doesn't support instance-methods.
     # https://github.com/samuelcolvin/pydantic/issues/1222
     # and it doesn't seem like this is going to get fixed any time soon.
@@ -33,7 +33,7 @@ def _validates_then_passes(obj):
         target = obj
         NEEDS_SELF = False
 
-    pydantified = _pyd.validate_arguments(
+    pydantified = _pyd.validate_arguments(  # type: ignore
         target, config={"arbitrary_types_allowed": True}
     )
 
@@ -45,13 +45,4 @@ def _validates_then_passes(obj):
             pydantified.validate(*args, **kwargs)
         return obj(*args, **kwargs)
 
-    return wrapper
-
-
-def validates_with_pydantic(func: _T) -> _T:  # pragma: no cover
-    # NOTE: currently *does not* utilize pydantic's coercion mechanism
-    # https://pydantic-docs.helpmanual.io/usage/models/#data-conversion
-    #
-    # It should be straightforward to expose a version of this that does,
-    # but that will be riskier to use
-    return cast(_T, _validates_then_passes(func))
+    return cast(_T, wrapper)

--- a/src/hydra_zen/experimental/utils.py
+++ b/src/hydra_zen/experimental/utils.py
@@ -76,6 +76,7 @@ def convert_sequences(obj: _T) -> _T:
         if (
             not inspect.isabstract(caster)  # E.g. caster = Sequence
             and issubclass(caster, Sequence)
+            and not issubclass(caster, str)  # strings don't need to be cast
             and caster is not list  # annotation is list to begin with
         ):
             list_caster_by_pos[n] = caster

--- a/src/hydra_zen/experimental/utils.py
+++ b/src/hydra_zen/experimental/utils.py
@@ -22,7 +22,7 @@ _T = TypeVar("_T", bound=Callable)
 __all__ = ["convert_sequences"]
 
 
-def _is_namedtuple_type(x) -> TypeGuard[Type[NamedTuple]]:
+def _is_namedtuple_type(x) -> TypeGuard[Type[NamedTuple]]:  # pragma: no cover
 
     try:
         bases = x.__bases__
@@ -124,11 +124,13 @@ def convert_sequences(obj: _T) -> _T:
                     annotation = _args[1]
                 elif _args[1] is _NoneType:
                     annotation = _args[0]
-                else:
+                else:  # pragma: no cover
                     # E.g. Union[A, B]
+                    # we cover this  in tests coverage-tooling struggles here
                     continue
-            else:
+            else:  # pragma: no cover
                 # E.g. Union[A, B, C]
+                # we cover this in tests but coverage-tooling struggles here
                 continue
         del _origin
 
@@ -156,7 +158,8 @@ def convert_sequences(obj: _T) -> _T:
                     return annotation(*x)  # type: ignore
 
                 caster = _unpack
-            else:
+            else:  # pragma: no cover
+                # covered in tests but coverage-tooling struggles here
                 continue
 
             if param.kind is not _KEYWORD_ONLY:

--- a/src/hydra_zen/experimental/utils.py
+++ b/src/hydra_zen/experimental/utils.py
@@ -1,0 +1,108 @@
+import inspect
+from functools import wraps
+from typing import Callable, Sequence, TypeVar, cast, get_type_hints
+
+from omegaconf import ListConfig
+
+_T = TypeVar("_T", bound=Callable)
+
+__all__ = ["convert_sequences"]
+
+
+def convert_sequences(obj: _T) -> _T:
+    """
+    Hydra is only able to read sequences as lists (or ListConfig).
+    This wrapper will cast these lists to their desired type, based
+    on the annotated-type associated with that sequence.
+
+    This is a no-op for objects that don't have any annotated sequence
+    types.
+
+    This is strictly an experimental utility. Use at your own risk.
+
+    Parameters
+    ----------
+    obj : Callable
+
+    Returns
+    -------
+    wrapped_obj
+
+    Examples
+    --------
+    >>> from hydra_zen import builds, instantiate
+    >>> def f(x: tuple): return x
+
+    Without wrapping:
+
+    >>> conf_no_wrap = builds(f, x=(1, 2))
+    >>> instantiate(conf_no_wrap)
+    [1, 2]
+
+    With wrapping:
+
+    >>> conf_wrapped = builds(f, x=(1, 2), zen_wrappers=convert_sequences)
+    >>> instantiate(conf_wrapped)
+    (1, 2)
+    """
+    if inspect.isclass(obj) and hasattr(type, "__init__"):
+        hints = get_type_hints(obj.__init__)
+    else:
+        hints = get_type_hints(obj)
+
+    if not hints:
+        return cast(_T, obj)
+
+    # We need to keep track of parameters that are annotated with
+    # sequence-like annotations
+    list_caster_by_pos = {}  # by pos-index in the signature
+    list_caster_by_name = {}  # by param-name in the signature
+
+    sig = inspect.signature(obj)
+    for n, name in enumerate(sig.parameters):
+        if name not in hints:
+            continue
+        annotation = hints[name]
+        if not isinstance(annotation, type):
+            # E.g. annotation = Tuple[int, int]
+            # Tuple[int, int].__origin__ -> tuple
+            caster = getattr(annotation, "__origin__", None)
+            if caster is None:
+                continue
+        else:
+            # E.g. annotation = tuple
+            caster = annotation
+
+        if (
+            not inspect.isabstract(caster)  # E.g. caster = Sequence
+            and issubclass(caster, Sequence)
+            and caster is not list  # annotation is list to begin with
+        ):
+            list_caster_by_pos[n] = caster
+            list_caster_by_name[name] = caster
+    min_pos = min(list_caster_by_pos) if list_caster_by_pos else 0
+
+    assert len(list_caster_by_name) == len(list_caster_by_pos)
+
+    if not list_caster_by_name:
+        # no annotations associated with sequences
+        return cast(_T, obj)
+
+    @wraps(obj)
+    def wrapper(*args, **kwargs):
+        if min_pos < len(args):
+            # at least one positional argument needs to be cast
+            args = list(args)
+            for pos in list_caster_by_pos:
+                if pos < len(args) and isinstance(args[pos], (list, ListConfig)):
+                    args[pos] = list_caster_by_pos[pos](args[pos])
+        if kwargs:
+            named = set(list_caster_by_name).intersection(kwargs)
+            for name in named:
+                # at least one named-arg needs to be cast
+                if isinstance(kwargs[name], (list, ListConfig)):
+                    kwargs[name] = list_caster_by_name[name](kwargs[name])
+
+        return obj(*args, **kwargs)
+
+    return cast(_T, wrapper)

--- a/src/hydra_zen/experimental/utils.py
+++ b/src/hydra_zen/experimental/utils.py
@@ -56,8 +56,8 @@ def convert_sequences(obj: _T) -> _T:
     This wrapper will cast these lists to their desired type, based
     on the annotated-type associated with that sequence.
 
-    This is a no-op for objects that don't have any annotated sequence
-    types.
+    This is a no-op for objects that don't have any annotated non-string
+    sequence types.
 
     This is strictly an experimental utility. Use at your own risk.
 
@@ -76,6 +76,9 @@ def convert_sequences(obj: _T) -> _T:
     - deques
     - lists
     - named-tuples
+
+    The only Union-based types that are supported are of the form
+    ``Optional[<sequence-type>]``.
 
     Examples
     --------

--- a/src/hydra_zen/experimental/utils.py
+++ b/src/hydra_zen/experimental/utils.py
@@ -19,7 +19,7 @@ from hydra_zen.structured_configs._utils import get_args, get_origin
 
 _T = TypeVar("_T", bound=Callable)
 
-__all__ = ["convert_sequences"]
+__all__ = ["coerce_sequences"]
 
 
 def _is_namedtuple_type(x) -> TypeGuard[Type[NamedTuple]]:  # pragma: no cover
@@ -50,7 +50,7 @@ _KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
 _VAR_KEYWORD = inspect.Parameter.VAR_KEYWORD
 
 
-def convert_sequences(obj: _T) -> _T:
+def coerce_sequences(obj: _T) -> _T:
     """
     Hydra is only able to read non-string sequences as lists (or ListConfig).
     This wrapper will cast these lists to their desired type, based

--- a/src/hydra_zen/experimental/utils.py
+++ b/src/hydra_zen/experimental/utils.py
@@ -138,7 +138,7 @@ def convert_sequences(obj: _T) -> _T:
             # E.g. annotation = Tuple[int, int]
             # Tuple[int, int].__origin__ -> tuple
             caster = get_origin(annotation)
-            if caster is None:
+            if caster is None:  # pragma: no cover
                 continue
         else:
             # E.g. annotation = tuple

--- a/src/hydra_zen/funcs.py
+++ b/src/hydra_zen/funcs.py
@@ -48,11 +48,15 @@ def zen_processing(
     _zen_wrappers: _typing.Union[str, _typing.Sequence[str]] = tuple(),
     **kwargs,
 ):
-    if isinstance(_zen_wrappers, str):
+    if isinstance(_zen_wrappers, str) or not isinstance(
+        _zen_wrappers, _typing.Sequence
+    ):
         _zen_wrappers = (_zen_wrappers,)
 
     # flip order: first wrapper listed should be called first
-    wrappers = tuple(get_obj(path=z) for z in _zen_wrappers)[::-1]
+    wrappers = tuple(
+        get_obj(path=z) if isinstance(z, str) else z for z in _zen_wrappers
+    )[::-1]
 
     obj = get_obj(path=_zen_target)
 

--- a/src/hydra_zen/funcs.py
+++ b/src/hydra_zen/funcs.py
@@ -14,9 +14,9 @@ from hydra.utils import log as _log
 
 from hydra_zen.typing import Partial as _Partial
 
-_T = _typing.TypeVar("_T")
+__all__ = ["partial", "get_obj", "zen_processing"]
 
-__all__ = ["partial", "get_obj"]
+_T = _typing.TypeVar("_T")
 
 
 def partial(
@@ -45,9 +45,19 @@ def zen_processing(
     _zen_target: str,
     _zen_partial: bool = False,
     _zen_exclude: _typing.Sequence[str] = tuple(),
+    _zen_wrappers: _typing.Union[str, _typing.Sequence[str]] = tuple(),
     **kwargs,
 ):
+    if isinstance(_zen_wrappers, str):
+        _zen_wrappers = (_zen_wrappers,)
+
+    # flip order: first wrapper listed should be called first
+    wrappers = tuple(get_obj(path=z) for z in _zen_wrappers)[::-1]
+
     obj = get_obj(path=_zen_target)
+
+    for wrapper in wrappers:
+        obj = wrapper(obj)
 
     if _zen_exclude:
         excluded_set = set(_zen_exclude)

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -754,18 +754,20 @@ def builds(
             target_field.append(
                 (
                     _META_FIELD_NAME,
-                    Dict[str, Any],
+                    Tuple[str, ...],
                     _utils.field(default=tuple(hydra_meta), init=False),
                 ),
             )
         if zen_wrappers:
             # TODO: handle config'd - callables
-            _callable_paths = tuple(_utils.get_obj_path(z) for z in zen_wrappers)
+            _callable_paths = tuple(
+                z if is_builds(z) else _utils.get_obj_path(z) for z in zen_wrappers
+            )
             if len(zen_wrappers) == 1:
                 target_field.append(
                     (
                         "_zen_wrappers",
-                        str,
+                        Any,
                         _utils.field(default=_callable_paths[0], init=False),
                     ),
                 )
@@ -773,7 +775,7 @@ def builds(
                 target_field.append(
                     (
                         "_zen_wrappers",
-                        Tuple[str, ...],
+                        Tuple[Any, ...],
                         _utils.field(default=_callable_paths, init=False),
                     ),
                 )

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -259,14 +259,14 @@ def sanitized_type(
         args = get_args(type_)
         if origin is Union:
             # Hydra only supports Optional[<type>] unions
-            if len(args) != 2 or type(None) not in args:
+            if len(args) != 2 or NoneType not in args:
                 # isn't Optional[<type>]
                 return Any
 
             args = cast(Tuple[type, type], args)
 
             optional_type, none_type = args
-            if not isinstance(None, none_type):
+            if none_type is not NoneType:
                 optional_type = none_type
             optional_type: Optional[Any]
             optional_type = sanitized_type(optional_type)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,14 @@ import pytest
 # Skip collection of tests that don't work on the current version of Python.
 collect_ignore_glob = []
 
-OPTIONAL_TEST_DEPENDENCIES = ("numpy", "torch", "jax", "pytorch_lightning", "pydantic")
+OPTIONAL_TEST_DEPENDENCIES = (
+    "numpy",
+    "torch",
+    "jax",
+    "pytorch_lightning",
+    "pydantic",
+    "beartype",
+)
 
 for _module_name in OPTIONAL_TEST_DEPENDENCIES:
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import pytest
 # Skip collection of tests that don't work on the current version of Python.
 collect_ignore_glob = []
 
-OPTIONAL_TEST_DEPENDENCIES = ("numpy", "torch", "jax", "pytorch_lightning")
+OPTIONAL_TEST_DEPENDENCIES = ("numpy", "torch", "jax", "pytorch_lightning", "pydantic")
 
 for _module_name in OPTIONAL_TEST_DEPENDENCIES:
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ if sys.version_info > (3, 6):
     collect_ignore_glob.append("*py36*")
 
 if sys.version_info < (3, 7):
-    collect_ignore_glob.append("tests/experimental/test_coerce_sequences.py")
+    collect_ignore_glob.append("**/*test_coerce_sequences.py")
 
 if sys.version_info < (3, 8):
     collect_ignore_glob.append("*py38*")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,10 @@ for _module_name in OPTIONAL_TEST_DEPENDENCIES:
     except ModuleNotFoundError:
         collect_ignore_glob.append(f"**/*{_module_name}*.py")
 
+
+if sys.version_info > (3, 6):
+    collect_ignore_glob.append("*py36*")
+
 if sys.version_info < (3, 7):
     collect_ignore_glob.append("tests/experimental/test_coerce_sequences.py")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,9 @@ for _module_name in OPTIONAL_TEST_DEPENDENCIES:
     except ModuleNotFoundError:
         collect_ignore_glob.append(f"**/*{_module_name}*.py")
 
+if sys.version_info < (3, 7):
+    collect_ignore_glob.append("tests/experimental/test_coerce_sequences.py")
+
 if sys.version_info < (3, 8):
     collect_ignore_glob.append("*py38*")
 

--- a/tests/experimental/test_coerce_sequences.py
+++ b/tests/experimental/test_coerce_sequences.py
@@ -7,7 +7,7 @@ from hypothesis import assume, given, settings
 from omegaconf.errors import GrammarParseError
 
 from hydra_zen import builds, instantiate, to_yaml
-from hydra_zen.experimental.utils import coerce_sequences
+from hydra_zen.experimental.coerce import coerce_sequences
 
 
 class MyNamedTuple(NamedTuple):

--- a/tests/experimental/test_coerce_sequences.py
+++ b/tests/experimental/test_coerce_sequences.py
@@ -7,7 +7,7 @@ from hypothesis import assume, given, settings
 from omegaconf.errors import GrammarParseError
 
 from hydra_zen import builds, instantiate, to_yaml
-from hydra_zen.experimental.utils import convert_sequences
+from hydra_zen.experimental.utils import coerce_sequences
 
 
 class MyNamedTuple(NamedTuple):
@@ -72,7 +72,7 @@ def test_convert_sequences_against_many_types(in_type, expected_type):
             args = (cast_x,)
 
         conf = builds(
-            f, *args, **kwargs, hydra_convert="all", zen_wrappers=convert_sequences
+            f, *args, **kwargs, hydra_convert="all", zen_wrappers=coerce_sequences
         )
 
         try:
@@ -121,11 +121,11 @@ def kwargs_only(x, **kwargs: tuple):
     "target_fn", [no_annotation, no_sequences, args_only, kwargs_only]
 )
 def test_convert_sequences_no_annotations_is_noop(target_fn):
-    assert target_fn is convert_sequences(target_fn)
+    assert target_fn is coerce_sequences(target_fn)
 
 
 def test_convert_sequence_on_various_inputs():
-    @convert_sequences
+    @coerce_sequences
     def f(x: MyNamedTuple, y: tuple, *args: tuple, z: Deque, **kwargs: tuple):
         return (x, y, *args, z) + tuple(kwargs.values())
 
@@ -142,7 +142,7 @@ def test_convert_sequence_on_various_inputs():
 
 
 def test_convert_sequences_on_class():
-    @convert_sequences
+    @coerce_sequences
     class AClass:
         def __init__(self, x: tuple, y) -> None:
             self.x = x
@@ -158,4 +158,4 @@ def test_invalid_type_annotation_doesnt_cause_internal_error():
         return x
 
     f.__annotations__["x"] = 1  # an unexpected type hint
-    assert convert_sequences(f)(x=10) == 10
+    assert coerce_sequences(f)(x=10) == 10

--- a/tests/experimental/test_utils.py
+++ b/tests/experimental/test_utils.py
@@ -1,0 +1,47 @@
+from collections import deque
+from typing import Deque, List, Sequence, Tuple
+
+import hypothesis.strategies as st
+import pytest
+from hypothesis import given
+
+from hydra_zen import builds, instantiate
+from hydra_zen.experimental.utils import convert_sequences
+
+
+def f(x):
+    return x
+
+
+@pytest.mark.parametrize(
+    "in_type, expected_type",
+    [
+        (int, int),
+        (str, str),
+        (Tuple[int, int], tuple),
+        (tuple, tuple),
+        (Deque[str], deque),
+        (List[str], list),
+        (Sequence[str], list),
+    ],
+)
+def test_convert_sequences_against_many_types(in_type, expected_type):
+    f.__annotations__["x"] = in_type
+
+    @given(x=st.from_type(in_type), as_named=st.booleans())
+    def run(x, as_named: bool):
+        args = ()
+        kwargs = {}
+        if as_named:
+            kwargs["x"] = x
+        else:
+            args = (x,)
+        out = instantiate(
+            builds(
+                f, *args, **kwargs, zen_wrappers=convert_sequences, hydra_convert="all"
+            )
+        )
+        assert isinstance(out, expected_type)
+        assert out == expected_type(x)
+
+    run()

--- a/tests/experimental/test_utils.py
+++ b/tests/experimental/test_utils.py
@@ -129,13 +129,25 @@ def test_convert_sequence_on_various_inputs():
     def f(x: MyNamedTuple, y: tuple, *args: tuple, z: Deque, **kwargs: tuple):
         return (x, y, *args, z) + tuple(kwargs.values())
 
-    assert f(0, [1, 2], z=[3, 4]) == (0, (1, 2), deque([3, 4]))
-    assert f(0, y=[1, 2], z=[3, 4]) == (0, (1, 2), deque([3, 4]))
-    assert f(0, [1, 2], [-1], z=[3, 4]) == (0, (1, 2), [-1], deque([3, 4]))
-    assert f(0, [1, 2], [-1], z=[3, 4], extra=[5, 6]) == (
+    assert f(0, [1, 2], z=[3, 4]) == (0, (1, 2), deque([3, 4]))  # type: ignore
+    assert f(0, y=[1, 2], z=[3, 4]) == (0, (1, 2), deque([3, 4]))  # type: ignore
+    assert f(0, [1, 2], [-1], z=[3, 4]) == (0, (1, 2), [-1], deque([3, 4]))  # type: ignore
+    assert f(0, [1, 2], [-1], z=[3, 4], extra=[5, 6]) == (  # type: ignore
         0,
         (1, 2),
         [-1],
         deque([3, 4]),
         [5, 6],
     )
+
+
+def test_convert_sequences_on_class():
+    @convert_sequences
+    class AClass:
+        def __init__(self, x: tuple, y) -> None:
+            self.x = x
+            self.y = y
+
+    out = AClass([1, 2], [3])  # type: ignore
+    assert out.x == (1, 2)
+    assert out.y == [3]

--- a/tests/experimental/test_utils.py
+++ b/tests/experimental/test_utils.py
@@ -151,3 +151,11 @@ def test_convert_sequences_on_class():
     out = AClass([1, 2], [3])  # type: ignore
     assert out.x == (1, 2)
     assert out.y == [3]
+
+
+def test_hacked_type():
+    def f(x):
+        return x
+
+    f.__annotations__["x"] = 1  # an unexpected type hint
+    assert convert_sequences(f)(x=10) == 10

--- a/tests/experimental/test_utils.py
+++ b/tests/experimental/test_utils.py
@@ -153,7 +153,7 @@ def test_convert_sequences_on_class():
     assert out.y == [3]
 
 
-def test_hacked_type():
+def test_invalid_type_annotation_doesnt_cause_internal_error():
     def f(x):
         return x
 

--- a/tests/experimental/test_utils.py
+++ b/tests/experimental/test_utils.py
@@ -1,16 +1,32 @@
-from collections import deque
-from typing import Deque, List, Sequence, Tuple
+from collections import UserList, deque, namedtuple
+from typing import Deque, List, NamedTuple, Optional, Sequence, Tuple, Union
 
 import hypothesis.strategies as st
 import pytest
-from hypothesis import given
+from hypothesis import assume, given, settings
+from omegaconf.errors import GrammarParseError
 
-from hydra_zen import builds, instantiate
+from hydra_zen import builds, instantiate, to_yaml
 from hydra_zen.experimental.utils import convert_sequences
+
+
+class MyNamedTuple(NamedTuple):
+    x: int
+    y: str
+
+
+MyNamedTuple2 = namedtuple("MyNamedTuple2", ["x", "y", "z"])
+
+
+class MyList(UserList):
+    pass
 
 
 def f(x):
     return x
+
+
+NoneType = type(None)
 
 
 @pytest.mark.parametrize(
@@ -18,30 +34,108 @@ def f(x):
     [
         (int, int),
         (str, str),
+        (bool, bool),
+        (Tuple, tuple),
         (Tuple[int, int], tuple),
-        (tuple, tuple),
         (Deque[str], deque),
-        (List[str], list),
-        (Sequence[str], list),
+        (List[int], list),
+        (MyList, list),
+        (Sequence[int], list),
+        (MyNamedTuple, MyNamedTuple),
+        (Optional[MyNamedTuple], (MyNamedTuple, NoneType)),
+        (tuple, tuple),
+        (deque, deque),
+        (list, list),
+        (Optional[int], (int, NoneType)),
+        (Optional[Tuple[int, int]], (tuple, NoneType)),
+        (Optional[Sequence[int]], (list, NoneType)),
+        (Union[NoneType, Tuple[int, int]], (tuple, NoneType)),
+        (Union[Tuple[int, int], NoneType], (tuple, NoneType)),
+        (Union[Tuple[int, int], Tuple[int, int, int]], (list, NoneType)),
+        (Union[Tuple[int, int], NoneType, Tuple[int, int, int]], (list, NoneType)),
     ],
 )
 def test_convert_sequences_against_many_types(in_type, expected_type):
     f.__annotations__["x"] = in_type
 
+    @settings(max_examples=10)
     @given(x=st.from_type(in_type), as_named=st.booleans())
     def run(x, as_named: bool):
         args = ()
         kwargs = {}
+
+        cast_x = list(x) if hasattr(x, "__iter__") and not isinstance(x, str) else x
+
         if as_named:
-            kwargs["x"] = x
+            kwargs["x"] = cast_x
         else:
-            args = (x,)
-        out = instantiate(
-            builds(
-                f, *args, **kwargs, zen_wrappers=convert_sequences, hydra_convert="all"
-            )
+            args = (cast_x,)
+
+        conf = builds(
+            f, *args, **kwargs, hydra_convert="all", zen_wrappers=convert_sequences
         )
+
+        try:
+            to_yaml(conf)  # ensure serializable
+            out = instantiate(conf)
+        except GrammarParseError:
+            assume(False)  # generated string was bad-interp
+            assert False  # unreachable
+
         assert isinstance(out, expected_type)
-        assert out == expected_type(x)
+
+        if isinstance(expected_type, tuple):
+            # case: Union
+            caster, _ = expected_type
+            if x is None:
+                assert out is None
+                return
+        else:
+            caster = expected_type
+
+        if not isinstance(x, (MyNamedTuple, MyNamedTuple2)):
+            assert out == caster(x)
+        else:
+            assert out == caster(*x)
 
     run()
+
+
+def no_annotation(x, y=2, *args, z, **kwargs):
+    ...
+
+
+def no_sequences(x: int, y: bool, z: str):
+    ...
+
+
+def args_only(x, *args: tuple):
+    ...
+
+
+def kwargs_only(x, **kwargs: tuple):
+    ...
+
+
+@pytest.mark.parametrize(
+    "target_fn", [no_annotation, no_sequences, args_only, kwargs_only]
+)
+def test_convert_sequences_no_annotations_is_noop(target_fn):
+    assert target_fn is convert_sequences(target_fn)
+
+
+def test_convert_sequence_on_various_inputs():
+    @convert_sequences
+    def f(x: MyNamedTuple, y: tuple, *args: tuple, z: Deque, **kwargs: tuple):
+        return (x, y, *args, z) + tuple(kwargs.values())
+
+    assert f(0, [1, 2], z=[3, 4]) == (0, (1, 2), deque([3, 4]))
+    assert f(0, y=[1, 2], z=[3, 4]) == (0, (1, 2), deque([3, 4]))
+    assert f(0, [1, 2], [-1], z=[3, 4]) == (0, (1, 2), [-1], deque([3, 4]))
+    assert f(0, [1, 2], [-1], z=[3, 4], extra=[5, 6]) == (
+        0,
+        (1, 2),
+        [-1],
+        deque([3, 4]),
+        [5, 6],
+    )

--- a/tests/test_py36.py
+++ b/tests/test_py36.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+def test_experimental_coerce_not_available():
+    with pytest.raises(NotImplementedError):
+        import hydra_zen.experimental.coerce as coerce
+
+        type(coerce)  # touch to keep formatters from freaking out
+
+
+def test_beartype_not_available():
+    with pytest.raises(NotImplementedError):
+        from hydra_zen.experimental.third_party.beartype import validates_with_beartype
+
+        type(validates_with_beartype)  # touch to keep formatters from freaking out

--- a/tests/test_third_party/test_type_validators.py
+++ b/tests/test_third_party/test_type_validators.py
@@ -44,7 +44,7 @@ def test_multiple_wraps_on_func(
 
     wrapped_f = f
     for _ in range(num_compositions):
-        wrapped_f = validator(f)
+        wrapped_f = validator(wrapped_f)
 
     assert f([1, 2]) == [1, 2]  # type: ignore
 
@@ -69,7 +69,7 @@ def test_multiple_wraps_on_class(
 
     wrapped_A = A
     for _ in range(num_compositions):
-        wrapped_A = validator(A)
+        wrapped_A = validator(wrapped_A)
 
     assert wrapped_A is A, "decoration should occur in-place"
 

--- a/tests/test_third_party/test_type_validators.py
+++ b/tests/test_third_party/test_type_validators.py
@@ -1,0 +1,191 @@
+from collections import deque
+from typing import Deque, List, NamedTuple, Sequence, Tuple
+
+import hypothesis.strategies as st
+import pytest
+from hypothesis import given
+from typing_extensions import Final
+
+from hydra_zen import builds, instantiate, to_yaml
+
+all_validators = []
+
+
+try:
+    from hydra_zen.experimental.third_party.pydantic import validates_with_pydantic
+
+    all_validators.append(validates_with_pydantic)
+    del validates_with_pydantic
+except ImportError:
+    pass
+
+
+try:
+    from hydra_zen.experimental.third_party.beartype import validates_with_beartype
+
+    all_validators.append(validates_with_beartype)
+    del validates_with_beartype
+except ImportError:
+    pass
+
+skip_if_no_validators: Final = pytest.mark.skipif(
+    not all_validators, reason="no thirdparty validators available"
+)
+
+
+@skip_if_no_validators
+@pytest.mark.parametrize("validator", all_validators)
+@given(num_compositions=st.integers(0, 4), x=st.integers(), as_named_arg=st.booleans())
+def test_multiple_wraps_on_func(
+    validator, num_compositions: int, x: int, as_named_arg: bool
+):
+    def f(x: int):
+        return x
+
+    wrapped_f = f
+    for _ in range(num_compositions):
+        wrapped_f = validator(f)
+
+    assert f([1, 2]) == [1, 2]  # type: ignore
+
+    if num_compositions:
+        with pytest.raises(Exception):
+            wrapped_f([1, 2])  # type: ignore
+    if as_named_arg:
+        assert f(x=x) == wrapped_f(x=x)
+    else:
+        assert f(x) == wrapped_f(x)
+
+
+@skip_if_no_validators
+@pytest.mark.parametrize("validator", all_validators)
+@given(num_compositions=st.integers(0, 4), x=st.integers(), as_named_arg=st.booleans())
+def test_multiple_wraps_on_class(
+    validator, num_compositions: int, x: int, as_named_arg: bool
+):
+    class A:
+        def __init__(self, x: int):
+            self.x = x
+
+    wrapped_A = A
+    for _ in range(num_compositions):
+        wrapped_A = validator(A)
+
+    assert wrapped_A is A, "decoration should occur in-place"
+
+    if num_compositions:
+        with pytest.raises(Exception):
+            wrapped_A([1, 2])  # type: ignore
+
+    a_instance = wrapped_A(x=x) if as_named_arg else wrapped_A(x)
+    assert isinstance(a_instance, A)
+    assert a_instance.x == x
+
+
+class MyNamedTuple(NamedTuple):
+    x: float
+    y: float
+    z: float
+
+
+@skip_if_no_validators
+@pytest.mark.parametrize("validator", all_validators)
+@pytest.mark.parametrize(
+    "annotation, caster",
+    [
+        (Sequence, list),
+        (List[float], list),
+        (List, list),
+        (list, list),
+        (Tuple[float, float, float], tuple),
+        (Tuple, tuple),
+        (tuple, tuple),
+        (Deque[float], deque),
+        (Deque, deque),
+        (deque, deque),
+        (MyNamedTuple, MyNamedTuple),
+    ],
+)
+@given(
+    x=st.lists(st.floats(allow_nan=False), min_size=3, max_size=3),
+)
+def test_coerces_lists_to_annotated_sequence_type(
+    validator, x: List[float], annotation: type, caster: type
+):
+    def f(x):
+        return x
+
+    f.__annotations__["x"] = annotation
+
+    wrapped_f = validator(f)
+    coerced_out = wrapped_f(x)
+    assert isinstance(f(x), list)  # type: ignore
+    assert isinstance(coerced_out, caster)
+    if caster is not MyNamedTuple:
+        assert coerced_out == caster(x)
+    else:
+        assert coerced_out == caster(*x)
+
+
+@skip_if_no_validators
+@pytest.mark.parametrize("validator", all_validators)
+def test_on_custom_types(validator):
+    class A:
+        pass
+
+    class B:
+        pass
+
+    @validator
+    def f(x: Tuple[A, B]):
+        return x
+
+    a = A()
+    b = B()
+
+    with pytest.raises(Exception):
+        f((a, a))  # type: ignore
+
+    assert f((a, b)) == (a, b)
+
+
+def run_with_hydra(x: float):
+    return x
+
+
+@skip_if_no_validators
+@pytest.mark.parametrize("validator", all_validators)
+def test_hydra_compatible_func_target(validator):
+    conf_with_val = builds(
+        run_with_hydra, populate_full_signature=True, zen_wrappers=validator
+    )
+    to_yaml(conf_with_val)
+
+    with pytest.raises(Exception):
+        instantiate(conf_with_val, x="not a float")
+
+    out = instantiate(conf_with_val, x=1)
+    assert isinstance(out, float)
+    assert out == 1.0
+
+
+class RunWithHydra:
+    def __init__(self, x: float):
+        self.x = x
+
+
+@skip_if_no_validators
+@pytest.mark.parametrize("validator", all_validators)
+def test_hydra_compatible_class_target(validator):
+    conf_with_val = builds(
+        RunWithHydra, populate_full_signature=True, zen_wrappers=validator
+    )
+    to_yaml(conf_with_val)
+
+    with pytest.raises(Exception):
+        instantiate(conf_with_val, x="not a float")
+
+    out = instantiate(conf_with_val, x=1)
+    assert isinstance(out, RunWithHydra)
+    assert isinstance(out.x, float)
+    assert out.x == 1.0

--- a/tests/test_third_party/test_using_beartype.py
+++ b/tests/test_third_party/test_using_beartype.py
@@ -1,0 +1,64 @@
+from typing import Tuple
+
+import pytest
+from beartype.roar import BeartypeException  # typing: ignore
+
+from hydra_zen import builds, instantiate
+from hydra_zen.experimental.third_party.beartype import validates_with_beartype
+
+
+class A:
+    pass
+
+
+def f(x: A):
+    return None
+
+
+class B:
+    def __init__(self, x: A) -> None:
+        pass
+
+
+def test_bear_basics():
+    C1 = builds(f, builds(A), zen_wrappers=validates_with_beartype)
+    C2 = builds(B, builds(A), zen_wrappers=validates_with_beartype)
+    instantiate(C1)
+    assert isinstance(instantiate(C2), B)
+
+
+class F:
+    pass
+
+
+class G:
+    pass
+
+
+def tuple_of_classes(x: Tuple[F, G]):
+    return x
+
+
+def test_beartype_with_arbitrary_allowed_types():
+    instantiate(builds(tuple_of_classes, [builds(F), builds(F)]))  # should pass
+
+    with pytest.raises(BeartypeException):
+        instantiate(
+            builds(
+                tuple_of_classes,
+                [builds(F), builds(F)],
+                zen_wrappers=validates_with_beartype,
+                hydra_convert="all",
+            )
+        )
+
+    f, g = instantiate(
+        builds(
+            tuple_of_classes,
+            [builds(F), builds(G)],
+            zen_wrappers=validates_with_beartype,
+            hydra_convert="all",
+        )
+    )
+    assert isinstance(f, F)
+    assert isinstance(g, G)

--- a/tests/test_third_party/test_using_beartype.py
+++ b/tests/test_third_party/test_using_beartype.py
@@ -1,64 +1,36 @@
-from typing import Tuple
-
 import pytest
-from beartype.roar import BeartypeException  # typing: ignore
+from beartype.cave import RegexTypes  # type: ignore
+from beartype.vale import Is  # type: ignore
+from typing_extensions import Annotated
 
-from hydra_zen import builds, instantiate
 from hydra_zen.experimental.third_party.beartype import validates_with_beartype
 
 
-class A:
-    pass
-
-
-def f(x: A):
-    return None
-
-
-class B:
-    def __init__(self, x: A) -> None:
+@pytest.mark.parametrize(
+    "custom_type, good_val, bad_val",
+    [
+        (RegexTypes, "abc+", 22),
+        (Annotated[str, Is[lambda text: 2 == len(text)]], "hi", "bye"),
+    ],
+)
+def test_beartype_specific_fields(custom_type, good_val, bad_val):
+    def f(x):
         pass
 
+    f.__annotations__["x"] = custom_type
+    bear_hugged_f = validates_with_beartype(f)
 
-def test_bear_basics():
-    C1 = builds(f, builds(A), zen_wrappers=validates_with_beartype)
-    C2 = builds(B, builds(A), zen_wrappers=validates_with_beartype)
-    instantiate(C1)
-    assert isinstance(instantiate(C2), B)
+    bear_hugged_f(good_val)  # ok
+    with pytest.raises(Exception):
+        bear_hugged_f(bad_val)
 
+    class A:
+        def __init__(self, x) -> None:
+            pass
 
-class F:
-    pass
+    A.__init__.__annotations__["x"] = custom_type
+    validates_with_beartype(A)
 
-
-class G:
-    pass
-
-
-def tuple_of_classes(x: Tuple[F, G]):
-    return x
-
-
-def test_beartype_with_arbitrary_allowed_types():
-    instantiate(builds(tuple_of_classes, [builds(F), builds(F)]))  # should pass
-
-    with pytest.raises(BeartypeException):
-        instantiate(
-            builds(
-                tuple_of_classes,
-                [builds(F), builds(F)],
-                zen_wrappers=validates_with_beartype,
-                hydra_convert="all",
-            )
-        )
-
-    f, g = instantiate(
-        builds(
-            tuple_of_classes,
-            [builds(F), builds(G)],
-            zen_wrappers=validates_with_beartype,
-            hydra_convert="all",
-        )
-    )
-    assert isinstance(f, F)
-    assert isinstance(g, G)
+    A(good_val)
+    with pytest.raises(Exception):
+        A(bad_val)

--- a/tests/test_third_party/test_using_pydantic.py
+++ b/tests/test_third_party/test_using_pydantic.py
@@ -1,0 +1,84 @@
+from typing import Tuple
+
+import pytest
+from pydantic import PositiveInt, ValidationError
+
+from hydra_zen import builds, instantiate
+from hydra_zen.experimental.third_party.pydantic import validates_with_pydantic
+
+
+def needs_pos_int(x: PositiveInt):
+    return x
+
+
+class NeedsPosInt:
+    def __init__(self, x: PositiveInt) -> None:
+        self.x = x
+
+
+def test_basic_pydantic_validation_on_func():
+    NoVal = builds(needs_pos_int, x=-100)
+    WithVal = builds(needs_pos_int, x=-100, zen_wrappers=validates_with_pydantic)
+    assert instantiate(NoVal) == -100
+
+    with pytest.raises((ValidationError, TypeError)):
+        # Unfortunately the interface for `pydantic.ValidationError` is weird..
+        # and breaks Hydra's error handling, which causes an additional TypeError.
+        # This needs to be fixes on pydantic's end, I think.
+        instantiate(WithVal)
+
+    assert instantiate(WithVal(10)) == 10
+
+
+def test_basic_pydantic_validation_on_class():
+    NoVal = builds(NeedsPosInt, -100)
+    WithVal = builds(NeedsPosInt, x=-100, zen_wrappers=validates_with_pydantic)
+    assert instantiate(NoVal).x == -100
+
+    with pytest.raises((ValidationError, TypeError)):
+        # Unfortunately the interface for `pydantic.ValidationError` is weird..
+        # and breaks Hydra's error handling, which causes an additional TypeError.
+        # This needs to be fixes on pydantic's end, I think.
+        instantiate(WithVal)
+
+    WithVal = builds(NeedsPosInt, x=100, zen_wrappers=validates_with_pydantic)
+    out = instantiate(WithVal)
+    assert isinstance(out, NeedsPosInt)
+    assert out.x == 100
+
+
+class F:
+    pass
+
+
+class G:
+    pass
+
+
+def tuple_of_classes(x: Tuple[F, G]):
+    return x
+
+
+def test_pydantic_with_arbitrary_allowed_types():
+    instantiate(builds(tuple_of_classes, [builds(F), builds(F)]))  # should pass
+
+    with pytest.raises((ValidationError, TypeError)):
+        instantiate(
+            builds(
+                tuple_of_classes,
+                [builds(F), builds(F)],
+                zen_wrappers=validates_with_pydantic,
+                hydra_convert="all",
+            )
+        )
+
+    f, g = instantiate(
+        builds(
+            tuple_of_classes,
+            [builds(F), builds(G)],
+            zen_wrappers=validates_with_pydantic,
+            hydra_convert="all",
+        )
+    )
+    assert isinstance(f, F)
+    assert isinstance(g, G)

--- a/tests/test_third_party/test_using_pydantic.py
+++ b/tests/test_third_party/test_using_pydantic.py
@@ -1,84 +1,35 @@
-from typing import Tuple
-
 import pytest
-from pydantic import PositiveInt, ValidationError
+from pydantic import AnyUrl, PositiveFloat
+from typing_extensions import Annotated
 
-from hydra_zen import builds, instantiate
 from hydra_zen.experimental.third_party.pydantic import validates_with_pydantic
 
 
-def needs_pos_int(x: PositiveInt):
-    return x
+@pytest.mark.parametrize(
+    "custom_type, good_val, bad_val",
+    [
+        (PositiveFloat, 22, -1),
+        (AnyUrl, "http://www.pythonlikeyoumeanit.com", "hello"),
+    ],
+)
+def test_pydantic_specific_fields(custom_type, good_val, bad_val):
+    def f(x):
+        pass
 
+    f.__annotations__["x"] = custom_type
+    bear_hugged_f = validates_with_pydantic(f)
 
-class NeedsPosInt:
-    def __init__(self, x: PositiveInt) -> None:
-        self.x = x
+    bear_hugged_f(good_val)  # ok
+    with pytest.raises(Exception):
+        bear_hugged_f(bad_val)
 
+    class A:
+        def __init__(self, x) -> None:
+            pass
 
-def test_basic_pydantic_validation_on_func():
-    NoVal = builds(needs_pos_int, x=-100)
-    WithVal = builds(needs_pos_int, x=-100, zen_wrappers=validates_with_pydantic)
-    assert instantiate(NoVal) == -100
+    A.__init__.__annotations__["x"] = custom_type
+    validates_with_pydantic(A)  # type: ignore
 
-    with pytest.raises((ValidationError, TypeError)):
-        # Unfortunately the interface for `pydantic.ValidationError` is weird..
-        # and breaks Hydra's error handling, which causes an additional TypeError.
-        # This needs to be fixes on pydantic's end, I think.
-        instantiate(WithVal)
-
-    assert instantiate(WithVal(10)) == 10
-
-
-def test_basic_pydantic_validation_on_class():
-    NoVal = builds(NeedsPosInt, -100)
-    WithVal = builds(NeedsPosInt, x=-100, zen_wrappers=validates_with_pydantic)
-    assert instantiate(NoVal).x == -100
-
-    with pytest.raises((ValidationError, TypeError)):
-        # Unfortunately the interface for `pydantic.ValidationError` is weird..
-        # and breaks Hydra's error handling, which causes an additional TypeError.
-        # This needs to be fixes on pydantic's end, I think.
-        instantiate(WithVal)
-
-    WithVal = builds(NeedsPosInt, x=100, zen_wrappers=validates_with_pydantic)
-    out = instantiate(WithVal)
-    assert isinstance(out, NeedsPosInt)
-    assert out.x == 100
-
-
-class F:
-    pass
-
-
-class G:
-    pass
-
-
-def tuple_of_classes(x: Tuple[F, G]):
-    return x
-
-
-def test_pydantic_with_arbitrary_allowed_types():
-    instantiate(builds(tuple_of_classes, [builds(F), builds(F)]))  # should pass
-
-    with pytest.raises((ValidationError, TypeError)):
-        instantiate(
-            builds(
-                tuple_of_classes,
-                [builds(F), builds(F)],
-                zen_wrappers=validates_with_pydantic,
-                hydra_convert="all",
-            )
-        )
-
-    f, g = instantiate(
-        builds(
-            tuple_of_classes,
-            [builds(F), builds(G)],
-            zen_wrappers=validates_with_pydantic,
-            hydra_convert="all",
-        )
-    )
-    assert isinstance(f, F)
-    assert isinstance(g, G)
+    A(good_val)
+    with pytest.raises(Exception):
+        A(bad_val)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,6 +93,9 @@ class Color(enum.Enum):
     pass
 
 
+NoneType = type(None)
+
+
 @pytest.mark.parametrize(
     "in_type, expected_type",
     [
@@ -123,8 +126,10 @@ class Color(enum.Enum):
         (abc.Mapping, Any),
         (Union[str, int], Any),
         (Optional[frozenset], Any),
-        (Union[type(None), frozenset], Any),
-        (Union[type(None), int], Optional[int]),  # supported Optional
+        (Union[NoneType, frozenset], Any),
+        (Union[frozenset, NoneType], Any),
+        (Union[NoneType, int], Optional[int]),  # supported Optional
+        (Union[int, NoneType], Optional[int]),  # supported Optional
         (Optional[Color], Optional[Color]),
         (Optional[List[Color]], Optional[List[Color]]),
         (Optional[List[List[int]]], Optional[List[Any]]),
@@ -141,6 +146,8 @@ class Color(enum.Enum):
         (Tuple[str, ...], Tuple[str, ...]),
         (Tuple[str, str, str], Tuple[str, str, str]),
         (Tuple[List[int]], Tuple[Any]),
+        (Union[NoneType, Tuple[int, int]], Optional[Tuple[int, int]]),
+        (Union[Tuple[int, int], NoneType], Optional[Tuple[int, int]]),
     ],
 )
 def test_sanitized_type_expected_behavior(in_type, expected_type):


### PR DESCRIPTION
I'm pretty excited about this.. 😄 

# New Feature: zen_wrappers

The [introduction of `hydra_zen.funcs.zen_processing`](https://github.com/mit-ll-responsible-ai/hydra-zen/pull/110) opened the door to incredible power and flexibility for modifying the instantiation process. `zen_wrappers` allows the user to "inject" one or more wrappers that will wrap the target-object before it is instantiated.

Whereas 

```python
conf = builds(target, *args, **kwargs)
instantiate(conf)
```
ultimately calls

```python
target(*args, **kwargs)
```

Using `zen_wrappers` as

```python
conf = builds(target, *args, **kwargs, zen_wrappers=[f1, f2])
instantiate(conf)
```
ultimately calls

```python
target = f1(target)  # wrap!
target = f2(target)  # wrap!
target(*args, **kwargs)  # instantiate wrapped target!
```


## A Basic Example

Let's cut to the chase and see this in action:

```python
from hydra_zen import builds, instantiate, to_yaml

def say_hello_to(func, repeat=1):
    print(f"hello, {func.__name__}!" * repeat)
    return func

def say_goodbye_to(func):
    print(f"goodbye, {func.__name__}!")
    return func
```

```python
# providing a single wrapper
>>> conf = builds(int, zen_wrappers=say_hello_to)
>>> instantiate(conf)
hello, int!
0
```

And the yaml is nice and readable
```python
>>> print(to_yaml(conf))
_target_: hydra_zen.funcs.zen_processing
_zen_target: builtins.int
_zen_wrappers: __main__.say_hello_to
```

```python
# providing a chain of wrappers, to be composed
>>> conf = builds(int, zen_wrappers=(say_goodbye_to, say_hello_to))
>>> instantiate(conf)
hello, int!
goodbye, int!
0
```

Incredibly... even the wrappers can be configured

```python
>>> conf = builds(
...     int,
...     zen_wrappers=builds(
...         say_hello_to,
...         hydra_partial=True,
...         repeat=2,
...     ),
... )
>>> instantiate(conf)
hello, int!hello, int!

>>> print(to_yaml(conf))
_target_: hydra_zen.funcs.zen_processing
_zen_target: builtins.int
_zen_wrappers:
  _target_: hydra_zen.funcs.zen_processing
  _zen_target: __main__.say_hello_to
  _zen_partial: true
  repeat: 2
```

It is kind of unbelievable how nicely this all fits together!

## A Realistic Example: Data-Validation with pydantic!

Yeah... this totally works! Try it out by checking out this PR's branch!

```python
from pydantic import PositiveInt

from hydra_zen.experimental.third_party.pydantic import validates_with_pydantic

def needs_pos_int(x: PositiveInt): 
    return x
```

```python
>>> conf_hydra_val = builds(needs_pos_int, -1)
>>> conf_pydantic_val = builds(needs_pos_int, -1, zen_wrappers=validates_with_pydantic)
>>> instantiate(conf_hydra_val)
-1

>>> instantiate(conf_pydantic_val)
---------------------------------------------------------------------------
ValidationError: 1 validation error for NeedsPosInt
x
  ensure this value is greater than 0 (type=value_error.number.not_gt; limit_value=0)

During handling of the above exception, another exception occurred:
```

This works really well... even with nested configs!

```python
class F:
    pass


class G:
    pass


class MyGuy:
    def __init__(self, tuple_of_classes: Tuple[F, G]):
        self.x = tuple_of_classes
```

```python
>>> conf_hydra_val = builds(MyGuy, [builds(F), builds(F)])
>>> instantiate(conf_hydra_val).x
[<__main__.F object at 0x0000022909BB2A90>, <__main__.F object at 0x0000022909BB2B20>]
```

```python
>>> conf_pydantic_val = builds(
...     MyGuy,
...     [builds(F), builds(F)],
...     hydra_convert="all",
...     zen_wrappers=validates_with_pydantic,
... )
>>> instantiate(conf_pydantic_val).x
---------------------------------------------------------------------------
ValidationError: 1 validation error for Init
tuple_of_classes -> 1
  instance of G expected (type=type_error.arbitrary_type; expected_arbitrary_type=G)
```

```python
>>> conf_pydantic_val = builds(
...     MyGuy,
...     [builds(F), builds(G)],  # <- fixed!
...     hydra_convert="all",
...     zen_wrappers=validates_with_pydantic,
... )
>>> instantiate(conf_pydantic_val).x
[<__main__.F at 0x22909ecb550>, <__main__.G at 0x22909ecb160>]
```

## Why a Wrapper?

Wrapping gives the user access to the inputs, the target, *and* the outputs! This enables pre-processing, post-process, transformation, and ...circumvention? This means that we can expose a single interface that enables users to do.. anything! And the implementation on our end is super simple.

The pydantic implementation was already a great proving ground for this. See the implementation [here](https://github.com/mit-ll-responsible-ai/hydra-zen/blob/zen-wrappers/src/hydra_zen/experimental/third_party/pydantic.py). Their `validate_arguments` doesn't work on instance methods, but I was able to pretty easily (and elegantly!) work around that. This really drives home the flexibility of the wrapper paradigm.

### Enabling third parties to implement and provide their own wrappers

**EDIT: This probably isn't necessary. Third party, or fourth party, sources can make these available / directly importable.**

`validates_with_pydantic` was pretty easy to implement, but ultimately it would be nice if third parties were responsible for their own implementations. This looks like a job for [entry-points](https://amir.rachum.com/blog/2017/07/28/python-entry-points/)! 

It would be nice for hydra-zen to expose an entry-point. Suppose [bear-type](https://github.com/beartype/beartype) wants people to be able to use *its* type-validation abilities, but nothing in its public-API quite gets the trick done. He could implements some function `bear_type._internal.hydra_zen_validator` and then make it available to anyone who has `hydra_zen` and `bear_type` installed:

```python
        entry_points={
            'zen_wrappers': ['bear_type = _internal:hydra_zen_validator']
        },
```

and we would look for it with:

```python
import pkg_resources

def get_wrappers():
    zen_wrappers = {
        'validates_with_pydantic': validates_with_pydantic,
    }
    for entry_point in pkg_resources.iter_entry_points('zen_wrappers'):
        zen_wrappers[entry_point.name] = entry_point.load()
    return zen_wrappers
```

I'm not exactly sure where to go from there, in terms of making the various wrappers nice and discoverable/importable to users. But I am sure that this can be done.


## Wrangling Unwieldy Configs

For validation with pydantic, users likely want to always use `hydra_convert="all"` so that pydantic doesn't get mad at omegaconf containers. But this makes for really clunky configs:

```python
conf = builds(
    MyGuy,
    [builds(F), builds(F)],
    hydra_convert="all",
    zen_wrappers=validates_with_pydantic,
)
```

plus doing things like turning on/off pydantic-validation in your configs becomes really painful.

We should provide a simply utility that allows people to set default options for builds. E.g.


```python
from hydra_zen import builds as _builds

builds = set_defaults(_builds, hydra_convert="all", zen_wrappers=validates_with_pydantic)

conf = builds(MyGuy, [builds(F), builds(F)])  # uses pydantic validation!
```

Now it is trivial for people to turn this validation on/off. Obviously there are many nice use-cases here.

```python
builds_schema = set_defaults(_builds, hydra_convert="all", zen_wrappers=validates_json_schema)
builds_xarray = set_defaults(_builds, hydra_convert="all", zen_wrappers=netcdf_to_xarray)
builds_verbose = set_defaults(_builds, populate_full_sig=True)
```


## Feedback

Am I missing something here? Are there opportunities that I am missing? Obstacles I am not foreseeing?

### Naming Things

First of all, I am going to change `hydra_meta` to `zen_meta`. It makes sense for all zen-specific features to have the `zen_` prefix and for only hydra-specific stuff to have the `hydra_` prefix. Fortunately this hasn't been released yet, so it is no biggie.  Along those lines... `hydra_partial` should be `zen_partial`... but I am not sure if I am prepared to make that change.

What do you think about the name `zen_wrappers`? A con is that one might ask *what* is it wrapping, and where is it wrapping it. But `zen_wraps_target_prior_to_instantiation` isn't exactly succinct. I think we can be okay with people just copy-pasting from the docs, and power-users doing the work to understand what it means. That being said, totally up for suggestions here.

### Config Wrangling

Any suggestions about the aforementioned `set_defaults`? Implementation-wise? Design-wise?

### Entry-points

**Note: I got some feedback on this and don't think we need entry-points**

I am totally new to these, so I don't even know what to ask for feedback on. Where should they live? `hydra_zen.third_party.wrappers`? I wish we could be more descriptive..
