### PR TITLE
ENH: hydra-zen will never be the first to import numpy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 21.11b1
     hooks:
     - id: black
       language_version: python3.8

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ INSTALL_REQUIRES = [
 ]
 TESTS_REQUIRE = [
     "pytest >= 3.8",
-    "hypothesis >= 6.16.0",
+    "hypothesis >= 6.28.0",
 ]
 
 DESCRIPTION = "Configurable, reproducible, and scalable workflows in Python, via Hydra"

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -516,7 +516,9 @@ _KEY_ERROR_PREFIX = "Configuring dictionary key:"
 def _is_ufunc(value) -> bool:
     # checks without importing numpy
     numpy = sys.modules.get("numpy")
-    if numpy is None:
+    if numpy is None:  # pragma: no cover
+        # we do actually cover this branch some runs of our CI,
+        # but our coverage job installs numpy
         return False
     return isinstance(value, numpy.ufunc)  # type: ignore
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 import inspect
+import sys
 import warnings
 from collections import Counter, defaultdict, deque
 from dataclasses import (
@@ -48,12 +49,6 @@ from hydra_zen.typing import Builds, Importable, Just, PartialBuilds, SupportedP
 from hydra_zen.typing._implementations import DataClass, HasPartialTarget, HasTarget
 
 from ._value_conversion import ZEN_SUPPORTED_PRIMITIVES, ZEN_VALUE_CONVERSION
-
-try:
-    # used to check if default values are ufuncs
-    from numpy import ufunc  # type: ignore
-except ImportError:  # pragma: no cover
-    ufunc = None
 
 _T = TypeVar("_T")
 _T2 = TypeVar("_T2", bound=Callable)
@@ -518,6 +513,14 @@ def just(obj: Importable) -> Type[Just[Importable]]:
 _KEY_ERROR_PREFIX = "Configuring dictionary key:"
 
 
+def _is_ufunc(value) -> bool:
+    # checks without importing numpy
+    numpy = sys.modules.get("numpy")
+    if numpy is None:
+        return False
+    return isinstance(value, numpy.ufunc)  # type: ignore
+
+
 def sanitized_default_value(
     value: Any,
     allow_zen_conversion: bool = True,
@@ -535,7 +538,7 @@ def sanitized_default_value(
             inspect.isfunction(value)
             or (not is_dataclass(value) and inspect.isclass(value))
             or isinstance(value, _builtin_function_or_method_type)
-            or (ufunc is not None and isinstance(value, ufunc))
+            or _is_ufunc(value)
         )
     ):
         return just(value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
-import importlib
 import logging
 import os
 import sys
 import tempfile
 
+import pkg_resources
 import pytest
 
 # Skip collection of tests that don't work on the current version of Python.
@@ -21,10 +21,10 @@ OPTIONAL_TEST_DEPENDENCIES = (
     "beartype",
 )
 
+_installed = {pkg.key for pkg in pkg_resources.working_set}
+
 for _module_name in OPTIONAL_TEST_DEPENDENCIES:
-    try:
-        importlib.import_module(_module_name)
-    except ModuleNotFoundError:
+    if _module_name in _installed:
         collect_ignore_glob.append(f"**/*{_module_name}*.py")
 
 if sys.version_info < (3, 8):
@@ -49,3 +49,6 @@ def cleandir():
         yield tmpdirname  # yields control to the test to be run
         os.chdir(old_dir)
         logging.shutdown()
+
+
+pytest_plugins = "pytester"

--- a/tests/test_third_party/test_against_numpy.py
+++ b/tests/test_third_party/test_against_numpy.py
@@ -119,8 +119,17 @@ def test_no_numpy_import():
     assert "numpy" not in sys.modules
 
     from hydra_zen import builds, launch, make_config
+    from hydra_zen.funcs import get_obj
+
     make_config(a=1)
     builds(dict, a=make_config)  # specifically exercises auto-just
+
+    # jogs imports through potential obfuscated modules
+    try:
+        get_obj(path="blahblah")
+    except ImportError:
+        pass
+
     assert "numpy" not in sys.modules
 """
 

--- a/tests/test_third_party/test_against_numpy.py
+++ b/tests/test_third_party/test_against_numpy.py
@@ -117,10 +117,15 @@ import sys
 
 def test_no_numpy_import():
     assert "numpy" not in sys.modules
+
+    from hydra_zen import builds, launch, make_config
+    make_config(a=1)
+    builds(dict, a=make_config)  # specifically exercises auto-just
+    assert "numpy" not in sys.modules
 """
 
 
-def test_hypothesis_is_not_the_first_to_import_numpy(pytester):
+def test_hydra_zen_is_not_the_first_to_import_numpy(pytester):
     # We only import numpy if the user did so first.
     pytester.makepyfile(SHOULD_NOT_IMPORT_NUMPY)
     pytester.makeconftest("")

--- a/tests/test_third_party/test_against_numpy.py
+++ b/tests/test_third_party/test_against_numpy.py
@@ -110,3 +110,19 @@ def test_obfuscated_modules_dont_get_mixed_up():
 
     assert get_target(builds(np.random.random)) is np.random.random
     assert get_target(builds(random.random)) is random.random
+
+
+SHOULD_NOT_IMPORT_NUMPY = """
+import sys
+
+def test_no_numpy_import():
+    assert "numpy" not in sys.modules
+"""
+
+
+def test_hypothesis_is_not_the_first_to_import_numpy(pytester):
+    # We only import numpy if the user did so first.
+    pytester.makepyfile(SHOULD_NOT_IMPORT_NUMPY)
+    pytester.makeconftest("")
+    result = pytester.runpytest_subprocess()
+    result.assert_outcomes(passed=1, failed=0)


### PR DESCRIPTION
hydra-zen provides specialized support for numpy so that its functions/classes can seamlessly be configured by our tools. This involves some "magic" on our end. Previously, we imported numpy if it was installed in a user's env. Well, things just got more magical: we now provide the same automatic support for numpy, but hydra-zen will never be first to import numpy.

Why bother with this? Because hydra-zen's support for numpy is not an obvious characteristic of the library, and we don't want users to be sent on a wild goose chase, trying to figure out where in *their* code they are importing NumPy. In general, we want the footprint left behind by hydra-zen to be as minimal as possible.

Note to devs: you'll need to upgrade your installation of hypothesis to get this new test to pass