### PR TITLE
Revert compat-breaking enum change introduced in v0.4.0

### DIFF
--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -598,18 +598,11 @@ def sanitized_default_value(
             resolved_value = conversion_fn(resolved_value)
             type_of_value = type(resolved_value)
 
-    if structured_conf_permitted and isinstance(resolved_value, Enum):
-        # Leverages programmatic access to enum member via value.
-        # E.g.
-        # >>> Color(1)
-        # <Color.RED: 1>
-        return builds(type(resolved_value), resolved_value.value)
-
     if type_of_value in HYDRA_SUPPORTED_PRIMITIVES or (
         structured_conf_permitted
         and (
             is_dataclass(resolved_value)
-            or isinstance(resolved_value, (ListConfig, DictConfig))
+            or isinstance(resolved_value, (Enum, ListConfig, DictConfig))
         )
     ):
         return resolved_value

--- a/tests/test_signature_parsing.py
+++ b/tests/test_signature_parsing.py
@@ -4,6 +4,7 @@
 import inspect
 from abc import ABC
 from dataclasses import dataclass
+from enum import Enum
 from inspect import Parameter
 from typing import Any, Callable, Dict, Mapping, Optional, Tuple, Type
 
@@ -373,3 +374,16 @@ def test_pop_full_sig_is_always_identical_to_manually_specifying_sig_args(
     note(to_yaml(Conf))
     note(to_yaml(ConfWithPopSig))
     assert to_yaml(Conf) == to_yaml(ConfWithPopSig)
+
+
+class Color(Enum):
+    red = 1
+    green = 2
+
+
+def f_with_color(x: Color = Color.red):
+    return x
+
+
+def test_populate_annotated_enum_regression():
+    assert instantiate(builds(f_with_color, populate_full_signature=True)) is Color.red

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -90,6 +90,10 @@ def test_value_supported_via_config_maker_functions(
     )
 
     if via_yaml:
+        if isinstance(value, Enum):
+            # Default omegaconf support for enums doesn't roundtrip from yamls
+            assume(False)
+
         Conf = OmegaConf.structured(to_yaml(Conf))
 
     conf = instantiate(Conf)


### PR DESCRIPTION
In the release of `v0.4.0`, I failed to document the compatibility-breaking change in how we support enums. Furthermore, it came to my attention that the change could introduce substantial, cumbersome changes in how a user configures and launches an app that involve enums. Lastly, the change disabled Hydra's ability to validate enum-types.

Thus this PR reverts the enum-specific changes introduced in #163 . I.e. we once again defer to the default omegaconf/Hydra support for enums.