### PR TITLE
pyright 1.1.182: fix issue with pyright flagging bare Unions in soure code

### DIFF
--- a/src/hydra_zen/_utils/coerce.py
+++ b/src/hydra_zen/_utils/coerce.py
@@ -127,7 +127,7 @@ def coerce_sequences(obj: _T) -> _T:
 
         _origin = get_origin(annotation)
 
-        if _origin is not None and _origin is Union:
+        if _origin is not None and _origin is Union:  # type: ignore
             # Check for Optional[A]
             _args = get_args(annotation)
             if len(_args) == 2:

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -292,7 +292,7 @@ def sanitized_type(
             return Any
 
         args = get_args(type_)
-        if origin is Union:
+        if origin is Union:  # type: ignore
             # Hydra only supports Optional[<type>] unions
             if len(args) != 2 or NoneType not in args:
                 # isn't Optional[<type>]


### PR DESCRIPTION
If this is deemed a false positive by the pyright team, and if this is fixed in `1.1.183`, then this change should be reverted and we should bump the minimum required pyright to `1.1.183` in our CI.