### PR TITLE
Rename top-level conf in config store: config -> my_app

### DIFF
--- a/docs/source/how_to/pytorch_lightning.rst
+++ b/docs/source/how_to/pytorch_lightning.rst
@@ -373,7 +373,7 @@ at :math:`-\pi/2`, :math:`0`, and :math:`\pi/2` should return, approximately, :m
    where :math:`N` – the number of "neurons" in our layer – is a hyperparameter.
 
 .. attention:: **Cleaning Up**:
-   To clean up after this tutorial, delete the ``mutlirun`` directory that Hydra 
+   To clean up after this tutorial, delete the ``multirun`` directory that Hydra 
    created upon launching our app. You can find this in the same directory as your 
    ``experiment.py`` file.
 

--- a/docs/source/tutorials/add_cli.rst
+++ b/docs/source/tutorials/add_cli.rst
@@ -39,13 +39,13 @@ Modify your script to match this:
    
    # 1) Register our config with Hydra's config store
    cs = ConfigStore.instance()
-   cs.store(name="config", node=Config)
+   cs.store(name="my_app", node=Config)
    
    
    # 2) Tell Hydra what config to use for our task-function.
    #    The name specified here - 'config' - must match the
    #    name that we provided to `cs.store(name=<...>, node=Config)`
-   @hydra.main(config_path=None, config_name="config")
+   @hydra.main(config_path=None, config_name="my_app")
    def task_function(cfg: Config):
        cfg = instantiate(cfg)
        p1 = cfg.player1

--- a/docs/source/tutorials/config_groups.rst
+++ b/docs/source/tutorials/config_groups.rst
@@ -112,7 +112,7 @@ default config for that group. Let's specify the ``CharConf`` config, which we n
    :caption: Specifying the player-group item named ``base`` as the default player-profile
 
    Config = make_config("player", defaults=["_self_", {"player": "base"}])
-   cs.store(name="config", node=Config)
+   cs.store(name="my_app", node=Config)
 
 
 Putting It All Together
@@ -169,10 +169,10 @@ over. Modify your ``my_app.py`` script to match the following code.
    # Specify default group for player to be: base
    Config = make_config("player", defaults=["_self_", {"player": "base"}])
    
-   cs.store(name="config", node=Config)
+   cs.store(name="my_app", node=Config)
    
    
-   @hydra.main(config_path=None, config_name="config")
+   @hydra.main(config_path=None, config_name="my_app")
    def task_function(cfg: Config):
        cfg = instantiate(cfg)
    

--- a/docs/source/tutorials/hierarchy.rst
+++ b/docs/source/tutorials/hierarchy.rst
@@ -194,10 +194,10 @@ script is as follows.
     Config = make_config(player=CharConf)
     
     cs = ConfigStore.instance()
-    cs.store(name="config", node=Config)
+    cs.store(name="my_app", node=Config)
     
     
-    @hydra.main(config_path=None, config_name="config")
+    @hydra.main(config_path=None, config_name="my_app")
     def task_function(cfg: Config):
         cfg = instantiate(cfg)
         

--- a/docs/source/tutorials/inject_wrapper.rst
+++ b/docs/source/tutorials/inject_wrapper.rst
@@ -170,10 +170,10 @@ over. Modify your ``my_app.py`` script to match the following code.
    
    Config = make_config("player", defaults=["_self_", {"player": "base"}])
    
-   cs.store(name="config", node=Config)
+   cs.store(name="my_app", node=Config)
    
    
-   @hydra.main(config_path=None, config_name="config")
+   @hydra.main(config_path=None, config_name="my_app")
    def task_function(cfg: Config):
        cfg = instantiate(cfg)
    


### PR DESCRIPTION
In the current form of the tutorials, if someone tries to reproduce their app's with:

```console
 python my_app.py -cp outputs/2021-10-27/15-23-47/.hydra/ -cn config
```

Hydra raises a deprecation warning:

'config' is validated against ConfigStore schema with the same name.
This behavior is deprecated in Hydra 1.1 and will be removed in Hydra 1.2.
See https://hydra.cc/docs/next/upgrades/1.0_to_1.1/automatic_schema_matching for migration instructions.
  task_function()

This is due to the fact that, in the tutorial, we specify:

```python
cs = ConfigStore.instance()
cs.store(name="config", node=Config)


@hydra.main(config_path=None, config_name="config")
...
```

Fortunately this is a trivial change:

```python
cs = ConfigStore.instance()
cs.store(name="my_app", node=Config)


@hydra.main(config_path=None, config_name="my_app")
...
```