### PR TITLE
Patch upstream omegaconf issue #830

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ commands = pytest \
 
 [testenv:min-deps]  # test against minimum dependency versions
 deps = hydra-core==1.1.0
+       omegaconf==2.1.1
        typing-extensions==3.10.0.1
        {[testenv]deps}
 basepython = python3.7
@@ -60,6 +61,7 @@ setenv = NUMBA_DISABLE_JIT=1
 usedevelop = true
 basepython = python3.8
 deps = {[testenv]deps}
+       omegaconf==2.1.1  # ensure we cover paths that patch omegaconf 830
        coverage
        pytest-cov
        numpy

--- a/src/hydra_zen/errors.py
+++ b/src/hydra_zen/errors.py
@@ -16,5 +16,9 @@ class HydraZenDeprecationWarning(HydraZenException, FutureWarning):
     """
 
 
-class HydraZenUnsupportedPrimitiveError(HydraZenException, ValueError):
+class HydraZenValidationError(HydraZenException):
+    pass
+
+
+class HydraZenUnsupportedPrimitiveError(HydraZenValidationError, ValueError):
     pass

--- a/tests/test_hydra_behaviors.py
+++ b/tests/test_hydra_behaviors.py
@@ -239,7 +239,14 @@ class A_inheritance:
     y: Any = 1
 
 
-valid_defaults = st.sampled_from([1, "a", None, True, [1], {"a": 1}])
+valid_defaults = (
+    st.none()
+    | st.booleans()
+    | st.text(alphabet="abcde")
+    | st.integers(-3, 3)
+    | st.lists(st.integers(-2, 2))
+    | st.fixed_dictionaries({"a": st.integers(-2, 2)})
+)
 
 
 def via_hydrated(x, Parent):

--- a/tests/test_hydra_behaviors.py
+++ b/tests/test_hydra_behaviors.py
@@ -265,6 +265,7 @@ def mutable_if_needed(x):
         lambda x, Parent: make_config(x=ZenField(Any, x), bases=(Parent,)),
         lambda x, Parent: make_config(ZenField(Any, x, "x"), bases=(Parent,)),
         lambda x, Parent: builds(A_inheritance, x=x, builds_bases=(Parent,)),
+        # TODO: add case where x is populated via pop-full-sig
         # we currently support specifing fields-as-args in builds
         lambda x, Parent: builds(
             A_inheritance, x=mutable_if_needed(x), builds_bases=(Parent,)

--- a/tests/test_hydra_behaviors.py
+++ b/tests/test_hydra_behaviors.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field, is_dataclass
 from typing import Any, List, Tuple
 
 import hypothesis.strategies as st
@@ -11,13 +11,15 @@ from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
 from omegaconf.errors import ValidationError
 
 from hydra_zen import (
+    ZenField,
     builds,
     hydrated_dataclass,
     instantiate,
     make_config,
     mutable_value,
 )
-from hydra_zen.structured_configs._utils import get_obj_path
+from hydra_zen.errors import HydraZenValidationError
+from hydra_zen.structured_configs._utils import PATCH_OMEGACONF_830, get_obj_path
 
 
 def f_three_vars(x, y, z):
@@ -210,28 +212,113 @@ def test_type_checking():
     instantiate(builds(g2, x=[conf_C, conf_C]))
 
 
-valid_defaults = st.sampled_from([1, "a", None, MISSING, True, [1], {"a": 1}])
+def test_PATCH_OMEGACONF_830_is_set_properly():
+    # test that PATCH_OMEGACONF_830 is True only if local version
+    # of omegaconf has known bug
+    assert isinstance(PATCH_OMEGACONF_830, bool)
+
+    @dataclass
+    class BasicConf:
+        setup: Any = 1
+
+    @dataclass
+    class Config(BasicConf):
+        setup: Any = field(default_factory=lambda: list(["hi"]))
+
+    conf = OmegaConf.structured(Config)
+    if PATCH_OMEGACONF_830:
+        assert conf.setup == 1
+    else:
+        # local version of omegaconf should have correct behavior
+        assert conf.setup == ["hi"]
 
 
+@dataclass
+class A_inheritance:
+    x: Any
+    y: Any = 1
+
+
+valid_defaults = st.sampled_from([1, "a", None, True, [1], {"a": 1}])
+
+
+def via_hydrated(x, Parent):
+    z = x if not isinstance(x, (list, dict)) else mutable_value(x)
+
+    @hydrated_dataclass(A_inheritance)
+    class Conf(Parent):
+        x: Any = z
+
+    return Conf
+
+
+def mutable_if_needed(x):
+    if isinstance(x, (dict, list)):
+        return mutable_value(x)
+    return x
+
+
+@pytest.mark.parametrize(
+    "config_maker",
+    [
+        lambda x, Parent: make_config(x=x, bases=(Parent,)),
+        lambda x, Parent: make_config(x=ZenField(Any, x), bases=(Parent,)),
+        lambda x, Parent: make_config(ZenField(Any, x, "x"), bases=(Parent,)),
+        lambda x, Parent: builds(A_inheritance, x=x, builds_bases=(Parent,)),
+        # we currently support specifing fields-as-args in builds
+        lambda x, Parent: builds(
+            A_inheritance, x=mutable_if_needed(x), builds_bases=(Parent,)
+        ),
+        via_hydrated,
+    ],
+)
 @given(
     parent_field_name=st.sampled_from(["x", "y"]),
     parent_default=valid_defaults,
     child_default=valid_defaults,
 )
 def test_known_inheritance_issues_in_omegaconf_are_circumvented(
-    parent_field_name, parent_default, child_default
+    parent_field_name, parent_default, child_default, config_maker
 ):
     # Exercises omegaconf bug documented in https://github.com/omry/omegaconf/issues/830
     # Should pass either because:
     #  - the test env is running a new version of omegaconf, which has patched this
     #  - hydra-zen is providing a workaround
+    if PATCH_OMEGACONF_830 and config_maker is via_hydrated:
+        pytest.skip("hydrated_dataclass cannot support patched workaround")
+
     assume(parent_field_name != "y" or parent_default is not MISSING)
 
     Parent = make_config(**{parent_field_name: parent_default})
-    Child = make_config(x=child_default, bases=(Parent,))
-    Obj = OmegaConf.create(Child)
-    if child_default is MISSING:
-        assert OmegaConf.is_missing(Obj, "x")
+    Child = config_maker(x=child_default, Parent=Parent)
+
+    if (
+        PATCH_OMEGACONF_830
+        and isinstance(child_default, (list, dict))
+        and not isinstance(parent_default, (list, dict))
+        and parent_field_name == "x"  # parent field overlaps
+    ):
+        # ensure we only case to dataclass when necessary
+        assert is_dataclass(Child.x)
     else:
-        Obj = instantiate(Obj)
-        assert Obj.x == child_default
+        assert Child().x == child_default
+
+    Obj = instantiate(Child)
+    assert Obj.x == child_default
+
+    if parent_field_name == "y":
+        assert Obj.y == parent_default
+
+
+@pytest.mark.skipif(
+    not PATCH_OMEGACONF_830, reason="issue has been patched by omegaconf"
+)
+def test_hydrated_dataclass_raises_on_omegaconf_inheritance_issue():
+
+    Parent = make_config(x=1)
+
+    with pytest.raises(HydraZenValidationError):
+
+        @hydrated_dataclass(A_inheritance)
+        class Conf(Parent):
+            x: Any = mutable_value([1, 2])

--- a/tests/test_make_config.py
+++ b/tests/test_make_config.py
@@ -184,6 +184,8 @@ def test_default_values_get_set_as_expected(default, input_type):
 )
 def test_mutable_default_value_uses_default_factory(input_type):
     default = [1, 2, 3]
+    make_config(a=default)
+    make_config(a=[1, 2, 3])
 
     if input_type is InputType.kwargs:
         Conf = make_config(a=default)

--- a/tests/test_make_config.py
+++ b/tests/test_make_config.py
@@ -184,8 +184,6 @@ def test_default_values_get_set_as_expected(default, input_type):
 )
 def test_mutable_default_value_uses_default_factory(input_type):
     default = [1, 2, 3]
-    make_config(a=default)
-    make_config(a=[1, 2, 3])
 
     if input_type is InputType.kwargs:
         Conf = make_config(a=default)


### PR DESCRIPTION
Closes #170 

For users using `omegaconf` 2.1.1 or earlier, we provide a patch of an upstream bug.

Before:

```python
>>> A = make_config(x=1)
>>> B = make_config(x=[1, 2], bases=(A,))  # must be a mutable value to trigger the bug
>>> instantiate(B)
{'x': 1}
```

After:

```python
>>> A = make_config(x=1)
>>> B = make_config(x=[1, 2], bases=(A,))  # must be a mutable value to trigger the bug
>>> instantiate(B)
{'x': [1, 2]}
```

We achieve this by detecting the particular conditions for which this bug occurs:
- The user is not using a newer version of `omegaconf`, where this bug is fixed
- and.. the config sets a mutable default value via default-value factory
- and.. the config inherits from one or more parent dataclasses
- and.. the parent also provides a field of the same name
- and.. the parent's field is *not* a default-value factory

*and only under these circumstances* will we automatically transform

```python
make_config(x=[1, 2], bases=(A,))
```

to

```python
make_config(x=builds(list, [1, 2]), bases=(A,))
```

which ensures that the resulting config will instantiate as-expected.

We provide this automatic support for all use-cases of `make_config` and `builds`. We cannot provide this automatic support for `hydrated_dataclass`, however we do still detect the conditions and raise a `HydraZenValidationError` in such circumstances. 