### PR TITLE
Fix inaccurate type info and unpin pyright

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,7 +41,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install pyright
-      run: sudo npm install -g pyright@"==1.1.197"
+      run: sudo npm install -g pyright@">=1.1.199"
     - uses: actions/checkout@v1
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -159,7 +159,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install pyright
-      run: sudo npm install -g pyright@"==1.1.197"
+      run: sudo npm install -g pyright@">=1.1.199"
     - uses: actions/checkout@v1
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/src/hydra_zen/_launch.py
+++ b/src/hydra_zen/_launch.py
@@ -18,7 +18,8 @@ from hydra_zen.typing._implementations import DataClass
 
 
 def _store_config(
-    cfg: Union[DataClass, DictConfig, Mapping], config_name: str = "hydra_launch"
+    cfg: Union[DataClass, Type[DataClass], DictConfig, Mapping],
+    config_name: str = "hydra_launch",
 ) -> str:
     """Stores configuration object in Hydra's ConfigStore.
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -64,6 +64,9 @@ ZenWrapper = Union[
     Builds[Callable[[_T2], _T2]],
     PartialBuilds[Callable[[_T2], _T2]],
     Just[Callable[[_T2], _T2]],
+    Type[Builds[Callable[[_T2], _T2]]],
+    Type[PartialBuilds[Callable[[_T2], _T2]]],
+    Type[Just[Callable[[_T2], _T2]]],
     Callable[[_T2], _T2],
     str,
 ]
@@ -786,7 +789,7 @@ def builds(
         The arguments specified here solely determine the signature of the resulting
         config, unless ``populate_full_signature=True`` is specified (see below).
 
-        Named parameters of the forms that have the prefixes ``hydra_``, ``zen_`` or 
+        Named parameters of the forms that have the prefixes ``hydra_``, ``zen_`` or
         ``_zen_`` are reserved to ensure future-compatibility, and thus cannot be
         specified by the user.
 


### PR DESCRIPTION
[This bug](https://github.com/microsoft/pyright/issues/2746) in pyright 1.1.198 has been fixed. Minimum version of pyright on our CI is now 1.1.199 (the latest release as of posting this).

The newest version of pyright located some incomplete type annotations, which this PR also fixes. 