### PR TITLE
Docs touchup

### DIFF
--- a/docs/source/how_to/beartype.rst
+++ b/docs/source/how_to/beartype.rst
@@ -53,6 +53,24 @@ containing the following code.
    def process_shape(shape: Union[int, Sequence[int]]):
        return shape
 
+Note that the annotation
+
+.. code-block:: python
+   :caption: Annotation of ``age``
+
+   PositiveInt = Annotated[int, Is[lambda x: x >= 0]]
+
+indicates that an associated value should not only be an :class:`int`, but also have a 
+non-negative value. Whereas
+
+.. code-block:: python
+   :caption: Annotation of ``shape``
+
+   Union[int, Sequence[int]]
+
+indicates that a value should either be an :class:`int` or any sequence (list, tuple, 
+etc.) of ints.
+
 Supposing that our Hydra app will configure these two "toy" functions, let's design 
 their configs so that beartype will validate their configured values upon 
 instantiation.
@@ -86,17 +104,21 @@ In the same console, verify that you can replicate the following behavior.
 
    >>> instantiate(ConfAge, age=12)  # OK
    12
+   
    >>> instantiate(ConfAge, age=-100)  # Bad: negative int
    BeartypeCallHintPepParamException- process_age() parameter age=-100 violates type 
    hint [...]
+
    >>> instantiate(ConfAge, age="twelve")  # Bad: not an int
    BeartypeCallHintPepParamException- process_age() parameter age='twelve' violates 
    type hint [...]
    
    >>> instantiate(ConfShape, shape=3)  # OK
    3
+   
    >>> instantiate(ConfShape, shape=[1, 2, 5])  # OK
    [1, 2, 5]
+   
    >>> instantiate(ConfShape, shape=["a", "b"])  # Bad: not a sequence of ints
    BeartypeCallHintPepParamException- process_shape() parameter shape=['a', 'b'] 
    violates type hint [...]

--- a/docs/source/how_to/pytorch_lightning.rst
+++ b/docs/source/how_to/pytorch_lightning.rst
@@ -3,7 +3,8 @@
 .. admonition:: Prerequisites
 
    Your must install `PyTorch <https://pytorch.org/>`_ and `PyTorch Lightning <https://
-   www.pytorchlightning.ai/>`_ in order to complete this How-To lesson.
+   www.pytorchlightning.ai/>`_ in your Python environment in order to complete this 
+   How-To guide.
 
 .. tip::
 
@@ -160,13 +161,13 @@ model.
    def task_function(cfg: ExperimentConfig):
        pl.seed_everything(cfg.seed)
    
-       cfg = instantiate(cfg)
+       obj = instantiate(cfg)
        
        # finish instantiating the lightning module, data-loader, and optimizer
-       lit_module = cfg.lit_module(dataloader=cfg.dataloader, optim=cfg.optim)
+       lit_module = obj.lit_module(dataloader=obj.dataloader, optim=obj.optim)
    
        # train the model
-       cfg.trainer.fit(lit_module)
+       obj.trainer.fit(lit_module)
    
        # evaluate the model over the domain to assess the fit
        data = lit_module.training_domain
@@ -373,7 +374,7 @@ at :math:`-\pi/2`, :math:`0`, and :math:`\pi/2` should return, approximately, :m
    where :math:`N` – the number of "neurons" in our layer – is a hyperparameter.
 
 .. attention:: **Cleaning Up**:
-   To clean up after this tutorial, delete the ``multirun`` directory that Hydra 
+   To clean up after this tutorial, delete the ``mutlirun`` directory that Hydra 
    created upon launching our app. You can find this in the same directory as your 
    ``experiment.py`` file.
 

--- a/docs/source/how_to/pytorch_lightning.rst
+++ b/docs/source/how_to/pytorch_lightning.rst
@@ -3,7 +3,7 @@
 .. admonition:: Prerequisites
 
    Your must install `PyTorch <https://pytorch.org/>`_ and `PyTorch Lightning <https://
-   www.pytorchlightning.ai/>`_ in your Python environment in order to complete this 
+   www.pytorchlightning.ai/>`_ in your Python environment in order to follow this 
    How-To guide.
 
 .. tip::
@@ -374,7 +374,7 @@ at :math:`-\pi/2`, :math:`0`, and :math:`\pi/2` should return, approximately, :m
    where :math:`N` – the number of "neurons" in our layer – is a hyperparameter.
 
 .. attention:: **Cleaning Up**:
-   To clean up after this tutorial, delete the ``mutlirun`` directory that Hydra 
+   To clean up after this tutorial, delete the ``multirun`` directory that Hydra 
    created upon launching our app. You can find this in the same directory as your 
    ``experiment.py`` file.
 

--- a/docs/source/how_tos.rst
+++ b/docs/source/how_tos.rst
@@ -1,7 +1,7 @@
 How-To Guides
 =============
 
-These how-to guides are here to help hydra-zen users who are wondering: "How do I ...". 
+These how-to guides are here to help hydra-zen users who are wondering: "How do I ___?". 
 Our guides help you learn by having you do; they provide simple steps towards concrete 
 objectives.
 

--- a/docs/source/tutorials/add_cli.rst
+++ b/docs/source/tutorials/add_cli.rst
@@ -47,9 +47,9 @@ Modify your script to match this:
    #    name that we provided to `cs.store(name=<...>, node=Config)`
    @hydra.main(config_path=None, config_name="my_app")
    def task_function(cfg: Config):
-       cfg = instantiate(cfg)
-       p1 = cfg.player1
-       p2 = cfg.player2
+       obj = instantiate(cfg)
+       p1 = obj.player1
+       p2 = obj.player2
    
        with open("player_log.txt", "w") as f:
            f.write("Game session log:\n")

--- a/docs/source/tutorials/basic_app.rst
+++ b/docs/source/tutorials/basic_app.rst
@@ -83,11 +83,11 @@ code in this file.
     Config = make_config("player1", "player2")
     
     def task_function(cfg: Config):
-        cfg = instantiate(cfg)
+        obj = instantiate(cfg)
         
         # access the player names from the config
-        p1 = cfg.player1
-        p2 = cfg.player2
+        p1 = obj.player1
+        p2 = obj.player2
 
         # write the log with the names
         with open("player_log.txt", "w") as f:

--- a/docs/source/tutorials/config_groups.rst
+++ b/docs/source/tutorials/config_groups.rst
@@ -174,9 +174,9 @@ over. Modify your ``my_app.py`` script to match the following code.
    
    @hydra.main(config_path=None, config_name="my_app")
    def task_function(cfg: Config):
-       cfg = instantiate(cfg)
+       obj = instantiate(cfg)
    
-       player = cfg.player
+       player = obj.player
        print(player)
    
        with open("player_log.txt", "w") as f:

--- a/docs/source/tutorials/hierarchy.rst
+++ b/docs/source/tutorials/hierarchy.rst
@@ -153,9 +153,9 @@ player now, not two, so we adjust accordingly. Let's also print the
    :caption: A revised task function (single-player only)
 
    def task_function(cfg: Config):
-       cfg = instantiate(cfg)
+       obj = instantiate(cfg)
        
-       player = cfg.player
+       player = obj.player
        print(player)
 
        with open("player_log.txt", "w") as f:
@@ -199,9 +199,9 @@ script is as follows.
     
     @hydra.main(config_path=None, config_name="my_app")
     def task_function(cfg: Config):
-        cfg = instantiate(cfg)
+        obj = instantiate(cfg)
         
-        player = cfg.player
+        player = obj.player
         print(player)
         
         with open("player_log.txt", "w") as f:

--- a/docs/source/tutorials/inject_wrapper.rst
+++ b/docs/source/tutorials/inject_wrapper.rst
@@ -175,9 +175,9 @@ over. Modify your ``my_app.py`` script to match the following code.
    
    @hydra.main(config_path=None, config_name="my_app")
    def task_function(cfg: Config):
-       cfg = instantiate(cfg)
+       obj = instantiate(cfg)
    
-       player = cfg.player
+       player = obj.player
        print(player)
    
        with open("player_log.txt", "w") as f:


### PR DESCRIPTION
Main improvement: avoid

```python
cfg = instantiate(cfg)
```

pattern in docs. As pointed out by @jgbos and others, this is needlessly misleading!