### PR TITLE
Bug fix: get_target with zen_processing

### DIFF
--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -41,7 +41,7 @@ except ImportError:  # pragma: no cover
 
 _T = TypeVar("_T")
 
-_ZEN_PROCESSING_LOCATION = _utils.get_obj_path(zen_processing)
+_ZEN_PROCESSING_LOCATION: Final[str] = _utils.get_obj_path(zen_processing)
 _TARGET_FIELD_NAME: Final[str] = "_target_"
 _RECURSIVE_FIELD_NAME: Final[str] = "_recursive_"
 _CONVERT_FIELD_NAME: Final[str] = "_convert_"

--- a/tests/test_roundtrips.py
+++ b/tests/test_roundtrips.py
@@ -160,6 +160,7 @@ def test_just_roundtrip(obj):
         builds,
         just,
         lambda x: builds(x, hydra_partial=True),
+        lambda x: builds(x, hydra_meta=dict(a=1)),
     ],
 )
 def test_get_target_roundtrip(x, fn):

--- a/tests/test_roundtrips.py
+++ b/tests/test_roundtrips.py
@@ -160,7 +160,7 @@ def test_just_roundtrip(obj):
         builds,
         just,
         lambda x: builds(x, hydra_partial=True),
-        lambda x: builds(x, hydra_meta=dict(a=1)),
+        lambda x: builds(x, hydra_meta=dict(_some_obscure_name=1)),
     ],
 )
 def test_get_target_roundtrip(x, fn):


### PR DESCRIPTION
Before:

```python
>>> conf = builds(dict, a="${.hi}", hydra_meta=dict(hi=1))
>>> get_target(conf)
<function hydra_zen.funcs.zen_processing(*args, _zen_target: str, _zen_partial: bool = False, _zen_exclude: Sequence[str] = (), _zen_wrappers: Union[str, Sequence[str]] = (), **kwargs)>
```

After

```python
>>> conf = builds(dict, a="${.hi}", hydra_meta=dict(hi=1))
>>> get_target(conf)
dict
```

