### PR TITLE
Improves internal code organization; adds future support for `_partial_`

### DIFF
--- a/src/hydra_zen/_compatibility.py
+++ b/src/hydra_zen/_compatibility.py
@@ -18,14 +18,15 @@ class Version(NamedTuple):
     patch: Optional[int] = None
 
 
-def get_version(ver_str: str) -> Version:
-    assert ver_str.count(".") >= 2
+def _get_version(ver_str: str) -> Version:
+    # Not for general use. Tested only for Hydra and OmegaConf
+    # version string styles
     major, minor, *_ = (int(v) for v in ver_str.split("."))
     return Version(major=major, minor=minor)
 
 
-OMEGACONF_VERSION: Final = get_version(omegaconf.__version__)
-HYDRA_VERSION: Final = get_version(hydra.__version__)
+OMEGACONF_VERSION: Final = _get_version(omegaconf.__version__)
+HYDRA_VERSION: Final = _get_version(hydra.__version__)
 
 
 # OmegaConf issue 830 describes a bug associated with structured configs

--- a/src/hydra_zen/_compatibility.py
+++ b/src/hydra_zen/_compatibility.py
@@ -1,11 +1,15 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
-
-from typing import NamedTuple, Optional
+from collections import Counter, deque
+from enum import Enum
+from pathlib import Path, PosixPath, WindowsPath
+from typing import NamedTuple, Optional, Set
 
 import hydra
 import omegaconf
 from typing_extensions import Final
+
+NoneType = type(None)
 
 
 class Version(NamedTuple):
@@ -37,3 +41,21 @@ PATCH_OMEGACONF_830: Final = True  # OMEGACONF_VERSION <= Version(2, 1)
 # by a `_partial_ = True` attribute.
 # https://github.com/facebookresearch/hydra/pull/1905
 HYDRA_SUPPORTS_PARTIAL: Final = Version(1, 1) < HYDRA_VERSION
+
+# Indicates primitive types permitted in type-hints of structured configs
+HYDRA_SUPPORTED_PRIMITIVE_TYPES: Final = {int, float, bool, str, Enum}
+# Indicates types of primitive values permitted in configs
+HYDRA_SUPPORTED_PRIMITIVES = {int, float, bool, str, list, tuple, dict, NoneType}
+ZEN_SUPPORTED_PRIMITIVES: Set[type] = {
+    set,
+    frozenset,
+    complex,
+    Path,
+    PosixPath,
+    WindowsPath,
+    bytes,
+    bytearray,
+    deque,
+    Counter,
+    range,
+}

--- a/src/hydra_zen/_compatibility.py
+++ b/src/hydra_zen/_compatibility.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2021 Massachusetts Institute of Technology
+# SPDX-License-Identifier: MIT
+
+from typing import NamedTuple, Optional
+
+import hydra
+import omegaconf
+from typing_extensions import Final
+
+
+class Version(NamedTuple):
+    major: int
+    minor: int
+    patch: Optional[int] = None
+
+
+def get_version(ver_str: str) -> Version:
+    assert ver_str.count(".") >= 2
+    major, minor, *_ = (int(v) for v in ver_str.split("."))
+    return Version(major=major, minor=minor)
+
+
+OMEGACONF_VERSION: Final = get_version(omegaconf.__version__)
+HYDRA_VERSION: Final = get_version(hydra.__version__)
+
+
+# OmegaConf issue 830 describes a bug associated with structured configs
+# composed via inheritance, where the child's attribute is a default-factory
+# and the parent's corresponding attribute is not.
+# We provide downstream workarounds until an upstream fix is released.
+#
+# Uncomment dynamic setting once OmegaConf merges fix:
+# https://github.com/omry/omegaconf/pull/832
+PATCH_OMEGACONF_830: Final = True  # OMEGACONF_VERSION <= Version(2, 1)
+
+# Hydra's instantiate API now supports partial-instantiation, indicated
+# by a `_partial_ = True` attribute.
+# https://github.com/facebookresearch/hydra/pull/1905
+HYDRA_SUPPORTS_PARTIAL: Final = Version(1, 1) < HYDRA_VERSION

--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -25,7 +25,7 @@ from typing import IO, Any, Callable, Type, TypeVar, Union, overload
 from hydra.utils import instantiate as hydra_instantiate
 from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
 
-from .typing import Builds, Just, Partial, PartialBuilds
+from .typing import Builds, HydraPartialBuilds, Just, Partial, PartialBuilds
 from .typing._implementations import _DataClass
 
 __all__ = ["instantiate", "to_yaml", "save_as_yaml", "load_from_yaml", "MISSING"]
@@ -38,6 +38,26 @@ T = TypeVar("T")
 def instantiate(
     config: Union[Just[T], Type[Just[T]]], *args: Any, **kwargs: Any
 ) -> T:  # pragma: no cover
+    ...
+
+
+@overload
+def instantiate(
+    config: Union[
+        HydraPartialBuilds[Callable[..., T]], Type[HydraPartialBuilds[Callable[..., T]]]
+    ],
+    *args: Any,
+    **kwargs: Any
+) -> Partial[T]:  # pragma: no cover
+    ...
+
+
+@overload
+def instantiate(
+    config: Union[HydraPartialBuilds[Type[T]], Type[HydraPartialBuilds[Type[T]]]],
+    *args: Any,
+    **kwargs: Any
+) -> Partial[T]:  # pragma: no cover
     ...
 
 

--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -25,8 +25,8 @@ from typing import IO, Any, Callable, Type, TypeVar, Union, overload
 from hydra.utils import instantiate as hydra_instantiate
 from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
 
-from .typing import Builds, HydraPartialBuilds, Just, Partial, PartialBuilds
-from .typing._implementations import _DataClass
+from .typing import Builds, Just, Partial, PartialBuilds
+from .typing._implementations import HydraPartialBuilds, _DataClass
 
 __all__ = ["instantiate", "to_yaml", "save_as_yaml", "load_from_yaml", "MISSING"]
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -40,6 +40,7 @@ from typing import (
 from omegaconf import DictConfig, ListConfig
 from typing_extensions import Final, Literal, TypeGuard
 
+from hydra_zen._compatibility import PATCH_OMEGACONF_830
 from hydra_zen.errors import (
     HydraZenDeprecationWarning,
     HydraZenUnsupportedPrimitiveError,
@@ -409,7 +410,7 @@ def hydrated_dataclass(
         decorated_obj = cast(Any, decorated_obj)
         decorated_obj = dataclass(frozen=frozen)(decorated_obj)
 
-        if _utils.PATCH_OMEGACONF_830 and 2 < len(decorated_obj.__mro__):
+        if PATCH_OMEGACONF_830 and 2 < len(decorated_obj.__mro__):
             parents = decorated_obj.__mro__[1:-1]
             # this class inherits from a parent
             for field_ in fields(decorated_obj):
@@ -1587,7 +1588,7 @@ def builds(
                     ),
                 )
             elif (
-                _utils.PATCH_OMEGACONF_830
+                PATCH_OMEGACONF_830
                 and builds_bases
                 and value.default_factory is not MISSING
             ):
@@ -2294,7 +2295,7 @@ def make_config(
         if not isinstance(value, ZenField):
             default_factory_permitted = (
                 not bases or _utils.mutable_default_permitted(bases, field_name=name)
-                if _utils.PATCH_OMEGACONF_830
+                if PATCH_OMEGACONF_830
                 else True
             )
             normalized_fields[name] = ZenField(
@@ -2356,7 +2357,7 @@ def _repack_zenfield(value: ZenField, name: str, bases: Tuple[_DataClass, ...]):
     default = value.default
 
     if (
-        _utils.PATCH_OMEGACONF_830
+        PATCH_OMEGACONF_830
         and bases
         and not _utils.mutable_default_permitted(bases, field_name=name)
         and isinstance(default, Field)

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -40,7 +40,12 @@ from typing import (
 from omegaconf import DictConfig, ListConfig
 from typing_extensions import Final, Literal, TypeGuard
 
-from hydra_zen._compatibility import HYDRA_SUPPORTS_PARTIAL, PATCH_OMEGACONF_830
+from hydra_zen._compatibility import (
+    HYDRA_SUPPORTED_PRIMITIVES,
+    HYDRA_SUPPORTS_PARTIAL,
+    PATCH_OMEGACONF_830,
+    ZEN_SUPPORTED_PRIMITIVES,
+)
 from hydra_zen.errors import (
     HydraZenDeprecationWarning,
     HydraZenUnsupportedPrimitiveError,
@@ -56,7 +61,7 @@ from hydra_zen.typing._implementations import (
     _DataClass,
 )
 
-from ._value_conversion import ZEN_SUPPORTED_PRIMITIVES, ZEN_VALUE_CONVERSION
+from ._value_conversion import ZEN_VALUE_CONVERSION
 
 _T = TypeVar("_T")
 _T2 = TypeVar("_T2", bound=Callable)
@@ -107,9 +112,6 @@ _POSITIONAL_OR_KEYWORD: Final = inspect.Parameter.POSITIONAL_OR_KEYWORD
 _VAR_POSITIONAL: Final = inspect.Parameter.VAR_POSITIONAL
 _KEYWORD_ONLY: Final = inspect.Parameter.KEYWORD_ONLY
 _VAR_KEYWORD: Final = inspect.Parameter.VAR_KEYWORD
-
-NoneType = type(None)
-HYDRA_SUPPORTED_PRIMITIVES = {int, float, bool, str, list, tuple, dict, NoneType}
 
 _builtin_function_or_method_type = type(len)
 

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -24,9 +24,8 @@ from typing import (
 from omegaconf import II
 from typing_extensions import Final, TypeGuard
 
+from hydra_zen._compatibility import PATCH_OMEGACONF_830
 from hydra_zen.typing._implementations import InterpStr, _DataClass
-
-PATCH_OMEGACONF_830: Final[bool] = True
 
 try:
     from typing import get_args, get_origin

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -24,7 +24,10 @@ from typing import (
 from omegaconf import II
 from typing_extensions import Final, TypeGuard
 
-from hydra_zen._compatibility import PATCH_OMEGACONF_830
+from hydra_zen._compatibility import (
+    HYDRA_SUPPORTED_PRIMITIVE_TYPES,
+    PATCH_OMEGACONF_830,
+)
 from hydra_zen.typing._implementations import InterpStr, _DataClass
 
 try:
@@ -97,8 +100,6 @@ COMMON_MODULES_WITH_OBFUSCATED_IMPORTS: Tuple[str, ...] = (
     "torch",
 )
 UNKNOWN_NAME: Final[str] = "<unknown>"
-HYDRA_SUPPORTED_PRIMITIVE_TYPES: Final = {int, float, bool, str, Enum}
-
 KNOWN_MUTABLE_TYPES = {list, dict, set}
 
 T = TypeVar("T")

--- a/src/hydra_zen/structured_configs/_value_conversion.py
+++ b/src/hydra_zen/structured_configs/_value_conversion.py
@@ -1,27 +1,15 @@
-from collections import Counter, deque
+# Copyright (c) 2021 Massachusetts Institute of Technology
+# SPDX-License-Identifier: MIT
+
 from dataclasses import dataclass
 from pathlib import Path, PosixPath, WindowsPath
-from typing import Any, Callable, Dict, Set, Type, cast
+from typing import Any, Callable, Dict, Type, cast
 
 from hydra_zen.typing import Builds
 
 from ._utils import get_obj_path
 
 # Some primitive support implemented in _implementations.py
-ZEN_SUPPORTED_PRIMITIVES: Set[type] = {
-    set,
-    frozenset,
-    complex,
-    Path,
-    PosixPath,
-    WindowsPath,
-    bytes,
-    bytearray,
-    deque,
-    Counter,
-    range,
-}
-
 ZEN_VALUE_CONVERSION: Dict[type, Callable[[Any], Any]] = {}
 
 

--- a/src/hydra_zen/typing/__init__.py
+++ b/src/hydra_zen/typing/__init__.py
@@ -3,6 +3,7 @@
 
 from ._implementations import (
     Builds,
+    HydraPartialBuilds,
     Importable,
     Just,
     Partial,
@@ -12,6 +13,7 @@ from ._implementations import (
 
 __all__ = [
     "Builds",
+    "HydraPartialBuilds",
     "Importable",
     "Just",
     "Partial",

--- a/src/hydra_zen/typing/__init__.py
+++ b/src/hydra_zen/typing/__init__.py
@@ -3,7 +3,6 @@
 
 from ._implementations import (
     Builds,
-    HydraPartialBuilds,
     Importable,
     Just,
     Partial,
@@ -13,7 +12,6 @@ from ._implementations import (
 
 __all__ = [
     "Builds",
-    "HydraPartialBuilds",
     "Importable",
     "Just",
     "Partial",

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -66,16 +66,15 @@ class DataClass(_DataClass, Protocol):  # pragma: no cover
     def __init__(self, *args, **kwargs) -> None:
         ...
 
-    def __getattribute__(self, name: str) -> Any:
+    def __getattribute__(self, __name: str) -> Any:
         ...
 
-    def __setattr__(self, name: str, value: Any) -> None:
+    def __setattr__(self, __name: str, __value: Any) -> None:
         ...
 
 
 @runtime_checkable
 class Builds(DataClass, Protocol[_T]):  # pragma: no cover
-
     _target_: str
 
 
@@ -90,6 +89,11 @@ class PartialBuilds(Builds, Protocol[_T]):  # pragma: no cover
     _target_: str = "hydra_zen.funcs.zen_processing"
     _zen_target: str
     _zen_partial: bool = True
+
+
+@runtime_checkable
+class HydraPartialBuilds(Builds, Protocol[_T]):  # pragma: no cover
+    _partial_: bool = True
 
 
 @runtime_checkable

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -5,7 +5,7 @@ from collections import Counter, deque
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Callable, List, Literal, Tuple, Type
+from typing import Callable, List, Literal, Tuple, Type, TypeVar
 
 from omegaconf import MISSING, DictConfig, ListConfig
 
@@ -19,7 +19,9 @@ from hydra_zen import (
     make_custom_builds_fn,
     mutable_value,
 )
-from hydra_zen.typing import Builds
+from hydra_zen.typing import Builds, HydraPartialBuilds
+
+T = TypeVar("T")
 
 
 class A:
@@ -338,3 +340,12 @@ def check_inheritance():
     # make_config(x=1, bases=(lambda x: x,))
     # make_config(x=1, bases=(None,))
     # make_config(x=1, bases=(A,))
+
+
+def make_hydra_partial(x: T) -> HydraPartialBuilds[Type[T]]:
+    ...
+
+
+def check_HydraPartialBuilds():
+    cfg = make_hydra_partial(int)
+    a: Literal["Partial[int]"] = reveal_type(instantiate(cfg))

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -19,7 +19,8 @@ from hydra_zen import (
     make_custom_builds_fn,
     mutable_value,
 )
-from hydra_zen.typing import Builds, HydraPartialBuilds
+from hydra_zen.typing import Builds
+from hydra_zen.typing._implementations import HydraPartialBuilds
 
 T = TypeVar("T")
 

--- a/tests/test_compatibility/test_hydra_supports_partial.py
+++ b/tests/test_compatibility/test_hydra_supports_partial.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass
+from functools import partial
+
+import pytest
+
+from hydra_zen import builds, get_target, instantiate, make_custom_builds_fn
+from hydra_zen._compatibility import HYDRA_SUPPORTS_PARTIAL
+from hydra_zen.structured_configs._implementations import (
+    is_partial_builds,
+    uses_zen_processing,
+)
+from hydra_zen.structured_configs._utils import get_obj_path
+from hydra_zen.typing import HydraPartialBuilds, PartialBuilds
+
+
+@dataclass
+class HydraPartialConf:
+    _target_: str = get_obj_path(dict)
+    _partial_: bool = True
+    x: int = 1
+
+
+def test_HydraPartialBuilds_protocol():
+    assert isinstance(HydraPartialConf(), HydraPartialBuilds)
+    assert not isinstance(HydraPartialConf(), PartialBuilds)
+
+
+def test_HYDRA_SUPPORTS_PARTIAL_is_set_properly():
+
+    obj = instantiate(HydraPartialConf)
+    if HYDRA_SUPPORTS_PARTIAL:
+        assert callable(obj) and obj() == {"x": 1}
+    else:
+        assert obj == {"x": 1, "_partial_": True}
+
+
+def test_is_partial_builds_on_hydra_partial_config():
+    assert is_partial_builds(HydraPartialConf) is HYDRA_SUPPORTS_PARTIAL
+
+
+def test_get_target_on_hydra_partial_config():
+    assert get_target(HydraPartialConf) is dict
+
+
+@pytest.mark.parametrize("via_custom_builds", [False, True])
+def test_builds_leverages_hydra_support_for_partial_when_no_other_zen_processing_used(
+    via_custom_builds,
+):
+    builder = (
+        partial(builds, zen_partial=True)
+        if not via_custom_builds
+        else make_custom_builds_fn(zen_partial=True)
+    )
+    Conf = builder(dict, x=1)
+    assert uses_zen_processing(Conf) is not HYDRA_SUPPORTS_PARTIAL
+    assert hasattr(Conf, "_partial_") is HYDRA_SUPPORTS_PARTIAL
+    instance = instantiate(Conf)()
+    assert instance == {"x": 1}
+
+
+def f(*args, **kwargs):
+    return args, kwargs
+
+
+def identity_wrapper(f):
+    return f
+
+
+@pytest.mark.parametrize("zen_meta", [None, {"_y": 1}])
+@pytest.mark.parametrize("zen_wrapper", [(), identity_wrapper])
+@pytest.mark.parametrize("pop_sig", [False, True])
+def test_partial_func_attr_is_always_target(zen_meta, zen_wrapper, pop_sig):
+    # Regardless of whether Hydra performs partial instantiation or if zen_processing
+    # is responsible, the result of the instantiation should be a partial object
+    # whose `.func` attr is the actual target-object.
+    #
+    # In particular, we want to ensure that `.func` never points to `zen_processing`,
+    # which could still produce the same end behavior for resolving the partial, but
+    # would nonetheless have unexpected behaviors to those users who query `.func`.
+    Conf = builds(
+        f,
+        "hi",
+        x=1,
+        zen_meta=zen_meta,
+        zen_wrappers=zen_wrapper,
+        populate_full_signature=pop_sig,
+        zen_partial=True,
+    )
+
+    partial_out = instantiate(Conf)
+    assert hasattr(partial_out, "func") and partial_out.func is f  # type: ignore
+    assert partial_out() == (("hi",), {"x": 1})

--- a/tests/test_compatibility/test_hydra_supports_partial.py
+++ b/tests/test_compatibility/test_hydra_supports_partial.py
@@ -29,8 +29,10 @@ def test_HYDRA_SUPPORTS_PARTIAL_is_set_properly():
 
     obj = instantiate(HydraPartialConf)
     if HYDRA_SUPPORTS_PARTIAL:
+        # instantiation should produce `functools.partial(dict, x=1)`
         assert callable(obj) and obj() == {"x": 1}
     else:
+        # instantiation should product `dict(x=1, _partial_=True)`
         assert obj == {"x": 1, "_partial_": True}
 
 

--- a/tests/test_compatibility/test_hydra_supports_partial.py
+++ b/tests/test_compatibility/test_hydra_supports_partial.py
@@ -10,7 +10,8 @@ from hydra_zen.structured_configs._implementations import (
     uses_zen_processing,
 )
 from hydra_zen.structured_configs._utils import get_obj_path
-from hydra_zen.typing import HydraPartialBuilds, PartialBuilds
+from hydra_zen.typing import PartialBuilds
+from hydra_zen.typing._implementations import HydraPartialBuilds
 
 
 @dataclass

--- a/tests/test_compatibility/test_omegaconf_830.py
+++ b/tests/test_compatibility/test_omegaconf_830.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2021 Massachusetts Institute of Technology
+# SPDX-License-Identifier: MIT
+
+from dataclasses import dataclass, field, is_dataclass
+from typing import Any
+
+import hypothesis.strategies as st
+import pytest
+from hypothesis import assume, given
+from omegaconf import MISSING, OmegaConf
+
+from hydra_zen import (
+    ZenField,
+    builds,
+    hydrated_dataclass,
+    instantiate,
+    make_config,
+    mutable_value,
+)
+from hydra_zen._compatibility import PATCH_OMEGACONF_830
+from hydra_zen.errors import HydraZenValidationError
+
+
+def test_PATCH_OMEGACONF_830_is_set_properly():
+    # test that PATCH_OMEGACONF_830 is True only if local version
+    # of omegaconf has known bug
+    assert isinstance(PATCH_OMEGACONF_830, bool)
+
+    @dataclass
+    class BasicConf:
+        setup: Any = 1
+
+    @dataclass
+    class Config(BasicConf):
+        setup: Any = field(default_factory=lambda: list(["hi"]))
+
+    conf = OmegaConf.structured(Config)
+    if PATCH_OMEGACONF_830:
+        assert conf.setup == 1
+    else:
+        # local version of omegaconf should have correct behavior
+        assert conf.setup == ["hi"]
+
+
+@dataclass
+class A_inheritance:
+    x: Any
+    y: Any = 1
+
+
+valid_defaults = (
+    st.none()
+    | st.booleans()
+    | st.text(alphabet="abcde")
+    | st.integers(-3, 3)
+    | st.lists(st.integers(-2, 2))
+    | st.fixed_dictionaries({"a": st.integers(-2, 2)})
+)
+
+
+def via_hydrated(x, Parent):
+    z = x if not isinstance(x, (list, dict)) else mutable_value(x)
+
+    @hydrated_dataclass(A_inheritance)
+    class Conf(Parent):
+        x: Any = z
+
+    return Conf
+
+
+def mutable_if_needed(x):
+    if isinstance(x, (dict, list)):
+        return mutable_value(x)
+    return x
+
+
+@pytest.mark.parametrize(
+    "config_maker",
+    [
+        lambda x, Parent: make_config(x=x, bases=(Parent,)),
+        lambda x, Parent: make_config(x=ZenField(Any, x), bases=(Parent,)),
+        lambda x, Parent: make_config(ZenField(Any, x, "x"), bases=(Parent,)),
+        lambda x, Parent: builds(A_inheritance, x=x, builds_bases=(Parent,)),
+        # TODO: add case where x is populated via pop-full-sig
+        # we currently support specifing fields-as-args in builds
+        lambda x, Parent: builds(
+            A_inheritance, x=mutable_if_needed(x), builds_bases=(Parent,)
+        ),
+        via_hydrated,
+    ],
+)
+@given(
+    parent_field_name=st.sampled_from(["x", "y"]),
+    parent_default=valid_defaults,
+    child_default=valid_defaults,
+)
+def test_known_inheritance_issues_in_omegaconf_are_circumvented(
+    parent_field_name, parent_default, child_default, config_maker
+):
+    # Exercises omegaconf bug documented in https://github.com/omry/omegaconf/issues/830
+    # Should pass either because:
+    #  - the test env is running a new version of omegaconf, which has patched this
+    #  - hydra-zen is providing a workaround
+    if PATCH_OMEGACONF_830 and config_maker is via_hydrated:
+        pytest.skip("hydrated_dataclass cannot support patched workaround")
+
+    assume(parent_field_name != "y" or parent_default is not MISSING)
+
+    Parent = make_config(**{parent_field_name: parent_default})
+    Child = config_maker(x=child_default, Parent=Parent)
+
+    if (
+        PATCH_OMEGACONF_830
+        and isinstance(child_default, (list, dict))
+        and not isinstance(parent_default, (list, dict))
+        and parent_field_name == "x"  # parent field overlaps
+    ):
+        # ensure we only case to dataclass when necessary
+        assert is_dataclass(Child.x)
+    else:
+        assert Child().x == child_default
+
+    Obj = instantiate(Child)
+    assert Obj.x == child_default
+
+    if parent_field_name == "y":
+        assert Obj.y == parent_default
+
+
+@pytest.mark.skipif(
+    not PATCH_OMEGACONF_830, reason="issue has been patched by omegaconf"
+)
+def test_hydrated_dataclass_raises_on_omegaconf_inheritance_issue():
+
+    Parent = make_config(x=1)
+
+    with pytest.raises(HydraZenValidationError):
+
+        @hydrated_dataclass(A_inheritance)
+        class Conf(Parent):
+            x: Any = mutable_value([1, 2])

--- a/tests/test_config_value_validation.py
+++ b/tests/test_config_value_validation.py
@@ -18,10 +18,10 @@ from hydra_zen import (
     make_config,
     to_yaml,
 )
+from hydra_zen._compatibility import ZEN_SUPPORTED_PRIMITIVES
 from hydra_zen.errors import HydraZenUnsupportedPrimitiveError
 from hydra_zen.structured_configs._implementations import HYDRA_SUPPORTED_PRIMITIVES
 from hydra_zen.structured_configs._utils import KNOWN_MUTABLE_TYPES
-from hydra_zen.structured_configs._value_conversion import ZEN_SUPPORTED_PRIMITIVES
 from tests import everything_except
 
 

--- a/tests/test_config_value_validation.py
+++ b/tests/test_config_value_validation.py
@@ -109,13 +109,11 @@ construction_fn_variations = [
 @example(unsupported={unsupported_instance: 1})
 @example(unsupported={1: unsupported_instance})
 @example(unsupported={unsupported_instance})
-@example(unsupported={unsupported_instance})
 @example(unsupported=unsupported_subclass)
 @example(unsupported=[unsupported_subclass])
 @example(unsupported=(unsupported_subclass,))
 @example(unsupported={unsupported_subclass: 1})
 @example(unsupported={1: unsupported_subclass})
-@example(unsupported={unsupported_subclass})
 @example(unsupported={unsupported_subclass})
 # Hydra doesn't support dataclass nodes for keys; ensure
 # hydra-zen doesn't provide enhanced primitive support for keys

--- a/tests/test_hydra_behaviors.py
+++ b/tests/test_hydra_behaviors.py
@@ -1,25 +1,16 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
-from dataclasses import dataclass, field, is_dataclass
+from dataclasses import dataclass
 from typing import Any, List, Tuple
 
 import hypothesis.strategies as st
 import pytest
-from hypothesis import assume, given
-from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
+from hypothesis import given
+from omegaconf import DictConfig, ListConfig
 from omegaconf.errors import ValidationError
 
-from hydra_zen import (
-    ZenField,
-    builds,
-    hydrated_dataclass,
-    instantiate,
-    make_config,
-    mutable_value,
-)
-from hydra_zen._compatibility import PATCH_OMEGACONF_830
-from hydra_zen.errors import HydraZenValidationError
+from hydra_zen import builds, hydrated_dataclass, instantiate, mutable_value
 from hydra_zen.structured_configs._utils import get_obj_path
 
 
@@ -211,102 +202,3 @@ def test_type_checking():
 
     # should be ok
     instantiate(builds(g2, x=[conf_C, conf_C]))
-
-
-@dataclass
-class A_inheritance:
-    x: Any
-    y: Any = 1
-
-
-valid_defaults = (
-    st.none()
-    | st.booleans()
-    | st.text(alphabet="abcde")
-    | st.integers(-3, 3)
-    | st.lists(st.integers(-2, 2))
-    | st.fixed_dictionaries({"a": st.integers(-2, 2)})
-)
-
-
-def via_hydrated(x, Parent):
-    z = x if not isinstance(x, (list, dict)) else mutable_value(x)
-
-    @hydrated_dataclass(A_inheritance)
-    class Conf(Parent):
-        x: Any = z
-
-    return Conf
-
-
-def mutable_if_needed(x):
-    if isinstance(x, (dict, list)):
-        return mutable_value(x)
-    return x
-
-
-@pytest.mark.parametrize(
-    "config_maker",
-    [
-        lambda x, Parent: make_config(x=x, bases=(Parent,)),
-        lambda x, Parent: make_config(x=ZenField(Any, x), bases=(Parent,)),
-        lambda x, Parent: make_config(ZenField(Any, x, "x"), bases=(Parent,)),
-        lambda x, Parent: builds(A_inheritance, x=x, builds_bases=(Parent,)),
-        # TODO: add case where x is populated via pop-full-sig
-        # we currently support specifing fields-as-args in builds
-        lambda x, Parent: builds(
-            A_inheritance, x=mutable_if_needed(x), builds_bases=(Parent,)
-        ),
-        via_hydrated,
-    ],
-)
-@given(
-    parent_field_name=st.sampled_from(["x", "y"]),
-    parent_default=valid_defaults,
-    child_default=valid_defaults,
-)
-def test_known_inheritance_issues_in_omegaconf_are_circumvented(
-    parent_field_name, parent_default, child_default, config_maker
-):
-    # Exercises omegaconf bug documented in https://github.com/omry/omegaconf/issues/830
-    # Should pass either because:
-    #  - the test env is running a new version of omegaconf, which has patched this
-    #  - hydra-zen is providing a workaround
-    if PATCH_OMEGACONF_830 and config_maker is via_hydrated:
-        pytest.skip("hydrated_dataclass cannot support patched workaround")
-
-    assume(parent_field_name != "y" or parent_default is not MISSING)
-
-    Parent = make_config(**{parent_field_name: parent_default})
-    Child = config_maker(x=child_default, Parent=Parent)
-
-    if (
-        PATCH_OMEGACONF_830
-        and isinstance(child_default, (list, dict))
-        and not isinstance(parent_default, (list, dict))
-        and parent_field_name == "x"  # parent field overlaps
-    ):
-        # ensure we only case to dataclass when necessary
-        assert is_dataclass(Child.x)
-    else:
-        assert Child().x == child_default
-
-    Obj = instantiate(Child)
-    assert Obj.x == child_default
-
-    if parent_field_name == "y":
-        assert Obj.y == parent_default
-
-
-@pytest.mark.skipif(
-    not PATCH_OMEGACONF_830, reason="issue has been patched by omegaconf"
-)
-def test_hydrated_dataclass_raises_on_omegaconf_inheritance_issue():
-
-    Parent = make_config(x=1)
-
-    with pytest.raises(HydraZenValidationError):
-
-        @hydrated_dataclass(A_inheritance)
-        class Conf(Parent):
-            x: Any = mutable_value([1, 2])

--- a/tests/test_hydra_behaviors.py
+++ b/tests/test_hydra_behaviors.py
@@ -213,27 +213,6 @@ def test_type_checking():
     instantiate(builds(g2, x=[conf_C, conf_C]))
 
 
-def test_PATCH_OMEGACONF_830_is_set_properly():
-    # test that PATCH_OMEGACONF_830 is True only if local version
-    # of omegaconf has known bug
-    assert isinstance(PATCH_OMEGACONF_830, bool)
-
-    @dataclass
-    class BasicConf:
-        setup: Any = 1
-
-    @dataclass
-    class Config(BasicConf):
-        setup: Any = field(default_factory=lambda: list(["hi"]))
-
-    conf = OmegaConf.structured(Config)
-    if PATCH_OMEGACONF_830:
-        assert conf.setup == 1
-    else:
-        # local version of omegaconf should have correct behavior
-        assert conf.setup == ["hi"]
-
-
 @dataclass
 class A_inheritance:
     x: Any

--- a/tests/test_hydra_behaviors.py
+++ b/tests/test_hydra_behaviors.py
@@ -18,8 +18,9 @@ from hydra_zen import (
     make_config,
     mutable_value,
 )
+from hydra_zen._compatibility import PATCH_OMEGACONF_830
 from hydra_zen.errors import HydraZenValidationError
-from hydra_zen.structured_configs._utils import PATCH_OMEGACONF_830, get_obj_path
+from hydra_zen.structured_configs._utils import get_obj_path
 
 
 def f_three_vars(x, y, z):

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -124,6 +124,7 @@ class NotZenPartial3:
         (just(int), True, True, False),
         (AJust, True, True, False),
         (builds(int, zen_partial=True), True, False, True),
+        (builds(int, zen_partial=True, zen_meta=dict(a=1)), True, False, True),
         (AZenPartial, True, False, True),
         (NotJust, True, False, False),
         (NotZenPartial, True, False, False),

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from hydra_zen import builds, instantiate, just
+from hydra_zen import builds, instantiate, just, make_custom_builds_fn
 from hydra_zen.funcs import get_obj, zen_processing
 from hydra_zen.structured_configs._implementations import (
     is_builds,
@@ -33,7 +33,7 @@ def test_runtime_checkability_of_protocols(fn, protocol):
     assert isinstance(conf, protocol)
 
 
-def test_Builds_is_not_PartialBuilds():
+def test_Builds_is_not_ZenPartialBuilds():
     Conf = builds(dict)
     assert not isinstance(Conf, PartialBuilds)
 
@@ -60,7 +60,10 @@ def test_targeted_dataclass_is_Builds():
     "fn,protocol",
     [
         (just, Just),
-        (partial(builds, zen_partial=True), PartialBuilds),
+        (
+            make_custom_builds_fn(zen_partial=True, zen_meta=dict(_y=None)),
+            PartialBuilds,
+        ),
     ],
 )
 def test_protocol_target_is_correct(fn, protocol):
@@ -79,7 +82,7 @@ class AJust:
 
 
 @dataclass
-class APartial:
+class AZenPartial:
     _target_: Any = zen_processing
     _zen_target: Any = "builtins.int"
     _zen_partial: bool = True
@@ -92,21 +95,21 @@ class NotJust:
 
 
 @dataclass
-class NotPartial:
+class NotZenPartial:
     _target_: Any = "builtins.dict"  # wrong target
     _zen_target: Any = "builtins.int"
     _zen_partial: bool = True
 
 
 @dataclass
-class NotPartial2:
+class NotZenPartial2:
     _target_: Any = "builtins.dict"
     # MISSING _zen_target
     _zen_partial: bool = True
 
 
 @dataclass
-class NotPartial3:
+class NotZenPartial3:
     # partial is False
     _target_: Any = zen_processing
     _zen_target: Any = "builtins.int"
@@ -121,11 +124,11 @@ class NotPartial3:
         (just(int), True, True, False),
         (AJust, True, True, False),
         (builds(int, zen_partial=True), True, False, True),
-        (APartial, True, False, True),
+        (AZenPartial, True, False, True),
         (NotJust, True, False, False),
-        (NotPartial, True, False, False),
-        (NotPartial2, True, False, False),
-        (NotPartial3, True, False, False),
+        (NotZenPartial, True, False, False),
+        (NotZenPartial2, True, False, False),
+        (NotZenPartial3, True, False, False),
     ],
 )
 def test_protocol_checkers(x, yes_builds, yes_just, yes_partial):

--- a/tests/test_roundtrips.py
+++ b/tests/test_roundtrips.py
@@ -174,6 +174,7 @@ def test_just_roundtrip(obj):
         just,
         lambda x: builds(x, zen_partial=True),
         lambda x: builds(x, zen_meta=dict(_some_obscure_name=1)),
+        lambda x: builds(x, zen_partial=True, zen_meta=dict(_some_obscure_name=1)),
     ],
 )
 def test_get_target_roundtrip(x, fn):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,6 +112,7 @@ NoneType = type(None)
         (bool, bool),
         (Color, Color),
         (C, Any),  # unsupported primitives
+        (type(None), Any),
         (set, Any),
         (list, Any),
         (tuple, Any),

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -11,10 +11,8 @@ from hypothesis import HealthCheck, assume, given, settings
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from hydra_zen import builds, instantiate, make_config, to_yaml
-from hydra_zen.structured_configs._value_conversion import (
-    ZEN_SUPPORTED_PRIMITIVES,
-    ZEN_VALUE_CONVERSION,
-)
+from hydra_zen._compatibility import ZEN_SUPPORTED_PRIMITIVES
+from hydra_zen.structured_configs._value_conversion import ZEN_VALUE_CONVERSION
 
 
 def test_supported_primitives_in_sync_with_value_conversion():


### PR DESCRIPTION
Closes #183 (I am tracking https://github.com/omry/omegaconf/issues/846 and https://github.com/facebookresearch/hydra/issues/1112 to begin testing new features in nightly builds)
Closes #182 

This PR:
- Reorganizes some of our internal utilities and tests to make it easier for us to adaptively support new features provided by OmegaConf/Hydra.
    - Version-specific flags are now set in `hydra_zen._compatibility`. E.g. `HYDRA_SUPPORTS_PARTIAL` indicates whether a user's local install of Hydra is recent enough to support the `_partial_` API.
    - The primitive types supported by Hydra and hydra-zen, respectively, are now specified in `hydra_zen._compatibility`. This will enable us to accommodate #181 and future changes to Hydra's supported primitives.
    - A shortcoming here is that the types in `hydra_zen.typing` cannot be set dynamically based on version. This becomes an issue if Hydra adds support a primitive that, for some reason, hydra-zen is unable to provide backwards-compatible support for. In such a case, we will likely have `hydra_zen.typing` support the latest types, which would mean that we would tolerate false-negatives in static type checking rather than false-positives.
- Adds support for `_partial_` via Hydra's instantiate API, which will be made  available in Hydra `1.2.0`
    - Defines a new protocol: `hydra_zen.typing._implementations.HydraPartialBuilds` (see below for issues with this). Note that this is not yet part of the public API for `hydra_zen.typing`.


## Supporting for `_partial_` from Hydra's instantiate API

For versions of Hydra prior to `1.2.0`, `builds(<target>, zen_partial=True)` effectively produces the following (simplified) dataclass:

```python
@dataclass
class ZenPartialConfig:
    _target_: str = "hydra_zen.funcs.zen_processing"
    _zen_target: str = <path-to-target>
    _zen_partial: bool = True
    ...
```

See that we leverage `hydra_zen.funcs.zen_processing` to handle the application of `functools.partial` here. 

For Hydra `1.2.0` and beyond, specifying `builds(<target>, zen_partial=True)` - **with no other zen-features (e.g. no meta-field or wrappers) included** - effectively produces the following dataclass:

```python
@dataclass
class HydraPartialConfig:
    _target_: str = <path-to-target>
    _partial_: bool = True
    ...
```

Note that if any zen-processing features (e.g. meta-fields) are specified in alongside `zen_partial=True`, then we will defer to a `ZenPartialConfig`-style dataclass. This ensures that the resulting partial'd object (post-instantiation) always points to the actual target via its `.func` attribute:

```python
# the desired behavior
>>> instantiate(builds(dict, zen_partial=True, zen_meta=dict(_y=2)))
partial(dict)
```

If we always relied on Hydra's `_partial_` mechanism, then including other zen-processing features would result in `hydra_zen.funcs.zen_processing` being the target of the partial:

```python
# the behavior we are avoiding
>>> instantiate(builds(dict, zen_partial=True, zen_meta=dict(_y=2)))
partial(hydra_zen.funcs.zen_processing, _target_="builtins.dict", _zen_exclude=('_y',))
```
Finalizing this partial would produce the correct dictionary, but this intermediary state is still something we want to avoid.

### Hitting a snag with our protocols

There is an issue here. The protocol `PartialBuilds` is:

```python
class PartialBuilds(Builds, Protocol[_T]):  # pragma: no cover
    _target_: str = "hydra_zen.funcs.zen_processing"
    _zen_target: str
    _zen_partial: bool = True
```

which reflects the structure of `ZenPartialConfig`, but  does not describe `HydraPartialConfig`; its protocol should be:

```python
class HydraPartialBuilds(Builds, Protocol[_T]):  # pragma: no cover
    _partial_: bool = True
```

which does not accurately reflect `ZenPartialConfig`.

Thus the issue is that, presently, `builds(zen_partial=True)` only emits `PartialBuilds`. I can revise its overloads so that it emits `HydraPartialBuilds` in the exact case of `zen_partial=True, zen_meta=None, zen_wrappers=()`, but this annotation is only accurate if the user has `Hydra >= 1.2.0` installed. And we cannot dynamically set overloads based on the installed version.

The solution that I am currently favor is: our type-annotations will reflect the behaviors of the latest versions of Hydra / OmegaConf. I.e. once Hydra `1.2.0` is released, we will update our overloads on `builds` as I described in the previous paragraph. Users who rely on specific implementation details of our protocols, and who want to use the latest version of hydra-zen, will simply have to update to the latest version of `1.2.0`. For most users, they won't notice any difference at all.

What I would *really* like to do is define `ZenPartialBuilds` and `HydraPartialBuilds`, and make `PartialBuilds` their union:

```python
class ZenPartialBuilds(Builds, Protocol[_T]):  # pragma: no cover
    _target_: str = "hydra_zen.funcs.zen_processing"
    _zen_target: str
    _zen_partial: bool = True

class HydraPartialBuilds(Builds, Protocol[_T]):  # pragma: no cover
    _partial_: bool = True

PartialBuilds = HydraPartialBuilds | ZenPartialBuilds
```

but the issue with this is that `PartialBuilds` would no longer be a generic. I.e. you could not write `PartialBuilds[int]`.

I don't think there is a perfect solution here, even if we do adopt the progressive stance of "our annotations assume you have the most recent dependencies installed". Fortunately, we don't need a solution right away, but it should be made clear that our support for `_partial_` is not finished, from the perspective of static typing.

## Feedback

The main feedback that could be useful here is our planned support for `_partial_`. Does the implementation here, and the above description, make sense? Are there any potential hiccups that I might not be foreseeing?