### PR TITLE
pin pyright to 1.1.184 in CI until 1.1.186 is released

### DIFF
--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -159,7 +159,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install pyright
-      run: sudo npm install -g pyright@">=1.1.183"
+      run: sudo npm install -g pyright@"==1.1.184"
     - uses: actions/checkout@v1
     - name: Set up Python
       uses: actions/setup-python@v2


### PR DESCRIPTION
Tracking here: https://github.com/microsoft/pyright/issues/2549