### PR TITLE
Add strict validation against Hydra's supported primitives

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -96,6 +96,55 @@ The following utilities can be used to work with YAML-serialized configs.
    load_from_yaml
 
 
+.. _valid-types:
+
+**********************************************************
+Configuration-Value Types Supported by Hydra and hydra-zen
+**********************************************************
+
+The types of values that can be specified in configs are limited by their ability to be 
+serialized to a YAML format. hydra-zen provides automatic support for an additional set 
+of common types via its :ref:`config-creation functions <create-config>`.
+
+Types Supported Natively by Hydra
+*********************************
+
+Values of the following types can be specified directly in configs:
+
+- ``NoneType``
+- :py:class:`bool`
+- :py:class:`int`
+- :py:class:`float`
+- :py:class:`str`
+- :py:class:`list`
+- :py:class:`dict`
+- :py:class:`enum.Enum`
+
+
+Types Supported via hydra-zen
+*****************************
+
+.. warning:: 
+   
+   This section refers to capabilities that are not yet available in a stable release 
+   of hydra-zen. They will be included in the release of `v0.4.0`.
+
+hydra-zen will automatically create targeted configs to represent values of the 
+following types:
+
+- :py:class:`bytes`
+- :py:class:`bytearray`
+- :py:class:`complex`
+- :py:class:`collections.Counter`
+- :py:class:`collections.deque`
+- :py:class:`pathlib.Path`
+- :py:class:`pathlib.PosixPath`
+- :py:class:`pathlib.WindowsPath`
+- :py:class:`range`
+- :py:class:`set`
+- :py:class:`frozenset`
+
+
 *********************
 Third-Party Utilities
 *********************

--- a/src/hydra_zen/errors.py
+++ b/src/hydra_zen/errors.py
@@ -14,3 +14,7 @@ class HydraZenDeprecationWarning(HydraZenException, FutureWarning):
     This is a subclass of FutureWarning, rather than DeprecationWarning, so
     that the warnings that it emits are not filtered by default.
     """
+
+
+class HydraZenUnsupportedPrimitiveError(HydraZenException, ValueError):
+    pass

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -110,19 +110,7 @@ def _convert_set(value: set) -> Type[Builds[Type[Set]]]:
     return builds(set, tuple(value))
 
 
-@dataclass
-class _ConfigComplex:
-    real: Any
-    imag: Any
-    _target_: str = _utils.get_obj_path(complex)
-
-
-def _convert_complex(value: complex) -> Builds[Type[complex]]:
-    return cast(Builds[Type[complex]], _ConfigComplex(real=value.real, imag=value.imag))
-
-
 ZEN_VALUE_CONVERSION[set] = _convert_set
-ZEN_VALUE_CONVERSION[complex] = _convert_complex
 
 
 def _get_target(x):

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1454,7 +1454,7 @@ def builds(
                     field_.default,
                     allow_zen_conversion=False,
                     error_prefix=_utils.building_error_prefix(target),
-                    field_name=field.name + " (set via inheritance)",
+                    field_name=field_.name + " (set via inheritance)",
                 )
             del field_
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -110,7 +110,12 @@ def _convert_set(value: set) -> Type[Builds[Type[Set]]]:
     return builds(set, tuple(value))
 
 
+def _convert_frozenset(value: set) -> Type[Builds[Type[FrozenSet]]]:
+    return builds(frozenset, tuple(value))
+
+
 ZEN_VALUE_CONVERSION[set] = _convert_set
+ZEN_VALUE_CONVERSION[frozenset] = _convert_frozenset
 
 
 def _get_target(x):

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -113,8 +113,6 @@ def _cast_via_tuple(dest_type: Type[_T]) -> Callable[[_T], Type[Builds[Type[_T]]
     return converter
 
 
-a = _cast_via_tuple(set)
-
 ZEN_VALUE_CONVERSION[set] = _cast_via_tuple(set)
 ZEN_VALUE_CONVERSION[frozenset] = _cast_via_tuple(frozenset)
 ZEN_VALUE_CONVERSION[deque] = _cast_via_tuple(deque)

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -521,6 +521,9 @@ def create_just_if_needed(value: _T) -> Union[_T, Type[Just]]:
     return value
 
 
+_KEY_ERROR_PREFIX = "Configuring dictionary key:"
+
+
 def sanitize_collection(x: _T) -> _T:
     """Pass contents of lists, tuples, or dicts through sanitized_default_values"""
     type_x = type(x)
@@ -528,7 +531,11 @@ def sanitize_collection(x: _T) -> _T:
         return type_x(sanitized_default_value(_x) for _x in x)  # type: ignore
     elif type_x is dict:
         return {
-            sanitized_default_value(k): sanitized_default_value(v)
+            # Hydra doesn't permit structured configs for keys, thus we only
+            # support its basic primitives here.
+            sanitized_default_value(
+                k, allow_zen_conversion=False, error_prefix=_KEY_ERROR_PREFIX
+            ): sanitized_default_value(v)
             for k, v in x.items()  # type: ignore
         }
     else:

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -35,6 +35,7 @@ from typing import (
     overload,
 )
 
+from omegaconf import DictConfig, ListConfig
 from typing_extensions import Final, Literal, TypeGuard
 
 from hydra_zen.errors import (
@@ -566,7 +567,11 @@ def sanitized_default_value(
         return builds(type(resolved_value), resolved_value.value)
 
     if type_of_value in HYDRA_SUPPORTED_PRIMITIVES or (
-        structured_conf_permitted and is_dataclass(resolved_value)
+        structured_conf_permitted
+        and (
+            is_dataclass(resolved_value)
+            or isinstance(resolved_value, (ListConfig, DictConfig))
+        )
     ):
         return resolved_value
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1545,7 +1545,7 @@ def builds(
         else:
             assert len(item) == 3, item
             value = item[-1]
-            # print(type(value))
+
             if not isinstance(value, Field):
                 value = sanitized_field(
                     value,

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -571,11 +571,13 @@ def sanitized_default_value(
 
     err_msg = (
         error_prefix
-        + f" The configured value {value}{field_name} is not supported by Hydra -- serializing or instantiating this config would ultimately result in an error."
+        + f" The configured value {value}{field_name} is not supported by Hydra -- "
+        f"serializing or instantiating this config would ultimately result in an error."
     )
 
     if structured_conf_permitted:
-        err_msg += f"\n\nConsider using `hydra_zen.builds({type(value)}, ...)` to create a config for this particular value."
+        err_msg += f"\n\nConsider using `hydra_zen.builds({type(value)}, ...)` to "
+        "create a config for this particular value."
 
     raise HydraZenUnsupportedPrimitiveError(err_msg)
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -507,21 +507,6 @@ def just(obj: Importable) -> Type[Just[Importable]]:
     return cast(Type[Just[Importable]], out_class)
 
 
-def create_just_if_needed(value: _T) -> Union[_T, Type[Just]]:
-    # Hydra can serialize dataclasses directly, thus we
-    # don't want to wrap these in `just`
-
-    if callable(value) and (
-        inspect.isfunction(value)
-        or (inspect.isclass(value) and not is_dataclass(value))
-        or isinstance(value, _builtin_function_or_method_type)
-        or (ufunc is not None and isinstance(value, ufunc))
-    ):
-        return just(value)
-
-    return value
-
-
 _KEY_ERROR_PREFIX = "Configuring dictionary key:"
 
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -521,13 +521,12 @@ def sanitize_collection(x: _T) -> _T:
     if type_x in {list, tuple}:
         return type_x(sanitized_default_value(_x) for _x in x)  # type: ignore
     elif type_x is dict:
-        return type_x(
-            {
-                sanitized_default_value(k): sanitized_default_value(v)
-                for k, v in x.items()  # type: ignore
-            }
-        )
+        return {
+            sanitized_default_value(k): sanitized_default_value(v)
+            for k, v in x.items()  # type: ignore
+        }
     else:
+        # pass-through
         return x
 
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -549,7 +549,8 @@ def sanitized_default_value(
         conversion_fn = ZEN_VALUE_CONVERSION.get(type_)
 
         if conversion_fn is not None:
-            return conversion_fn(resolved_value)
+            resolved_value = conversion_fn(resolved_value)
+            type_value = type(resolved_value)
 
     if type_value in HYDRA_SUPPORTED_PRIMITIVES or is_dataclass(resolved_value):
         return resolved_value

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -19,7 +19,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Collection,
     Dict,
     FrozenSet,
     List,
@@ -111,7 +110,19 @@ def _convert_set(value: set) -> Type[Builds[Type[Set]]]:
     return builds(set, tuple(value))
 
 
+@dataclass
+class _ConfigComplex:
+    real: Any
+    imag: Any
+    _target_: str = _utils.get_obj_path(complex)
+
+
+def _convert_complex(value: complex) -> Builds[Type[complex]]:
+    return cast(Builds[Type[complex]], _ConfigComplex(real=value.real, imag=value.imag))
+
+
 ZEN_VALUE_CONVERSION[set] = _convert_set
+ZEN_VALUE_CONVERSION[complex] = _convert_complex
 
 
 def _get_target(x):

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -97,7 +97,7 @@ COMMON_MODULES_WITH_OBFUSCATED_IMPORTS: Tuple[str, ...] = (
 UNKNOWN_NAME: Final[str] = "<unknown>"
 HYDRA_SUPPORTED_PRIMITIVE_TYPES: Final = {int, float, bool, str, Enum}
 
-KNOWN_MUTABLE_TYPES = (list, dict, set)
+KNOWN_MUTABLE_TYPES = {list, dict, set}
 
 T = TypeVar("T")
 

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -95,7 +95,8 @@ COMMON_MODULES_WITH_OBFUSCATED_IMPORTS: Tuple[str, ...] = (
     "torch",
 )
 UNKNOWN_NAME: Final[str] = "<unknown>"
-HYDRA_SUPPORTED_PRIMITIVES: Final = {int, float, bool, str, Enum}
+HYDRA_SUPPORTED_PRIMITIVE_TYPES: Final = {int, float, bool, str, Enum}
+
 KNOWN_MUTABLE_TYPES = (list, dict, set)
 
 T = TypeVar("T")
@@ -350,7 +351,7 @@ def sanitized_type(
 
     if (
         type_ is Any
-        or type_ in HYDRA_SUPPORTED_PRIMITIVES
+        or type_ in HYDRA_SUPPORTED_PRIMITIVE_TYPES
         or is_dataclass(type_)
         or (isinstance(type_, type) and issubclass(type_, Enum))
     ):

--- a/src/hydra_zen/structured_configs/_value_conversion.py
+++ b/src/hydra_zen/structured_configs/_value_conversion.py
@@ -1,5 +1,24 @@
-from typing import Any, Callable, Dict, Set
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Set, Type, cast
+
+from hydra_zen.typing import Builds
+
+from ._utils import get_obj_path
 
 # `set` support implemented in _implementations.py
-ZEN_SUPPORTED_PRIMITIVES: Set[type] = {set}
+ZEN_SUPPORTED_PRIMITIVES: Set[type] = {set, complex}
 ZEN_VALUE_CONVERSION: Dict[type, Callable[[Any], Any]] = {}
+
+
+@dataclass
+class _ConfigComplex:
+    real: Any
+    imag: Any
+    _target_: str = get_obj_path(complex)
+
+
+def _convert_complex(value: complex) -> Builds[Type[complex]]:
+    return cast(Builds[Type[complex]], _ConfigComplex(real=value.real, imag=value.imag))
+
+
+ZEN_VALUE_CONVERSION[complex] = _convert_complex

--- a/src/hydra_zen/structured_configs/_value_conversion.py
+++ b/src/hydra_zen/structured_configs/_value_conversion.py
@@ -1,12 +1,13 @@
+from collections import Counter, deque
 from dataclasses import dataclass
 from pathlib import Path, PosixPath, WindowsPath
-from typing import Any, Callable, Dict, Set, Type, cast
+from typing import Any, Callable, Dict, Optional, Set, Type, cast
 
 from hydra_zen.typing import Builds
 
 from ._utils import get_obj_path
 
-# `set` support implemented in _implementations.py
+# Some primitive support implemented in _implementations.py
 ZEN_SUPPORTED_PRIMITIVES: Set[type] = {
     set,
     frozenset,
@@ -14,7 +15,13 @@ ZEN_SUPPORTED_PRIMITIVES: Set[type] = {
     Path,
     PosixPath,
     WindowsPath,
+    bytes,
+    bytearray,
+    deque,
+    Counter,
+    range,
 }
+
 ZEN_VALUE_CONVERSION: Dict[type, Callable[[Any], Any]] = {}
 
 

--- a/src/hydra_zen/structured_configs/_value_conversion.py
+++ b/src/hydra_zen/structured_configs/_value_conversion.py
@@ -1,4 +1,5 @@
 from typing import Any, Callable, Dict, Tuple
 
-ZEN_SUPPORTED_PRIMITIVES: Tuple[type, ...] = ()
+# `set` support implemented in _implementations.py
+ZEN_SUPPORTED_PRIMITIVES: Tuple[type, ...] = (set,)
 ZEN_VALUE_CONVERSION: Dict[type, Callable[[Any], Any]] = {}

--- a/src/hydra_zen/structured_configs/_value_conversion.py
+++ b/src/hydra_zen/structured_configs/_value_conversion.py
@@ -1,5 +1,5 @@
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, Set
 
 # `set` support implemented in _implementations.py
-ZEN_SUPPORTED_PRIMITIVES: Tuple[type, ...] = (set,)
+ZEN_SUPPORTED_PRIMITIVES: Set[type] = {set}
 ZEN_VALUE_CONVERSION: Dict[type, Callable[[Any], Any]] = {}

--- a/src/hydra_zen/structured_configs/_value_conversion.py
+++ b/src/hydra_zen/structured_configs/_value_conversion.py
@@ -1,0 +1,4 @@
+from typing import Any, Callable, Dict, Tuple
+
+ZEN_SUPPORTED_PRIMITIVES: Tuple[type, ...] = ()
+ZEN_VALUE_CONVERSION: Dict[type, Callable[[Any], Any]] = {}

--- a/src/hydra_zen/structured_configs/_value_conversion.py
+++ b/src/hydra_zen/structured_configs/_value_conversion.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from pathlib import Path, PosixPath, WindowsPath
 from typing import Any, Callable, Dict, Set, Type, cast
 
 from hydra_zen.typing import Builds
@@ -6,19 +7,34 @@ from hydra_zen.typing import Builds
 from ._utils import get_obj_path
 
 # `set` support implemented in _implementations.py
-ZEN_SUPPORTED_PRIMITIVES: Set[type] = {set, complex}
+ZEN_SUPPORTED_PRIMITIVES: Set[type] = {set, complex, Path, PosixPath, WindowsPath}
 ZEN_VALUE_CONVERSION: Dict[type, Callable[[Any], Any]] = {}
 
 
 @dataclass
-class _ConfigComplex:
+class ConfigComplex:
     real: Any
     imag: Any
     _target_: str = get_obj_path(complex)
 
 
-def _convert_complex(value: complex) -> Builds[Type[complex]]:
-    return cast(Builds[Type[complex]], _ConfigComplex(real=value.real, imag=value.imag))
+def convert_complex(value: complex) -> Builds[Type[complex]]:
+    return cast(Builds[Type[complex]], ConfigComplex(real=value.real, imag=value.imag))
 
 
-ZEN_VALUE_CONVERSION[complex] = _convert_complex
+ZEN_VALUE_CONVERSION[complex] = convert_complex
+
+
+@dataclass
+class ConfigPath:
+    _args_: Any
+    _target_: str = get_obj_path(Path)
+
+
+def convert_path(value: Path) -> Builds[Type[Path]]:
+    return cast(Builds[Type[Path]], ConfigPath(_args_=(str(value),)))
+
+
+ZEN_VALUE_CONVERSION[Path] = convert_path
+ZEN_VALUE_CONVERSION[PosixPath] = convert_path
+ZEN_VALUE_CONVERSION[WindowsPath] = convert_path

--- a/src/hydra_zen/structured_configs/_value_conversion.py
+++ b/src/hydra_zen/structured_configs/_value_conversion.py
@@ -1,7 +1,7 @@
 from collections import Counter, deque
 from dataclasses import dataclass
 from pathlib import Path, PosixPath, WindowsPath
-from typing import Any, Callable, Dict, Optional, Set, Type, cast
+from typing import Any, Callable, Dict, Set, Type, cast
 
 from hydra_zen.typing import Builds
 

--- a/src/hydra_zen/structured_configs/_value_conversion.py
+++ b/src/hydra_zen/structured_configs/_value_conversion.py
@@ -7,7 +7,14 @@ from hydra_zen.typing import Builds
 from ._utils import get_obj_path
 
 # `set` support implemented in _implementations.py
-ZEN_SUPPORTED_PRIMITIVES: Set[type] = {set, complex, Path, PosixPath, WindowsPath}
+ZEN_SUPPORTED_PRIMITIVES: Set[type] = {
+    set,
+    frozenset,
+    complex,
+    Path,
+    PosixPath,
+    WindowsPath,
+}
 ZEN_VALUE_CONVERSION: Dict[type, Callable[[Any], Any]] = {}
 
 

--- a/src/hydra_zen/typing/__init__.py
+++ b/src/hydra_zen/typing/__init__.py
@@ -1,7 +1,14 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
-from ._implementations import Builds, Importable, Just, Partial, PartialBuilds
+from ._implementations import (
+    Builds,
+    Importable,
+    Just,
+    Partial,
+    PartialBuilds,
+    SupportedPrimitive,
+)
 
 __all__ = [
     "Builds",
@@ -9,4 +16,5 @@ __all__ = [
     "Just",
     "Partial",
     "PartialBuilds",
+    "SupportedPrimitive",
 ]

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -2,7 +2,21 @@
 # SPDX-License-Identifier: MIT
 
 from dataclasses import Field
-from typing import Any, Callable, Dict, Generic, NewType, Tuple, TypeVar
+from enum import Enum
+from pathlib import Path
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    NewType,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from typing_extensions import Protocol, runtime_checkable
 
@@ -12,6 +26,7 @@ __all__ = [
     "PartialBuilds",
     "Partial",
     "Importable",
+    "SupportedPrimitive",
 ]
 
 
@@ -80,3 +95,28 @@ class HasTarget(Protocol):  # pragma: no cover
 @runtime_checkable
 class HasPartialTarget(Protocol):  # pragma: no cover
     _zen_partial: bool = True
+
+
+__SupportedPrimitives = Union[
+    bool,
+    None,
+    int,
+    float,
+    str,
+    type,
+    Callable,
+    Enum,
+    DataClass,
+    Type[DataClass],
+    complex,
+    Path,
+]
+
+_SupportedPrimitives = Union[
+    __SupportedPrimitives,
+    Dict[__SupportedPrimitives, __SupportedPrimitives],
+    Set[__SupportedPrimitives],
+]
+
+
+SupportedPrimitive = Union[_SupportedPrimitives, Sequence[_SupportedPrimitives]]

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -1,16 +1,21 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 from dataclasses import Field
 from enum import Enum
 from pathlib import Path
 from typing import (
     Any,
     Callable,
+    Counter,
+    Deque,
     Dict,
+    FrozenSet,
     Generic,
+    List,
     NewType,
-    Sequence,
     Set,
     Tuple,
     Type,
@@ -18,6 +23,7 @@ from typing import (
     Union,
 )
 
+from omegaconf import DictConfig, ListConfig
 from typing_extensions import Protocol, runtime_checkable
 
 __all__ = [
@@ -97,26 +103,34 @@ class HasPartialTarget(Protocol):  # pragma: no cover
     _zen_partial: bool = True
 
 
-__SupportedPrimitives = Union[
+_HydraPrimitive = Union[
     bool,
     None,
     int,
     float,
     str,
+]
+
+_SupportedPrimitive = Union[
+    _HydraPrimitive,
+    ListConfig,
+    DictConfig,
     type,
     Callable,
     Enum,
-    DataClass,
-    Type[DataClass],
+    _DataClass,
     complex,
     Path,
+    range,
 ]
 
-_SupportedPrimitives = Union[
-    __SupportedPrimitives,
-    Dict[__SupportedPrimitives, __SupportedPrimitives],
-    Set[__SupportedPrimitives],
+SupportedPrimitive = Union[
+    _SupportedPrimitive,
+    Dict[_HydraPrimitive, "SupportedPrimitive"],
+    Counter[_HydraPrimitive],
+    Set["SupportedPrimitive"],
+    FrozenSet["SupportedPrimitive"],
+    Deque["SupportedPrimitive"],
+    List["SupportedPrimitive"],
+    Tuple["SupportedPrimitive", ...],
 ]
-
-
-SupportedPrimitive = Union[_SupportedPrimitives, Sequence[_SupportedPrimitives]]

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
-from __future__ import annotations
-
 from dataclasses import Field
 from enum import Enum
 from pathlib import Path

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -16,7 +16,6 @@ from typing import (
     NewType,
     Set,
     Tuple,
-    Type,
     TypeVar,
     Union,
 )

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -7,7 +7,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Callable, List, Literal, Tuple, Type
 
-from omegaconf import DictConfig, ListConfig
+from omegaconf import MISSING, DictConfig, ListConfig
 
 from hydra_zen import (
     ZenField,
@@ -277,6 +277,8 @@ def supported_primitives():
 
     a7 = builds(
         f,
+        None,
+        MISSING,
         1,
         "hi",
         2.0,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,9 @@ import os
 import sys
 import tempfile
 
+import hypothesis.strategies as st
 import pytest
+from omegaconf import DictConfig, ListConfig
 
 # Skip collection of tests that don't work on the current version of Python.
 collect_ignore_glob = []
@@ -49,3 +51,9 @@ def cleandir():
         yield tmpdirname  # yields control to the test to be run
         os.chdir(old_dir)
         logging.shutdown()
+
+
+st.register_type_strategy(ListConfig, st.lists(st.integers()).map(ListConfig))
+st.register_type_strategy(
+    DictConfig, st.dictionaries(st.integers(), st.integers()).map(DictConfig)
+)

--- a/tests/test_config_value_validation.py
+++ b/tests/test_config_value_validation.py
@@ -105,6 +105,9 @@ construction_fn_variations = [
 @example(unsupported={1: unsupported_subclass})
 @example(unsupported={unsupported_subclass})
 @example(unsupported={unsupported_subclass})
+# Hydra doesn't support dataclass nodes for keys; ensure
+# hydra-zen doesn't provide enhanced primitive support for keys
+@example(unsupported={1j: 1})
 @settings(
     max_examples=20,
     deadline=None,

--- a/tests/test_config_value_validation.py
+++ b/tests/test_config_value_validation.py
@@ -129,10 +129,14 @@ def test_unsupported_config_value_raises_while_making_config(
 def test_that_configs_passed_by_zen_validation_are_serializable(
     config_construction_fn, value
 ):
+    # `value` is literally any value that Hypothesis knows how to describe
     try:
         Conf = config_construction_fn(value)
     except (HydraZenUnsupportedPrimitiveError, ModuleNotFoundError):
+        # the drawn value is not compatible with Hydra -- should be caught
+        # by us
         return
-    # check serializability & instantiability
+    # The value passed our construction, thus the resulting config
+    # should be serializable & instantiable
     to_yaml(Conf)
     instantiate(Conf)

--- a/tests/test_config_value_validation.py
+++ b/tests/test_config_value_validation.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import hypothesis.strategies as st
 import pytest
-from hypothesis import assume, given, settings
+from hypothesis import HealthCheck, assume, given, settings
 
 from hydra_zen import (
     ZenField,
@@ -79,7 +79,9 @@ def f_with_bad_default_value(x=unsupported_instance):
         lambda x: builds(f_concrete_sig, builds_bases=(make_dataclass(x),)),
     ],
 )
-@settings(max_examples=20, deadline=None)
+@settings(
+    max_examples=20, deadline=None, suppress_health_check=(HealthCheck.data_too_large,)
+)
 @given(
     unsupported=st.just(unsupported_instance)
     | everything_except(
@@ -112,6 +114,7 @@ def test_unsupported_config_value_raises_while_making_config(
         lambda x: builds(f_concrete_sig, builds_bases=(make_dataclass(x),)),
     ],
 )
+@settings(suppress_health_check=(HealthCheck.data_too_large,), deadline=None)
 @given(value=everything_except())
 def test_that_configs_passed_by_zen_validation_are_serializable(
     config_construction_fn, value

--- a/tests/test_config_value_validation.py
+++ b/tests/test_config_value_validation.py
@@ -67,13 +67,13 @@ construction_fn_variations = [
     lambda x: make_config(a=x),
     lambda x: make_config(ZenField(name="a", default=x)),
     lambda x: builds(f_concrete_sig, x=x, populate_full_signature=False),
-    lambda x: builds(f_concrete_sig, x, populate_full_signature=False),
+    lambda x: builds(f_concrete_sig, x, populate_full_signature=False),  #
     lambda x: builds(f_with_kwargs, x=x, populate_full_signature=False),
-    lambda x: builds(f_with_kwargs, x, populate_full_signature=False),
+    lambda x: builds(f_with_kwargs, x, populate_full_signature=False),  #
     lambda x: builds(f_concrete_sig, x=x, populate_full_signature=True),
-    lambda x: builds(f_concrete_sig, x, populate_full_signature=True),
+    lambda x: builds(f_concrete_sig, x, populate_full_signature=True),  #
     lambda x: builds(f_with_kwargs, x=x, populate_full_signature=True),
-    lambda x: builds(f_with_kwargs, x, populate_full_signature=True),
+    lambda x: builds(f_with_kwargs, x, populate_full_signature=True),  #
     lambda x: builds(f_with_bad_default_value, populate_full_signature=True),
     lambda x: make_hydrated_dataclass(f_concrete_sig, x),
     # test validation via inheritance
@@ -90,6 +90,12 @@ construction_fn_variations = [
 )
 @given(
     unsupported=st.just(unsupported_instance)
+    # test collections containing unsupported values
+    | st.just([unsupported_instance])
+    | st.just((unsupported_instance,))
+    | st.just({unsupported_instance: 1})
+    | st.just({1: unsupported_instance})
+    | st.just({unsupported_instance})
     | everything_except(
         *(HYDRA_SUPPORTED_PRIMITIVES + ZEN_SUPPORTED_PRIMITIVES)
     ).filter(lambda x: not inspect.isfunction(x))

--- a/tests/test_config_value_validation.py
+++ b/tests/test_config_value_validation.py
@@ -1,0 +1,125 @@
+import inspect
+from dataclasses import dataclass
+from typing import Any
+
+import hypothesis.strategies as st
+import pytest
+from hypothesis import assume, given, settings
+
+from hydra_zen import (
+    ZenField,
+    builds,
+    hydrated_dataclass,
+    instantiate,
+    make_config,
+    to_yaml,
+)
+from hydra_zen.errors import HydraZenUnsupportedPrimitiveError
+from hydra_zen.structured_configs._implementations import HYDRA_SUPPORTED_PRIMITIVES
+from hydra_zen.structured_configs._utils import KNOWN_MUTABLE_TYPES
+from hydra_zen.structured_configs._value_conversion import ZEN_SUPPORTED_PRIMITIVES
+from tests import everything_except
+
+
+def f_concrete_sig(x):
+    pass
+
+
+def f_with_kwargs(*args, **kwargs):
+    pass
+
+
+def make_hydrated_dataclass(target, a):
+    assume(not isinstance(a, KNOWN_MUTABLE_TYPES))
+
+    @hydrated_dataclass(target)
+    class Config:
+        x: Any = a
+
+    return Config
+
+
+def make_dataclass(a):
+    assume(not isinstance(a, KNOWN_MUTABLE_TYPES))
+
+    @dataclass
+    class C:
+        x: Any = a
+
+    return C
+
+
+class SomeType:
+    pass
+
+
+unsupported_instance = SomeType()
+
+
+def f_with_bad_default_value(x=unsupported_instance):
+    pass
+
+
+@pytest.mark.parametrize(
+    "config_construction_fn",
+    [
+        lambda x: make_config(a=x),
+        lambda x: make_config(ZenField(name="a", default=x)),
+        lambda x: builds(f_concrete_sig, x=x, populate_full_signature=False),
+        lambda x: builds(f_concrete_sig, x, populate_full_signature=False),
+        lambda x: builds(f_with_kwargs, x=x, populate_full_signature=False),
+        lambda x: builds(f_with_kwargs, x, populate_full_signature=False),
+        lambda x: builds(f_concrete_sig, x=x, populate_full_signature=True),
+        lambda x: builds(f_concrete_sig, x, populate_full_signature=True),
+        lambda x: builds(f_with_kwargs, x=x, populate_full_signature=True),
+        lambda x: builds(f_with_kwargs, x, populate_full_signature=True),
+        lambda x: builds(f_with_bad_default_value, populate_full_signature=True),
+        lambda x: make_hydrated_dataclass(f_concrete_sig, x),
+        # test validation via inheritance
+        lambda x: builds(f_concrete_sig, builds_bases=(make_dataclass(x),)),
+    ],
+)
+@settings(max_examples=20, deadline=None)
+@given(
+    unsupported=st.just(unsupported_instance)
+    | everything_except(
+        *(HYDRA_SUPPORTED_PRIMITIVES + ZEN_SUPPORTED_PRIMITIVES)
+    ).filter(lambda x: not inspect.isfunction(x))
+)
+def test_unsupported_config_value_raises_while_making_config(
+    config_construction_fn, unsupported
+):
+    with pytest.raises((HydraZenUnsupportedPrimitiveError, ModuleNotFoundError)):
+        config_construction_fn(unsupported)
+
+
+@pytest.mark.parametrize(
+    "config_construction_fn",
+    [
+        lambda x: make_config(a=x),
+        lambda x: make_config(ZenField(name="a", default=x)),
+        lambda x: builds(f_concrete_sig, x=x, populate_full_signature=False),
+        lambda x: builds(f_concrete_sig, x, populate_full_signature=False),
+        lambda x: builds(f_with_kwargs, x=x, populate_full_signature=False),
+        lambda x: builds(f_with_kwargs, x, populate_full_signature=False),
+        lambda x: builds(f_concrete_sig, x=x, populate_full_signature=True),
+        lambda x: builds(f_concrete_sig, x, populate_full_signature=True),
+        lambda x: builds(f_with_kwargs, x=x, populate_full_signature=True),
+        lambda x: builds(f_with_kwargs, x, populate_full_signature=True),
+        lambda x: builds(f_with_bad_default_value, populate_full_signature=True),
+        lambda x: make_hydrated_dataclass(f_concrete_sig, x),
+        # test validation via inheritance
+        lambda x: builds(f_concrete_sig, builds_bases=(make_dataclass(x),)),
+    ],
+)
+@given(value=everything_except())
+def test_that_configs_passed_by_zen_validation_are_serializable(
+    config_construction_fn, value
+):
+    try:
+        Conf = config_construction_fn(value)
+    except (HydraZenUnsupportedPrimitiveError, ModuleNotFoundError):
+        return
+    # check serializability & instantiability
+    to_yaml(Conf)
+    instantiate(Conf)

--- a/tests/test_config_value_validation.py
+++ b/tests/test_config_value_validation.py
@@ -94,7 +94,7 @@ construction_fn_variations = [
     # test validation via inheritance
     lambda x: builds(f_concrete_sig, builds_bases=(make_dataclass(x),)),
     # test validation of meta-fields
-    lambda x: builds(f_concrete_sig, zen_meta=dict(a=x)),
+    lambda x: builds(f_concrete_sig, x=1, zen_meta=dict(a=x)),
 ]
 
 

--- a/tests/test_config_value_validation.py
+++ b/tests/test_config_value_validation.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2021 Massachusetts Institute of Technology
+# SPDX-License-Identifier: MIT
+
 import inspect
 from dataclasses import dataclass
 from typing import Any
@@ -60,8 +63,7 @@ def f_with_bad_default_value(x=unsupported_instance):
     pass
 
 
-@pytest.mark.parametrize(
-    "config_construction_fn",
+construction_fn_variations = (
     [
         lambda x: make_config(a=x),
         lambda x: make_config(ZenField(name="a", default=x)),
@@ -78,6 +80,12 @@ def f_with_bad_default_value(x=unsupported_instance):
         # test validation via inheritance
         lambda x: builds(f_concrete_sig, builds_bases=(make_dataclass(x),)),
     ],
+)
+
+
+@pytest.mark.parametrize(
+    "config_construction_fn",
+    construction_fn_variations,
 )
 @settings(
     max_examples=20, deadline=None, suppress_health_check=(HealthCheck.data_too_large,)
@@ -95,25 +103,7 @@ def test_unsupported_config_value_raises_while_making_config(
         config_construction_fn(unsupported)
 
 
-@pytest.mark.parametrize(
-    "config_construction_fn",
-    [
-        lambda x: make_config(a=x),
-        lambda x: make_config(ZenField(name="a", default=x)),
-        lambda x: builds(f_concrete_sig, x=x, populate_full_signature=False),
-        lambda x: builds(f_concrete_sig, x, populate_full_signature=False),
-        lambda x: builds(f_with_kwargs, x=x, populate_full_signature=False),
-        lambda x: builds(f_with_kwargs, x, populate_full_signature=False),
-        lambda x: builds(f_concrete_sig, x=x, populate_full_signature=True),
-        lambda x: builds(f_concrete_sig, x, populate_full_signature=True),
-        lambda x: builds(f_with_kwargs, x=x, populate_full_signature=True),
-        lambda x: builds(f_with_kwargs, x, populate_full_signature=True),
-        lambda x: builds(f_with_bad_default_value, populate_full_signature=True),
-        lambda x: make_hydrated_dataclass(f_concrete_sig, x),
-        # test validation via inheritance
-        lambda x: builds(f_concrete_sig, builds_bases=(make_dataclass(x),)),
-    ],
-)
+@pytest.mark.parametrize("config_construction_fn", construction_fn_variations)
 @settings(suppress_health_check=(HealthCheck.data_too_large,), deadline=None)
 @given(value=everything_except())
 def test_that_configs_passed_by_zen_validation_are_serializable(

--- a/tests/test_config_value_validation.py
+++ b/tests/test_config_value_validation.py
@@ -63,24 +63,22 @@ def f_with_bad_default_value(x=unsupported_instance):
     pass
 
 
-construction_fn_variations = (
-    [
-        lambda x: make_config(a=x),
-        lambda x: make_config(ZenField(name="a", default=x)),
-        lambda x: builds(f_concrete_sig, x=x, populate_full_signature=False),
-        lambda x: builds(f_concrete_sig, x, populate_full_signature=False),
-        lambda x: builds(f_with_kwargs, x=x, populate_full_signature=False),
-        lambda x: builds(f_with_kwargs, x, populate_full_signature=False),
-        lambda x: builds(f_concrete_sig, x=x, populate_full_signature=True),
-        lambda x: builds(f_concrete_sig, x, populate_full_signature=True),
-        lambda x: builds(f_with_kwargs, x=x, populate_full_signature=True),
-        lambda x: builds(f_with_kwargs, x, populate_full_signature=True),
-        lambda x: builds(f_with_bad_default_value, populate_full_signature=True),
-        lambda x: make_hydrated_dataclass(f_concrete_sig, x),
-        # test validation via inheritance
-        lambda x: builds(f_concrete_sig, builds_bases=(make_dataclass(x),)),
-    ],
-)
+construction_fn_variations = [
+    lambda x: make_config(a=x),
+    lambda x: make_config(ZenField(name="a", default=x)),
+    lambda x: builds(f_concrete_sig, x=x, populate_full_signature=False),
+    lambda x: builds(f_concrete_sig, x, populate_full_signature=False),
+    lambda x: builds(f_with_kwargs, x=x, populate_full_signature=False),
+    lambda x: builds(f_with_kwargs, x, populate_full_signature=False),
+    lambda x: builds(f_concrete_sig, x=x, populate_full_signature=True),
+    lambda x: builds(f_concrete_sig, x, populate_full_signature=True),
+    lambda x: builds(f_with_kwargs, x=x, populate_full_signature=True),
+    lambda x: builds(f_with_kwargs, x, populate_full_signature=True),
+    lambda x: builds(f_with_bad_default_value, populate_full_signature=True),
+    lambda x: make_hydrated_dataclass(f_concrete_sig, x),
+    # test validation via inheritance
+    lambda x: builds(f_concrete_sig, builds_bases=(make_dataclass(x),)),
+]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config_value_validation.py
+++ b/tests/test_config_value_validation.py
@@ -93,6 +93,8 @@ construction_fn_variations = [
     lambda x: make_hydrated_dataclass(f_concrete_sig, x),
     # test validation via inheritance
     lambda x: builds(f_concrete_sig, builds_bases=(make_dataclass(x),)),
+    # test validation of meta-fields
+    lambda x: builds(f_concrete_sig, zen_meta=dict(a=x)),
 ]
 
 

--- a/tests/test_config_value_validation.py
+++ b/tests/test_config_value_validation.py
@@ -109,7 +109,9 @@ construction_fn_variations = [
 @example(unsupported={unsupported_subclass})
 @example(unsupported={unsupported_subclass})
 @settings(
-    max_examples=20, deadline=None, suppress_health_check=(HealthCheck.data_too_large,)
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=(HealthCheck.data_too_large, HealthCheck.too_slow),
 )
 @given(
     unsupported=everything_except(
@@ -124,7 +126,10 @@ def test_unsupported_config_value_raises_while_making_config(
 
 
 @pytest.mark.parametrize("config_construction_fn", construction_fn_variations)
-@settings(suppress_health_check=(HealthCheck.data_too_large,), deadline=None)
+@settings(
+    suppress_health_check=(HealthCheck.data_too_large, HealthCheck.too_slow),
+    deadline=None,
+)
 @given(value=everything_except())
 def test_that_configs_passed_by_zen_validation_are_serializable(
     config_construction_fn, value

--- a/tests/test_config_value_validation.py
+++ b/tests/test_config_value_validation.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 from hypothesis import HealthCheck, assume, example, given, settings
-from omegaconf import OmegaConf
+from omegaconf import DictConfig, ListConfig, OmegaConf
 from omegaconf.errors import KeyValidationError
 
 from hydra_zen import (
@@ -120,6 +120,8 @@ construction_fn_variations = [
 @example(unsupported={make_dataclass(1): 1})
 @example(unsupported={SomeType: 1})
 @example(unsupported={1j: 1})
+@example(unsupported={ListConfig([1, 2]): 1})
+@example(unsupported={DictConfig({1: 1}): 1})
 @settings(
     max_examples=20,
     deadline=None,

--- a/tests/test_config_value_validation.py
+++ b/tests/test_config_value_validation.py
@@ -5,7 +5,6 @@ import inspect
 from dataclasses import dataclass
 from typing import Any
 
-import hypothesis.strategies as st
 import pytest
 from hypothesis import HealthCheck, assume, example, given, settings
 
@@ -59,8 +58,6 @@ class SomeType:
 class SubclassOfSupportedPrimitive(int):
     def __repr__(self) -> str:
         return "SubclassOfSupportedPrimitive(" + super().__repr__() + ")"
-
-    pass
 
 
 unsupported_subclass = SubclassOfSupportedPrimitive()

--- a/tests/test_dataclass_semantics.py
+++ b/tests/test_dataclass_semantics.py
@@ -118,7 +118,6 @@ def test_frozen_via_hydrated_dataclass():
     | st.dictionaries(st.integers(), st.integers(), min_size=1).map(
         lambda x: {0: 0, **x}
     )
-    | st.sets(st.integers(), min_size=1)
 )
 def test_mutable_defaults_generated_from_factory(mutable):
     Conf = builds(dict, x=mutable)

--- a/tests/test_third_party/test_type_validators.py
+++ b/tests/test_third_party/test_type_validators.py
@@ -216,7 +216,7 @@ class UserIdentity(TypedDict):
     ],
 )
 @pytest.mark.parametrize("validator", all_validators)
-@settings(max_examples=20)
+@settings(max_examples=20, deadline=None)
 @given(data=st.data(), as_yaml=st.booleans())
 def test_validations_missed_by_hydra(
     annotation, fools_hydra, validator, as_yaml: bool, data: st.DataObject

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -1,14 +1,15 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
-
+from enum import Enum
 from pathlib import Path
-from typing import FrozenSet, Set, Union
+from typing import Dict, FrozenSet, List, Set, Union
 
 import hypothesis.strategies as st
 import pytest
 from hypothesis import HealthCheck, given, settings
+from omegaconf import OmegaConf
 
-from hydra_zen import instantiate, make_config, to_yaml
+from hydra_zen import builds, instantiate, make_config, to_yaml
 from hydra_zen.structured_configs._value_conversion import (
     ZEN_SUPPORTED_PRIMITIVES,
     ZEN_VALUE_CONVERSION,
@@ -20,9 +21,26 @@ def test_supported_primitives_in_sync_with_value_conversion():
     assert set(ZEN_SUPPORTED_PRIMITIVES) == set(ZEN_VALUE_CONVERSION)
 
 
+class Shake(Enum):
+    VANILLA = 7
+    CHOCOLATE = 4
+    COOKIES = 9
+    MINT = 3
+
+
 @pytest.mark.parametrize(
     "zen_supported_type",
     (
+        # Hydra supported primitives
+        int,
+        float,
+        bool,
+        str,
+        type(None),
+        Shake,
+        List[Union[int, List[int], Dict[int, int]]],
+        Dict[int, Union[int, str, List[int], Dict[int, int]]],
+        # hydra-zen supported primitives
         set,
         frozenset,
         FrozenSet[Union[int, complex]],
@@ -33,20 +51,29 @@ def test_supported_primitives_in_sync_with_value_conversion():
 )
 @settings(
     deadline=None,
-    max_examples=20,
+    max_examples=40,
     suppress_health_check=(HealthCheck.data_too_large, HealthCheck.too_slow),
 )
-@given(st.data())
-def test_value_conversion(zen_supported_type, data: st.DataObject):
+@given(data=st.data(), as_builds=st.booleans(), via_yaml=st.booleans())
+def test_value_conversion(
+    zen_supported_type, data: st.DataObject, as_builds: bool, via_yaml: bool
+):
     value = data.draw(st.from_type(zen_supported_type))
-    Conf = make_config(a=value)
-    to_yaml(Conf)
+    Conf = (
+        make_config(a=value, hydra_convert="all")
+        if not as_builds
+        else builds(dict, a=value, hydra_convert="all")
+    )
+
+    if via_yaml:
+        Conf = OmegaConf.structured(to_yaml(Conf))
+
     conf = instantiate(Conf)
-    assert isinstance(conf.a, type(value))
+    assert isinstance(conf["a"], type(value))
     if value == value:  # avoid nans
         if hasattr(value, "__iter__") and any(
             v != v for v in value
         ):  # avoid nans in collections
             pass
         else:
-            assert conf.a == value
+            assert conf["a"] == value

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path
-from typing import Set, Union
+from typing import FrozenSet, Set, Union
 
 import hypothesis.strategies as st
 import pytest
@@ -21,7 +21,15 @@ def test_supported_primitives_in_sync_with_value_conversion():
 
 
 @pytest.mark.parametrize(
-    "zen_supported_type", (set, Set[Union[int, str, complex, Path]], complex, Path)
+    "zen_supported_type",
+    (
+        set,
+        frozenset,
+        FrozenSet[int],
+        Set[Union[int, str, complex, Path]],
+        complex,
+        Path,
+    ),
 )
 @settings(
     deadline=None, max_examples=20, suppress_health_check=(HealthCheck.data_too_large,)

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2021 Massachusetts Institute of Technology
+# SPDX-License-Identifier: MIT
+
+from typing import Set, Union
+
+import hypothesis.strategies as st
+import pytest
+from hypothesis import given, settings
+
+from hydra_zen import instantiate, make_config, to_yaml
+from hydra_zen.structured_configs._value_conversion import (
+    ZEN_SUPPORTED_PRIMITIVES,
+    ZEN_VALUE_CONVERSION,
+)
+
+
+def test_supported_primitives_in_sync_with_value_conversion():
+    assert len(set(ZEN_SUPPORTED_PRIMITIVES)) == len(ZEN_SUPPORTED_PRIMITIVES)
+    assert set(ZEN_SUPPORTED_PRIMITIVES) == set(ZEN_VALUE_CONVERSION)
+
+
+@pytest.mark.parametrize("zen_supported_type", (Set[Union[int, str]],))
+@settings(deadline=None, max_examples=20)
+@given(st.data())
+def test_value_conversion(zen_supported_type, data: st.DataObject):
+    value = data.draw(st.from_type(zen_supported_type))
+    Conf = make_config(a=value)
+    to_yaml(Conf)
+    conf = instantiate(Conf)
+    assert conf.a == value

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -3,7 +3,7 @@
 from collections import Counter, deque
 from enum import Enum
 from pathlib import Path
-from typing import Dict, FrozenSet, List, Set, Union
+from typing import Any, Dict, FrozenSet, List, Set, Union
 
 import hypothesis.strategies as st
 import pytest
@@ -27,6 +27,15 @@ class Shake(Enum):
     CHOCOLATE = 4
     COOKIES = 9
     MINT = 3
+
+
+# Needed for python 3.6
+def is_ascii(x: str) -> bool:
+    try:
+        x.encode("ascii")
+        return True
+    except UnicodeEncodeError:
+        return False
 
 
 @pytest.mark.parametrize(
@@ -66,7 +75,7 @@ def test_value_supported_via_config_maker_functions(
 ):
     value = data.draw(st.from_type(zen_supported_type))
     if isinstance(value, str):
-        assume(value.isascii())
+        assume(is_ascii(value))
 
     Conf = (
         make_config(a=value, hydra_convert="all")

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -8,7 +8,7 @@ from typing import Dict, FrozenSet, List, Set, Union
 import hypothesis.strategies as st
 import pytest
 from hypothesis import HealthCheck, assume, given, settings
-from omegaconf import OmegaConf
+from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from hydra_zen import builds, instantiate, make_config, to_yaml
 from hydra_zen.structured_configs._value_conversion import (
@@ -50,6 +50,8 @@ def is_ascii(x: str) -> bool:
         Shake,
         List[Union[int, List[int], Dict[int, int]]],
         Dict[int, Union[int, List[int], Dict[int, int]]],
+        ListConfig,
+        DictConfig,
         # hydra-zen supported primitives
         set,
         frozenset,
@@ -87,7 +89,10 @@ def test_value_supported_via_config_maker_functions(
         Conf = OmegaConf.structured(to_yaml(Conf))
 
     conf = instantiate(Conf)
-    assert isinstance(conf["a"], type(value))
+
+    if not isinstance(value, (ListConfig, DictConfig)):
+        assert isinstance(conf["a"], type(value))
+
     if value == value:  # avoid nans
         if (
             not isinstance(value, range)

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -3,7 +3,7 @@
 from collections import Counter, deque
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, FrozenSet, List, Set, Union
+from typing import Dict, FrozenSet, List, Set, Union
 
 import hypothesis.strategies as st
 import pytest

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -32,7 +32,9 @@ def test_supported_primitives_in_sync_with_value_conversion():
     ),
 )
 @settings(
-    deadline=None, max_examples=20, suppress_health_check=(HealthCheck.data_too_large,)
+    deadline=None,
+    max_examples=20,
+    suppress_health_check=(HealthCheck.data_too_large, HealthCheck.too_slow),
 )
 @given(st.data())
 def test_value_conversion(zen_supported_type, data: st.DataObject):

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -19,7 +19,7 @@ def test_supported_primitives_in_sync_with_value_conversion():
     assert set(ZEN_SUPPORTED_PRIMITIVES) == set(ZEN_VALUE_CONVERSION)
 
 
-@pytest.mark.parametrize("zen_supported_type", (Set[Union[int, str]],))
+@pytest.mark.parametrize("zen_supported_type", (Set[Union[int, str, complex]], complex))
 @settings(deadline=None, max_examples=20)
 @given(st.data())
 def test_value_conversion(zen_supported_type, data: st.DataObject):
@@ -27,4 +27,8 @@ def test_value_conversion(zen_supported_type, data: st.DataObject):
     Conf = make_config(a=value)
     to_yaml(Conf)
     conf = instantiate(Conf)
-    assert conf.a == value
+    if value == value:  # avoid nans
+        if hasattr(value, "__iter__") and any(v != v for v in value):
+            pass
+        else:
+            assert conf.a == value

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -25,7 +25,7 @@ def test_supported_primitives_in_sync_with_value_conversion():
     (
         set,
         frozenset,
-        FrozenSet[int],
+        FrozenSet[Union[int, complex]],
         Set[Union[int, str, complex, Path]],
         complex,
         Path,

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -6,7 +6,7 @@ from typing import Set, Union
 
 import hypothesis.strategies as st
 import pytest
-from hypothesis import given, settings
+from hypothesis import HealthCheck, given, settings
 
 from hydra_zen import instantiate, make_config, to_yaml
 from hydra_zen.structured_configs._value_conversion import (
@@ -23,7 +23,9 @@ def test_supported_primitives_in_sync_with_value_conversion():
 @pytest.mark.parametrize(
     "zen_supported_type", (set, Set[Union[int, str, complex, Path]], complex, Path)
 )
-@settings(deadline=None, max_examples=20)
+@settings(
+    deadline=None, max_examples=20, suppress_health_check=(HealthCheck.data_too_large,)
+)
 @given(st.data())
 def test_value_conversion(zen_supported_type, data: st.DataObject):
     value = data.draw(st.from_type(zen_supported_type))

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
+from collections import Counter, deque
 from enum import Enum
 from pathlib import Path
 from typing import Dict, FrozenSet, List, Set, Union
 
 import hypothesis.strategies as st
 import pytest
-from hypothesis import HealthCheck, given, settings
+from hypothesis import HealthCheck, assume, given, settings
 from omegaconf import OmegaConf
 
 from hydra_zen import builds, instantiate, make_config, to_yaml
@@ -39,7 +40,7 @@ class Shake(Enum):
         type(None),
         Shake,
         List[Union[int, List[int], Dict[int, int]]],
-        Dict[int, Union[int, str, List[int], Dict[int, int]]],
+        Dict[int, Union[int, List[int], Dict[int, int]]],
         # hydra-zen supported primitives
         set,
         frozenset,
@@ -47,6 +48,11 @@ class Shake(Enum):
         Set[Union[int, str, complex, Path]],
         complex,
         Path,
+        bytes,
+        bytearray,
+        deque,
+        range,
+        Counter,
     ),
 )
 @settings(
@@ -55,10 +61,13 @@ class Shake(Enum):
     suppress_health_check=(HealthCheck.data_too_large, HealthCheck.too_slow),
 )
 @given(data=st.data(), as_builds=st.booleans(), via_yaml=st.booleans())
-def test_value_conversion(
+def test_value_supported_via_config_maker_functions(
     zen_supported_type, data: st.DataObject, as_builds: bool, via_yaml: bool
 ):
     value = data.draw(st.from_type(zen_supported_type))
+    if isinstance(value, str):
+        assume(value.isascii())
+
     Conf = (
         make_config(a=value, hydra_convert="all")
         if not as_builds
@@ -71,8 +80,10 @@ def test_value_conversion(
     conf = instantiate(Conf)
     assert isinstance(conf["a"], type(value))
     if value == value:  # avoid nans
-        if hasattr(value, "__iter__") and any(
-            v != v for v in value
+        if (
+            not isinstance(value, range)
+            and hasattr(value, "__iter__")
+            and any(v != v for v in value)
         ):  # avoid nans in collections
             pass
         else:

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
+from pathlib import Path
 from typing import Set, Union
 
 import hypothesis.strategies as st
@@ -19,7 +20,9 @@ def test_supported_primitives_in_sync_with_value_conversion():
     assert set(ZEN_SUPPORTED_PRIMITIVES) == set(ZEN_VALUE_CONVERSION)
 
 
-@pytest.mark.parametrize("zen_supported_type", (Set[Union[int, str, complex]], complex))
+@pytest.mark.parametrize(
+    "zen_supported_type", (set, Set[Union[int, str, complex, Path]], complex, Path)
+)
 @settings(deadline=None, max_examples=20)
 @given(st.data())
 def test_value_conversion(zen_supported_type, data: st.DataObject):
@@ -27,8 +30,11 @@ def test_value_conversion(zen_supported_type, data: st.DataObject):
     Conf = make_config(a=value)
     to_yaml(Conf)
     conf = instantiate(Conf)
+    assert isinstance(conf.a, type(value))
     if value == value:  # avoid nans
-        if hasattr(value, "__iter__") and any(v != v for v in value):
+        if hasattr(value, "__iter__") and any(
+            v != v for v in value
+        ):  # avoid nans in collections
             pass
         else:
             assert conf.a == value


### PR DESCRIPTION
![The Eyes of T.J. Eckleburg, The Great Gatsby (2013)](https://user-images.githubusercontent.com/29104956/142258402-d1f6fae9-bc3f-453b-af5f-f0b2e34adbb4.png)
> The Eyes of T.J. Eckleburg, *The Great Gatsby* (2013)

Closes #149 

## Adding strict validation against Hydra's supported primitives

Prior to this PR, hydra-zen would not check configured values to see if they are compatible with Hydra's supported primitives. This means that you could construct a config via `builds` and `make_config` that are destined to raise whenever Hydra tries to serialize or instantiate the config. This is no good!

**Before**:

```python
from hydra_zen import make_config, to_yaml, instantiate, builds

class MyCustomClass:
    pass
```

```python
>>> not_supported = MyCustomClass()
>>> Conf = make_config(a=not_supported)  # hydra-zen is OK with this even though it is doomed to fail
>>> to_yaml(Conf)   # will raise
>>> instantiate(Conf) # will raise
```

Also, our annotations did not provide any feedback along these lines

![image](https://user-images.githubusercontent.com/29104956/142256082-d2ef90ad-5be8-4bcb-b1f3-d7cd44ac3520.png)


**After**:

Now `builds`, `make_config`, and `hydrated_dataclass` strive to strictly validate all configured values -- whether they are specified by the user or auto-populated from an object's signature. The goal here is to catch mistakes in configs, which would eventually be "snagged" by omegaconf/Hydra, before you even launch your app.

```python
>>> not_supported = MyCustomClass()
>>> Conf = make_config(a=not_supported) 
---------------------------------------------------------------------------
HydraZenUnsupportedPrimitiveError         Traceback (most recent call last)
HydraZenUnsupportedPrimitiveError: Building: dict ..
 The configured value <__main__.MyCustomClass object at 0x000001E01B72B4C0>, for field `a`, is not supported by Hydra. Serializing or instantiating this config would ultimately result in an error.
Consider using `hydra_zen.builds` to create a config for this particular value.
```

I hope that the error message is sufficiently clear

> HydraZenUnsupportedPrimitiveError: Building: dict ..
 The configured value <__main__.MyCustomClass object at 0x000001E01B72B4C0>, for field `a`, is not supported by Hydra. Serializing or instantiating this config would ultimately result in an error.
Consider using `hydra_zen.builds` to create a config for this particular value.

We even peek inside containers and validate their contents

```python
>>> builds(dict, a=[1, not_supported])  # will raise  (inside list)
>>> make_config(a={1: not_supported}))  # will raise  (as value in dict)
>>> make_config(a={not_supported: "a"}))  # will raise  (as key in dict)
```

Note that *all* of our type-checking used for this validation should adhere to the form: `type(x) is in SUPPORTED_TYPE`, and **not** `isinstance(x, SUPPORTED_TYPES)` because we do not handle/permit subclasses of valid primitive types.

## Providing Support for Additional Primitives

This PR isn't just about narc-ing on bad configs, it also adds new capabilities! We can add support for common types that Hydra doesn't handle. Presently, we add support for:

- bytes
- bytearray
- complex
- Counter
- deque
- Path
- PosixPath
- WindowsPath
- range
- set
- frozenset

```python
from pathlib import Path
from hydra_zen import to_yaml

def pp(x): print(to_yaml(x))
```

```python
>>> pp(make_config(a=Path.home()))
a:
  _args_:
  - C:\Users\Ryan Soklaski
  _target_: pathlib.Path

>>> instantiate(make_config(a=Path.home()))
{'a': WindowsPath('C:/Users/Ryan Soklaski')}

>>> pp(make_config(a={1, 2, 3}))
a:
  _target_: builtins.set
  _args_:
  - - 1
    - 2
    - 3

>>> pp(make_config(a=1+2j))
a:
  real: 1.0
  imag: 2.0
  _target_: builtins.complex
```

We're pretty fancy here - we even permit things like sets of complex numbers!

```python
>>> pp(make_config(a={1+2j, -10j}))
a:
  _target_: builtins.set
  _args_:
  - - real: -0.0
      imag: -10.0
      _target_: builtins.complex
    - real: 1.0
      imag: 2.0
      _target_: builtins.complex
```

## Improved Annotations

The annotation for our config-creating functions are much better now; type-checkers will now flag bad inputs. The following reflects the behavior of pyright/pylance under the "basic" type-checking mode.

![image](https://user-images.githubusercontent.com/29104956/142256601-c2910550-b7f9-41c3-8f3c-4c2e5f67422a.png)

## Feedback on this PR

### Exception vs Warning (for now)

Given that we raise an exception for this validation, upgrading from v0.3 to v0.4 could be a rude awakening for folks who are, for some reason, using hydra-zen to a bunch of ultimately-invalid configs.

I have been considering having this PR raise a warning on bad-configurations, and note that in a future version the warning will become an exception. The reasons why I opted for going the more abrupt route of raising an error is:
1. For current user code for which this PR will introduce exceptions, I expect that their code would be raising *already*, but just downstream. I suppose that that folks *could* be using `builds` and `make_config` in a way that is detached from Hydra... but that really isn't what `hydra_zen`  is for, and I wouldn't be surprised if literally no one is doing this.
2. It is harder to track down the source of a warning than it is the emitter of an exception. So going the route of raising an exception actually makes it easier for new users to quickly diagnose the source of their error.
3. I want people to immediately be able to incorporate this improved validation in the automated tests. Converting warnings to exceptions on the user-side is way too much work.

The above is my reasoning on this topic. I am open to discussion if there are other opinions.

### Any Other Low-Hanging Fruit for Supporting Primitives?

I plan to add support for `numpy.ndarray` and `torch.Tensor`, but in a separate PR because handling the dynamic imports is a bit trickier. 

That all being said, are there other primitives, beyond `set`, `frozenset`, `complex`, and `pathlib.Path`, that we should add support for? For example, `pathlib.Path` jumped out at me as being *super* useful. Obviously there are plenty of fish in the std-lib sea; support can be added incrementally.

### Possible Future Capability: Enable Users to Register Their Own Primitives / Conversion Strategies

There are various ways by which we could enable users to register new types and corresponding conversion strategies. 

The biggest "Pro" is that if someone is regularly using some custom type in their config, registering a converter makes config-design *much* more elegantly.

The biggest "Con" that I can think of is that this can introduce "secret" dependencies on dynamic code. E.g. A user's config-generating code can only be run *after* that converter has been registered. Fortunately, the resulting config (either the dataclass or yaml) should be independent of this dependency. This is an improvement of omegaconf's capability for registering resolvers -- where even yamls can become secretly tethered to third-party code.

# Implementation Details

## Restricted Primitives for Dictionary Keys
omegaconf does not permit dataclasses as keys in dictionaries, even if they would instantiate to a hashable value. Thus the extended primitive support is not provided for dict-keys

![image](https://user-images.githubusercontent.com/29104956/143608541-2a1c8009-9683-4417-a8f0-b17883a34cfe.png)

## No Support for `attrs` (for now)

We currently do not provide any support for the [attrs](https://www.attrs.org/en/stable/) library; it is likely that `attrs` instances will get caught by our validation in its current form. This is not likely to impact most hydra-zen users in the near term, but we should eventually add support for it.

## Support for Enum

Although Omegaconf provides support for `Enum`, the yaml serialization process only retains the enum-member's name:

```python
from enum import Enum

from hydra_zen import make_config, builds, to_yaml, instantiate
from omegaconf import OmegaConf, ListConfig, DictConfig

class Color(Enum):
    red = 1
    green = 2
```
 ```python
>>> OmegaConf.create(to_yaml({1: Color.red}))
{1: 'red'}
```

It appears that the enum-member can only be restored if a schema is provided that contains the `Enum` subclass in the annotation. Thus hydra-zen instead provides specialized support for `Enum`:

```python
>>> OmegaConf.create(to_yaml(make_config(a={1: Color.red})))
{'a': {1: {'_target_': '__main__.Color', '_args_': [1]}}}
```

this way, one can roundtrip from a yaml and restore the actual enum-member:

```python
>>> instantiate(OmegaConf.create(to_yaml(make_config(a={1: Color.red}))))
{'a': {1: <Color.red: 1>}}
```