### PR TITLE
Loosen type annotations to avoid false-positives on mutable generic containers

### DIFF
--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -7,14 +7,11 @@ from pathlib import Path
 from typing import (
     Any,
     Callable,
-    Counter,
     Deque,
     Dict,
     FrozenSet,
     Generic,
-    List,
     NewType,
-    Set,
     Tuple,
     TypeVar,
     Union,
@@ -119,15 +116,21 @@ _SupportedPrimitive = Union[
     complex,
     Path,
     range,
+    # Very sadly, mutable generic containers need to be invariant.
+    # See: https://mypy.readthedocs.io/en/stable/common_issues.html#invariance-vs-covariance
+    #
+    # So we can't do e.g. List['SupportedPrimitive'] for accurate, recursive
+    # lists. We would need to so List[int] | List[str] | ... ad naeseum
+    # in order to avoide hitting users with false-positives.
+    # But hey! At least our frozen-sets are very accurately typed :P
+    list,
+    dict,
+    set,
+    Deque,
 ]
 
 SupportedPrimitive = Union[
     _SupportedPrimitive,
-    Dict[_HydraPrimitive, "SupportedPrimitive"],
-    Counter[_HydraPrimitive],
-    Set["SupportedPrimitive"],
     FrozenSet["SupportedPrimitive"],
-    Deque["SupportedPrimitive"],
-    List["SupportedPrimitive"],
     Tuple["SupportedPrimitive", ...],
 ]

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -299,9 +299,21 @@ def supported_primitives():
         olist,
     )
 
+    a_list = [1, 2, [1, 2]]
+    a_dict = {"a": [1, 2, [1, 2]]}
+    a_set = {1, 2.0, (1, 2)}
+
+    # make sure we don't hit this issue again
+    # https://github.com/microsoft/pyright/issues/2659
+    a8 = make_config(x=a_list, y=a_dict, z=a_set)
+
     # The following should be marked as "bad by type-checkers
     # make_config(a=M())
+    # make_config(a=(1, M()))
     # builds(dict, a=M())
+
+    # The following *should* be invalid, but we are limited
+    # by mutable invariants being generic
     # make_config(a={1j: 1})
     # make_config(a={M: 1})
     # make_config(a={ADataclass: 1})

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -37,8 +37,6 @@ def requires_A(x: int):
 
 # test type behaviors
 def f1():
-    # test builds(..., zen_partial=True)
-    # there is something really weird where annotating : PartialBuilds[Type[A]] breaks this..
     a: Literal["Type[PartialBuilds[Type[A]]]"] = reveal_type(
         builds(A, zen_partial=True)
     )
@@ -181,6 +179,10 @@ def zen_wrappers():
         builds(str, zen_partial=True, zen_wrappers=(f, J, B, PB, None))
     )
 
+    # should fail
+    # builds(str, zen_wrappers=(2.0, 1))
+    # builds(str, zen_wrappers=False)
+
 
 def custom_builds_fn():
     _builds = make_custom_builds_fn()
@@ -319,3 +321,20 @@ def supported_primitives():
     # make_config(a={1j: 1})
     # make_config(a={M: 1})
     # make_config(a={ADataclass: 1})
+
+
+def check_inheritance():
+    P1 = make_config(x=1)
+    P2 = builds(dict)
+
+    @dataclass
+    class P3:
+        pass
+
+    C: Literal["Type[DataClass]"] = reveal_type(make_config(x=1, bases=(P1, P2, P3)))
+    D: Literal["Type[Builds[Type[int]]]"] = reveal_type(builds(int, bases=(P1, P2, P3)))
+
+    # should fail
+    # make_config(x=1, bases=(lambda x: x,))
+    # make_config(x=1, bases=(None,))
+    # make_config(x=1, bases=(A,))

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -309,7 +309,9 @@ def supported_primitives():
 
     # The following should be marked as "bad by type-checkers
     # make_config(a=M())
+    # make_config(a={"a": M()})
     # make_config(a=(1, M()))
+    # make_config(a=[1, M()])
     # builds(dict, a=M())
 
     # The following *should* be invalid, but we are limited
@@ -317,4 +319,3 @@ def supported_primitives():
     # make_config(a={1j: 1})
     # make_config(a={M: 1})
     # make_config(a={ADataclass: 1})
-    # make_config(a={ADataclass(): 1})


### PR DESCRIPTION
Closes #173 

Broadens our type-annotations for mutable containers (dicts, sets, lists, deques) to avoid the risk of users hitting false-positives in their code. ~On the downside, we can no longer provide precise feedback about whether, e.g., a list has OK contents for Hydra via our annotations.~ (EDIT: See [comment](https://github.com/mit-ll-responsible-ai/hydra-zen/pull/175#issuecomment-986170971)).  At runtime we still provide accurate checking.