### PR TITLE
Use type-checking hack to make builds-sig legible in jupyter

### DIFF
--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -42,22 +42,18 @@ except ImportError:  # pragma: no cover
 
 _T = TypeVar("_T")
 _T2 = TypeVar("_T2", bound=Callable)
-_Wrapper = Callable[[_T2], _T2]
-
+ZenWrapper = Union[
+    None,
+    Builds[Callable[[_T2], _T2]],
+    PartialBuilds[Callable[[_T2], _T2]],
+    Just[Callable[[_T2], _T2]],
+    Callable[[_T2], _T2],
+    str,
+]
 if TYPE_CHECKING:  # pragma: no cover
-    ZenWrapper = Union[
-        None, Builds[_Wrapper], PartialBuilds[_Wrapper], Just[_Wrapper], _Wrapper, str
-    ]
+    ZenWrappers = Union[ZenWrapper, Sequence[ZenWrapper]]
 else:
-    ZenWrapper = TypeVar(
-        "ZenWrapper",
-        type(None),
-        Builds[_Wrapper],
-        PartialBuilds[_Wrapper],
-        Just[_Wrapper],
-        _Wrapper,
-        str,
-    )
+    ZenWrappers = TypeVar("ZenWrappers")
 
 # Hydra-specific fields
 _TARGET_FIELD_NAME: Final[str] = "_target_"
@@ -207,7 +203,7 @@ def hydrated_dataclass(
     target: Callable,
     *pos_args: Any,
     zen_partial: bool = False,
-    zen_wrappers: Union[ZenWrapper, Sequence[ZenWrapper]] = None,
+    zen_wrappers: ZenWrappers = tuple(),
     zen_meta: Optional[Mapping[str, Any]] = None,
     populate_full_signature: bool = False,
     hydra_recursive: Optional[bool] = None,
@@ -495,7 +491,7 @@ def builds(
     hydra_target: Importable,
     *pos_args: Any,
     zen_partial: Literal[False] = False,
-    zen_wrappers: Union[ZenWrapper, Sequence[ZenWrapper]] = None,
+    zen_wrappers: ZenWrappers = tuple(),
     zen_meta: Optional[Mapping[str, Any]] = None,
     populate_full_signature: bool = False,
     hydra_recursive: Optional[bool] = None,
@@ -514,7 +510,7 @@ def builds(
     hydra_target: Importable,
     *pos_args: Any,
     zen_partial: Literal[True],
-    zen_wrappers: Union[ZenWrapper, Sequence[ZenWrapper]] = None,
+    zen_wrappers: ZenWrappers = tuple(),
     zen_meta: Optional[Mapping[str, Any]] = None,
     populate_full_signature: bool = False,
     hydra_recursive: Optional[bool] = None,
@@ -533,7 +529,7 @@ def builds(
     hydra_target: Importable,
     *pos_args: Any,
     zen_partial: bool,
-    zen_wrappers: Union[ZenWrapper, Sequence[ZenWrapper]] = None,
+    zen_wrappers: ZenWrappers = tuple(),
     zen_meta: Optional[Mapping[str, Any]] = None,
     populate_full_signature: bool = False,
     hydra_recursive: Optional[bool] = None,
@@ -553,7 +549,7 @@ def builds(
 def builds(
     *pos_args: Any,
     zen_partial: bool = False,
-    zen_wrappers: Union[ZenWrapper, Sequence[ZenWrapper]] = None,
+    zen_wrappers: ZenWrappers = tuple(),
     zen_meta: Optional[Mapping[str, Any]] = None,
     populate_full_signature: bool = False,
     hydra_recursive: Optional[bool] = None,


### PR DESCRIPTION
This is [the second time](https://github.com/rsokl/MyGrad/blob/4256b6f286e52eaa819fd6657decc705ce3dd32a/src/mygrad/typing/_array_like.py#L51-L56) I have encountered this problem...

The type-annotations for `zen_wrapper` do a great job during static-checking, but they make an absolute mess of the signature of `builds`, when viewed from common editors:

### Pre-PR
**VSCode (Pylance)**
![vscode](https://user-images.githubusercontent.com/29104956/136427419-43afaab5-835b-446e-afeb-5b6c3100dfa0.png)

**PyCharm**
![pycharm](https://user-images.githubusercontent.com/29104956/136427635-3a4de19b-6908-4bb0-b07c-7206dc27c8fd.png)

**Jupyter**
![jupyter](https://user-images.githubusercontent.com/29104956/136427760-dfabfa60-b71a-4932-9126-7fb647bda41b.png)

### Post-PR
The `TYPE_CHECKING` hack + identifying this [pylance behavior](https://github.com/microsoft/pylance-release/issues/1914#issuecomment-938187778) and updating the default value of `zen_wrappers` to `tuple()` leads to...

New Jupyter:

![image](https://user-images.githubusercontent.com/29104956/136473918-bc1fbc7e-1fce-46d4-881a-2916860ed373.png)


New VSCode:

![image](https://user-images.githubusercontent.com/29104956/136474023-89a6b7a2-52df-4408-bb83-67fd1839997e.png)


(no impact on PyCharm)