### PR TITLE
Add contrapositive pyright tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,7 +41,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install pyright
-      run: sudo npm install -g pyright@"==1.1.211"
+      run: sudo npm install -g pyright@">1.1.212"
     - uses: actions/checkout@v1
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -159,7 +159,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install pyright
-      run: sudo npm install -g pyright@"==1.1.211"
+      run: sudo npm install -g pyright@"=>1.1.212"
     - uses: actions/checkout@v1
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -159,7 +159,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install pyright
-      run: sudo npm install -g pyright@"=>1.1.212"
+      run: sudo npm install -g pyright@">1.1.212"
     - uses: actions/checkout@v1
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -8,4 +8,5 @@
         "src/hydra_zen/_version.py",
         "**/third_party",
     ],
+    "reportUnnecessaryTypeIgnoreComment": true,
 }

--- a/src/hydra_zen/funcs.py
+++ b/src/hydra_zen/funcs.py
@@ -58,7 +58,7 @@ def zen_processing(
     if isinstance(_zen_wrappers, str) or not isinstance(
         _zen_wrappers, _typing.Sequence
     ):
-        unresolved_wrappers: _typing.Sequence[_WrapperConf] = (_zen_wrappers,)  # type: ignore
+        unresolved_wrappers: _typing.Sequence[_WrapperConf] = (_zen_wrappers,)
     else:
         unresolved_wrappers: _typing.Sequence[_WrapperConf] = _zen_wrappers
     del _zen_wrappers

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -584,7 +584,7 @@ def _is_ufunc(value) -> bool:
         # we do actually cover this branch some runs of our CI,
         # but our coverage job installs numpy
         return False
-    return isinstance(value, numpy.ufunc)  # type: ignore
+    return isinstance(value, numpy.ufunc)
 
 
 def sanitized_default_value(

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -364,7 +364,7 @@ def sanitized_type(
             # for some pytorch-lightning classes. So we just do it ourselves...
             # It might be worth removing this later since none of our standard tests
             # cover it.
-            type_ = Optional[type_]  # type: ignore
+            type_ = Optional[type_]
         return type_
 
     # Needed to cover python 3.6 where __origin__ doesn't normalize to type


### PR DESCRIPTION
We can now check that pyright sees particular invocations of our code as "erroneous". E.g., we can now verify that a line like

```python
builds(1)
```

will be marked as an error by static type checkers. This is achieved by configuring pyright to raise whenever `# type: ignore` is used unnecessarily. Thus we can write

```python
builds(1)  # type: ignore
```

that pyright then runs without issue thus indicates that it indeed did suppress an error on that line. 

We also unpin pyright, specifying 1.1.213 as the new minimum version.