### PR TITLE
Improve type-widening and add tests

### DIFF
--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1565,6 +1565,7 @@ def builds(
                 )
             del field_
 
+    # sanitize all types and configured values
     sanitized_base_fields: List[Union[Tuple[str, Any], Tuple[str, Any, Field]]] = []
 
     for item in base_fields:
@@ -1614,9 +1615,10 @@ def builds(
                 # the recursive instantiation will appropriately produce `int` for
                 # that field. This will not be addressed by hydra/omegaconf:
                 #    https://github.com/facebookresearch/hydra/issues/1759
-                # Thus we will auto-broaden the annotation when we see that the user
-                # has specified a `Builds` as a default value.
-                if not is_builds(value) or hydra_recursive is False
+                # Thus we will auto-broaden the annotation when we see that a field
+                # is set with a structured config as a default value - assuming that
+                # the field isn't annotated with a structured config type.
+                if hydra_recursive is False or not is_builds(value) or is_builds(type_)
                 else Any
             )
             sanitized_base_fields.append((name, sanitized_type, _field))


### PR DESCRIPTION
`builds` performs type-widening when users specify targeted configs as default values. This prevents common friction with Hydra's validation system; see https://github.com/mit-ll-responsible-ai/hydra-zen/pull/84 

However, this type-widening behavior is too aggressive: A targeted config type should not be broadened to `Any` since this is a valid type that can be leveraged by Hydra's runtime validation. Thus this PR fixes this, so that dataclass-types are retained and thus can be leveraged by Hydra for validation.

**Before**:

```python
from hydra_zen import builds, instantiate

BuildsInt = builds(int)

def f_with_dataclass_annotation(x: BuildsInt = BuildsInt()):
    return x
```
```python
>>> bad_value = builds(str)()  # not an instance of `BuildsInt`
>>> instantiate(builds(f_with_dataclass_annotation, x=bad_value))  # should raise validation error
''
```

**After**

```python
>>> bad_value = builds(str)()
>>> instantiate(builds(f_with_dataclass_annotation, x=bad_value))
---------------------------------------------------------------------------
ValidationError   
ValidationError: Invalid type assigned: Builds_str is not a subclass of Builds_int. value: Builds_str(_target_='builtins.str')
    full_key: x
    object_type=None

>>> ok_value = builds(str, builds_bases=(BuildsInt,))()  # inherits from `BuildsInt`: type-checking passes
>>> instantiate(builds(f_with_dataclass_annotation, x=ok_value))
''
```

This PR also ensures that type-widening is performed based on a configuration value *after* it has been processed by our sanitization functions. Currently, the only example that I could think of to actually exercise this distinction involves the functionality in https://github.com/mit-ll-responsible-ai/hydra-zen/pull/172 . The test I included will thus only exercise this aspect of this PR for sufficiently-old versions of omegaconf.  