### PR TITLE
improve type annotation for builds -- target must be callable

### DIFF
--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -9,7 +9,6 @@ from typing import (
     Callable,
     Dict,
     FrozenSet,
-    Generic,
     Mapping,
     NewType,
     Sequence,
@@ -57,8 +56,6 @@ class Partial(Protocol[T2]):
 
 
 InterpStr = NewType("InterpStr", str)
-
-Importable = TypeVar("Importable")
 
 
 class _DataClass(Protocol):  # pragma: no cover
@@ -109,6 +106,8 @@ class HasTarget(Protocol):  # pragma: no cover
 class HasPartialTarget(Protocol):  # pragma: no cover
     _zen_partial: bool = True
 
+
+Importable = TypeVar("Importable", bound=Callable)
 
 _HydraPrimitive = Union[
     bool,

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -357,3 +357,14 @@ def check_partial_protocol():
     x: Partial[int]
     x = partial(int)
     # x = partial(str)  # should fail
+
+
+def check_target_annotation():
+    builds(int)
+    builds(print)
+    builds(partial(int))
+
+    # should fail:
+    builds()
+    builds(1)
+    builds(None)

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -365,6 +365,6 @@ def check_target_annotation():
     builds(partial(int))
 
     # should fail:
-    builds()
-    builds(1)
-    builds(None)
+    # builds()
+    # builds(1)
+    # builds(None)


### PR DESCRIPTION
Before:

```python
builds(1)  # OK to static type-checkers
```

After:

```python
builds(1)  # marked as invalid by static type-checkers
```
