### PR TITLE
Support partial'd object as configured value

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -148,6 +148,7 @@ hydra-zen provides such support for values of the following types:
 - :py:class:`complex`
 - :py:class:`collections.Counter`
 - :py:class:`collections.deque`
+- :py:func:`functools.partial`  (*added in v0.5.0*)
 - :py:class:`pathlib.Path`
 - :py:class:`pathlib.PosixPath`
 - :py:class:`pathlib.WindowsPath`

--- a/src/hydra_zen/_compatibility.py
+++ b/src/hydra_zen/_compatibility.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 from collections import Counter, deque
 from enum import Enum
+from functools import partial
 from pathlib import Path, PosixPath, WindowsPath
 from typing import NamedTuple, Optional, Set
 
@@ -54,6 +55,7 @@ ZEN_SUPPORTED_PRIMITIVES: Set[type] = {
     set,
     frozenset,
     complex,
+    partial,
     Path,
     PosixPath,
     WindowsPath,

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -14,6 +14,7 @@ from typing import (
     NewType,
     Sequence,
     Tuple,
+    Type,
     TypeVar,
     Union,
 )
@@ -36,19 +37,22 @@ class EmptyDict(TypedDict):
 
 
 _T = TypeVar("_T", covariant=True)
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
 
 
-class Partial(Generic[_T]):
-    func: Callable[..., _T]
+@runtime_checkable
+class Partial(Protocol[T2]):
+    func: Callable[..., T2]
     args: Tuple[Any, ...]
     keywords: Dict[str, Any]
 
-    def __init__(
-        self, func: Callable[..., _T], *args: Any, **kwargs: Any
-    ) -> None:  # pragma: no cover
+    def __new__(
+        cls: Type[T3], func: Callable[..., T2], *args: Any, **kwargs: Any
+    ) -> T3:  # pragma: no cover
         ...
 
-    def __call__(self, *args: Any, **kwargs: Any) -> _T:  # pragma: no cover
+    def __call__(self, *args: Any, **kwargs: Any) -> T2:  # pragma: no cover
         ...
 
 

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -4,6 +4,7 @@
 from collections import Counter, deque
 from dataclasses import dataclass
 from enum import Enum
+from functools import partial
 from pathlib import Path
 from typing import Callable, List, Literal, Tuple, Type, TypeVar
 
@@ -19,7 +20,7 @@ from hydra_zen import (
     make_custom_builds_fn,
     mutable_value,
 )
-from hydra_zen.typing import Builds
+from hydra_zen.typing import Builds, Partial
 from hydra_zen.typing._implementations import HydraPartialBuilds
 
 T = TypeVar("T")
@@ -350,3 +351,9 @@ def make_hydra_partial(x: T) -> HydraPartialBuilds[Type[T]]:
 def check_HydraPartialBuilds():
     cfg = make_hydra_partial(int)
     a: Literal["Partial[int]"] = reveal_type(instantiate(cfg))
+
+
+def check_partial_protocol():
+    x: Partial[int]
+    x = partial(int)
+    # x = partial(str)  # should fail

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -14,7 +14,7 @@ from hydra_zen.structured_configs._implementations import (
     is_just,
     is_partial_builds,
 )
-from hydra_zen.typing import Builds, Just, PartialBuilds
+from hydra_zen.typing import Builds, Just, Partial, PartialBuilds
 
 
 @pytest.mark.parametrize(
@@ -139,3 +139,8 @@ def test_protocol_checkers(x, yes_builds, yes_just, yes_partial):
 
     if yes_builds or yes_just or yes_partial:
         instantiate(x)
+
+
+def test_partial_protocol():
+    assert isinstance(partial(int), Partial)
+    assert not isinstance(print, Partial)

--- a/tests/test_value_conversion.py
+++ b/tests/test_value_conversion.py
@@ -14,6 +14,7 @@ from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from hydra_zen import builds, instantiate, make_config, to_yaml
 from hydra_zen._compatibility import ZEN_SUPPORTED_PRIMITIVES
+from hydra_zen.errors import HydraZenValidationError
 from hydra_zen.structured_configs._value_conversion import ZEN_VALUE_CONVERSION
 
 
@@ -137,7 +138,9 @@ def f2(*args, **kwargs):
     as_builds=st.booleans(),
     via_yaml=st.booleans(),
 )
-def test_functools_partial(target, args, kwargs, as_builds: bool, via_yaml: bool):
+def test_functools_partial_as_configured_value(
+    target, args, kwargs, as_builds: bool, via_yaml: bool
+):
     partiald_obj = partial(target, *args, **kwargs)
     Conf = (
         make_config(field=partiald_obj)
@@ -154,3 +157,14 @@ def test_functools_partial(target, args, kwargs, as_builds: bool, via_yaml: bool
     assert out.func is target
     assert out.args == args
     assert out.keywords == kwargs
+
+
+def f3(z):
+    return
+
+
+def test_functools_partial_gets_validated():
+    make_config(x=partial(f3, z=2))  # OK
+
+    with pytest.raises(TypeError):
+        make_config(x=partial(f3, y=2))  # no param named `y`


### PR DESCRIPTION
Partially addresses #197 

Now users can directly specify a "partial'd" object -- i.e. an object produced by `functools.partial(...)` -- directly as a configured value in `make_config` and `builds`. 

Consider the following.

```python
from hydra_zen import make_config, instantiate
from functools import partial

def f(x, y): 
    return (x, y)
```
Before

```python
>>> make_config(v=partial(f, x=1))
HydraZenUnsupportedPrimitiveError: ...
```

After:

```python
>>> Conf = make_config(v=partial(f, x=1))
>>> instantiate(Conf)
>>> {'v': functools.partial(<function f at 0x0000015924B6A700>, x=1)}
```

### Implementation Details

Under the hood, `make_config` and `builds` will identify `partial`-type configured values and "unpack" them, so that we can use `builds(..., zen_partial=True)` to create a valid targeted config that describes the same object.

The unpacking is simple:

```python
def _unpack_partial(value: Partial[_T]) -> Type[PartialBuilds[Type[_T]]]:
    target = cast(Type[_T], value.func)
    return builds(target, *value.args, **value.keywords, zen_partial=True)
```

### Some Additional Changes
`hydra_zen.typing.Partial` is updated to be made a protocol, rather than a generic type. Also, its definition was modified to more closely match the implementation of `functools.partial`. We now have tests to check that runtime and static checks using the protocol are OK.