### PR TITLE
Improve signature parsing in `builds`

### DIFF
--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1299,6 +1299,18 @@ def builds(
 
     try:
         signature_params = inspect.signature(target).parameters
+
+        # dealing with this bug: https://bugs.python.org/issue40897
+        if (
+            len(signature_params) == 2
+            and inspect.isclass(target)
+            and hasattr(type, "__init__")
+            and {p.kind for p in signature_params.values()}
+            == {_VAR_POSITIONAL, _VAR_KEYWORD}
+        ):
+            signature_params = dict(inspect.signature(target.__init__).parameters)
+            signature_params.pop("self", None)
+
         target_has_valid_signature: bool = True
     except ValueError:
         if populate_full_signature:

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1387,7 +1387,7 @@ def builds(
                 "__new__" in parent.__dict__ for parent in target.__mro__[1:-1]
             ):
                 _annotation_target = target.__new__
-            else:  # pragam: no cover
+            else:
                 _annotation_target = target.__init__
         else:
             _annotation_target = target
@@ -1398,10 +1398,11 @@ def builds(
         # We don't need to pop self/class because we only make on-demand
         # requests from `type_hints`
 
-    except (TypeError, NameError, AttributeError):
-        # TypeError: Covers case for ufuncs, which do not have inspectable type hints
-        # NameError: Covers case for unresolved forward reference
-        # AttributeError: Class doesn't have "__new__" or "__init__"
+    except (
+        TypeError,  # ufuncs, which do not have inspectable type hints
+        NameError,  # Unresolvable forward reference
+        AttributeError,  # Class doesn't have "__new__" or "__init__"
+    ):
         type_hints = defaultdict(lambda: Any)
 
     sig_by_kind: Dict[Any, List[inspect.Parameter]] = {

--- a/tests/test_roundtrips.py
+++ b/tests/test_roundtrips.py
@@ -9,6 +9,7 @@ import random
 import re
 import statistics
 import string
+from collections import Counter, defaultdict, deque
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
@@ -147,6 +148,9 @@ a_bunch_of_objects = [
     operator.add,
     statistics.mean,
     os.getcwd,
+    Counter,
+    deque,
+    defaultdict,
 ]
 
 

--- a/tests/test_signature_parsing.py
+++ b/tests/test_signature_parsing.py
@@ -505,7 +505,7 @@ def test_Counter():
     assert instantiate(builds(Counter, [1, 1, 2, 1])) == Counter([1, 1, 2, 1])
     assert instantiate(builds(Counter, a=1, b=2)) == Counter(a=1, b=2)
 
-    if sys.version_info > (3, 7):
+    if sys.version_info > (3, 8):
         with pytest.raises(TypeError):
             # signature: Counter(iterable=None, /, **kwds)
             builds(Counter, [1], [2])

--- a/tests/test_signature_parsing.py
+++ b/tests/test_signature_parsing.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2021 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
-
 import inspect
+import sys
 from abc import ABC
+from collections import Counter
 from dataclasses import dataclass
 from enum import Enum
 from inspect import Parameter
@@ -495,3 +496,16 @@ def test_parse_sig_with_new_vs_init(Obj):
     )
 
     assert sig_via_builds == Obj.py_310_sig
+
+
+def test_Counter():
+    # Counter has an interesting signature
+    # Python 3.7: (*args, **kwds)                   -- no self!
+    #      >=3.8: (self, iterable=None, /, **kwds)  -- pos-only
+    assert instantiate(builds(Counter, [1, 1, 2, 1])) == Counter([1, 1, 2, 1])
+    assert instantiate(builds(Counter, a=1, b=2)) == Counter(a=1, b=2)
+
+    if sys.version_info > (3, 7):
+        with pytest.raises(TypeError):
+            # signature: Counter(iterable=None, /, **kwds)
+            builds(Counter, [1], [2])

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -106,3 +106,13 @@ def test_value_supported_via_config_maker_functions(
             pass
         else:
             assert conf["a"] == value
+
+
+@given(x=st.lists(st.integers(-2, 2)))
+def test_Counter_roundtrip(x):
+    counter = Counter(x)
+    BuildsConf = builds(dict, counter=counter)
+
+    out_counter = instantiate(OmegaConf.structured(to_yaml(BuildsConf)))["counter"]
+
+    assert counter == out_counter

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -75,19 +75,7 @@ def test_value_supported_via_config_maker_functions(
     zen_supported_type, data: st.DataObject, as_builds: bool, via_yaml: bool
 ):
     if zen_supported_type is str:
-        value = data.draw(st.text(alphabet=string.printable))
-        # don't permit bytes: https://github.com/omry/omegaconf/pull/845
-        # or missing values
-        assume(not value.startswith(('b"', "b'")) and value != "???")
-
-        # don't permit strings that can be parsed as floats
-        try:
-            float(value)
-        except ValueError:
-            pass
-        else:
-            assume(False)
-            return
+        value = data.draw(st.text(alphabet=string.ascii_letters))
     else:
         value = data.draw(st.from_type(zen_supported_type))
 


### PR DESCRIPTION
This PR provides two significant improvements to the ability of `hydra_zen.builds` to parse a target's signature:

### 1. `builds` will now inspect `target.__new__` for annotations (when appropriate)

Previously, `builds(<target>, ...)` did not look at `target.__new__` for annotations, even if that is where the signature was derived from. This has been fixed. Consider the following:

```python
from hydra_zen import make_custom_builds_fn

import inspect

builds = make_custom_builds_fn(populate_full_signature=True)

class A:
    def __new__(cls, a: int, b: bool):
        ...
```
```python
>>> inspect.signature(A)
<Signature (a: int, b: bool)>
```

Before:

```python
# note that the annotations are incorrect
>>> inspect.signature(builds(A))
<Signature (a: Any, b: Any) -> None>
```

After:

```python
>>> inspect.signature(builds(A))
<Signature (a: int, b: bool) -> None>
```

### 2. We provide a downstream fix for a bug in `inspect.signature` that obfuscated some class signatures

There is [a bug in `inspect.signature` for Python < 3.9.1](https://bugs.python.org/issue40897) where `__new__` is over-prioritized for resolving a type's signature:

```python
# demonstrating bug in `inspect.signature`

class A:
    def __new__(cls, a=1, *args, **kwargs):
        return object.__new__(cls)

class B(A):
    def __init__(self, b):
        pass

import inspect
print(inspect.signature(B))

The above example prints "(a=1, *args, **kwargs)" instead of "(b)".
``` 

Because `builds` relies on `inspect.signature` under the hood, this can inhibit `builds` from parsing a target's signature, which limits its ability to accurately auto-populate and validate parameters. A common case where this occurs is when a class inherits from `typing.Generic`, which causes signatures to appear as `(*args, **kwds)`; e.g. this occurs for PyTorch's `torch.nn.utils.data.DataLoader`:

```python
# signature of DataLoader is obfuscated by bug in `inspect.signature`
>>> inspect.signature(torch.utils.data.DataLoader)
<Signature (*args, **kwds)>
```

this PR provides a downstream fix for all versions of Python supported by hydra-zen; `builds` now detects the above edge-case and circumvents it appropriately.

Before:

```python
>>> builds = make_custom_builds_fn(populate_full_signature=True)
>>> Conf = builds(tr.utils.data.DataLoader)
>>> inspect.signature(Conf)
<Signature () -> None>
```

After:

```python
>>> builds = make_custom_builds_fn(populate_full_signature=True)
>>> Conf = builds(tr.utils.data.DataLoader)
>>> inspect.signature(Conf)
<Signature (dataset: Any, batch_size: Union[int, NoneType] = 1, shuffle: bool = False, sampler: Any = None, batch_sampler: Any = None, num_workers: int = 0, collate_fn: Any = None, pin_memory: bool = False, drop_last: bool = False, timeout: float = 0, worker_init_fn: Any = None, multiprocessing_context: Any = None, generator: Any = None, prefetch_factor: int = 2, persistent_workers: bool = False) -> None>
```

this will significantly improve the experience of reproducibility (i.e. more-detailed YAML summaries of one's run) and improved runtime validation provided by `builds` in cases where this bug was manifesting.