### PR TITLE
Improves our protocols

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ extensions = [
     "numpydoc",
     "sphinx_copybutton",
     "sphinx_tabs.tabs",
-    # "sphinx_codeautolink",
+    "sphinx_codeautolink",
 ]
 
 # Strip input prompts:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ extensions = [
     "numpydoc",
     "sphinx_copybutton",
     "sphinx_tabs.tabs",
-    "sphinx_codeautolink",
+    # "sphinx_codeautolink",
 ]
 
 # Strip input prompts:

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -62,12 +62,7 @@ from hydra_zen.typing import (
     PartialBuilds,
     SupportedPrimitive,
 )
-from hydra_zen.typing._implementations import (
-    DataClass,
-    HasPartialTarget,
-    HasTarget,
-    _DataClass,
-)
+from hydra_zen.typing._implementations import DataClass, HasTarget, _DataClass
 
 from ._value_conversion import ZEN_VALUE_CONVERSION
 
@@ -1771,11 +1766,11 @@ def get_target(obj: Union[Builds[_T], Type[Builds[_T]]]) -> _T:  # pragma: no co
 
 
 @overload
-def get_target(obj: Union[HasTarget, HasPartialTarget]) -> Any:  # pragma: no cover
+def get_target(obj: HasTarget) -> Any:  # pragma: no cover
     ...
 
 
-def get_target(obj: Union[HasTarget, HasPartialTarget]) -> Any:
+def get_target(obj):
     """
     Returns the target-object from a targeted config.
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -47,11 +47,7 @@ from hydra_zen._compatibility import (
     PATCH_OMEGACONF_830,
     ZEN_SUPPORTED_PRIMITIVES,
 )
-from hydra_zen.errors import (
-    HydraZenDeprecationWarning,
-    HydraZenUnsupportedPrimitiveError,
-    HydraZenValidationError,
-)
+from hydra_zen.errors import HydraZenUnsupportedPrimitiveError, HydraZenValidationError
 from hydra_zen.funcs import get_obj, partial, zen_processing
 from hydra_zen.structured_configs import _utils
 from hydra_zen.typing import (

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import (
     Any,
     Callable,
+    ClassVar,
     Dict,
     FrozenSet,
     Mapping,
@@ -19,7 +20,7 @@ from typing import (
 )
 
 from omegaconf import DictConfig, ListConfig
-from typing_extensions import Protocol, TypedDict, runtime_checkable
+from typing_extensions import Literal, Protocol, TypedDict, runtime_checkable
 
 __all__ = [
     "Just",
@@ -60,7 +61,7 @@ InterpStr = NewType("InterpStr", str)
 
 class _DataClass(Protocol):  # pragma: no cover
     # doesn't provide __init__, __getattribute__, etc.
-    __dataclass_fields__: Dict[str, Field]
+    __dataclass_fields__: ClassVar[Dict[str, Field]]
 
 
 class DataClass(_DataClass, Protocol):  # pragma: no cover
@@ -76,25 +77,27 @@ class DataClass(_DataClass, Protocol):  # pragma: no cover
 
 @runtime_checkable
 class Builds(DataClass, Protocol[_T]):  # pragma: no cover
-    _target_: str
+    _target_: ClassVar[str]
 
 
 @runtime_checkable
 class Just(Builds, Protocol[_T]):  # pragma: no cover
-    path: str  # interpolated string for importing obj
-    _target_: str = "hydra_zen.funcs.get_obj"
+    path: ClassVar[str]  # interpolated string for importing obj
+    _target_: ClassVar[Literal["hydra_zen.funcs.get_obj"]] = "hydra_zen.funcs.get_obj"
 
 
 @runtime_checkable
 class PartialBuilds(Builds, Protocol[_T]):  # pragma: no cover
-    _target_: str = "hydra_zen.funcs.zen_processing"
-    _zen_target: str
-    _zen_partial: bool = True
+    _target_: ClassVar[
+        Literal["hydra_zen.funcs.zen_processing"]
+    ] = "hydra_zen.funcs.zen_processing"
+    _zen_target: ClassVar[str]
+    _zen_partial: ClassVar[Literal[True]] = True
 
 
 @runtime_checkable
 class HydraPartialBuilds(Builds, Protocol[_T]):  # pragma: no cover
-    _partial_: bool = True
+    _partial_: ClassVar[bool] = True
 
 
 @runtime_checkable

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -97,17 +97,12 @@ class PartialBuilds(Builds, Protocol[_T]):  # pragma: no cover
 
 @runtime_checkable
 class HydraPartialBuilds(Builds, Protocol[_T]):  # pragma: no cover
-    _partial_: ClassVar[bool] = True
+    _partial_: ClassVar[Literal[True]] = True
 
 
 @runtime_checkable
 class HasTarget(Protocol):  # pragma: no cover
     _target_: str
-
-
-@runtime_checkable
-class HasPartialTarget(Protocol):  # pragma: no cover
-    _zen_partial: bool = True
 
 
 Importable = TypeVar("Importable", bound=Callable)

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -409,3 +409,26 @@ def check_target_annotation():
     builds()  # type: ignore
     builds(1)  # type: ignore
     builds(None)  # type: ignore
+
+
+def check_protocols():
+    reveal_type(builds(int)._target_, expected_text="str")
+    reveal_type(builds(int)()._target_, expected_text="str")
+
+    PBuilds = builds(int, zen_partial=True)
+    reveal_type(
+        PBuilds._target_, expected_text="Literal['hydra_zen.funcs.zen_processing']"
+    )
+    reveal_type(
+        PBuilds()._target_, expected_text="Literal['hydra_zen.funcs.zen_processing']"
+    )
+
+    reveal_type(PBuilds._zen_target, expected_text="str")
+    reveal_type(PBuilds()._zen_target, expected_text="str")
+
+    reveal_type(PBuilds._zen_partial, expected_text="Literal[True]")
+    reveal_type(PBuilds()._zen_partial, expected_text="Literal[True]")
+
+    Just = just(int)
+    reveal_type(Just._target_, expected_text="Literal['hydra_zen.funcs.get_obj']")
+    reveal_type(Just()._target_, expected_text="Literal['hydra_zen.funcs.get_obj']")


### PR DESCRIPTION
Our protocols: `Builds`, `PartialBuilds`, and `Just` failed to mark their class variables with [`ClassVar`](https://docs.python.org/3/library/typing.html#typing.ClassVar). This has been fixed. This also removes `HasPartialTarget` which wasn't used in any meaningful way.

Before:

```python
builds(int)._target_  # pyright `error:` Builds does not define _target_ as a ClassVar
```

After:

```python
builds(int)._target_  # OK, reveals type str
```

Additionally, some of the annotations for these attributes were made to be more precise. E.g. `PartialBuilds._zen_partial` can only be `True` in order to carry the downstream behavior of `PartialBuilds` as opposed to `Builds`. Thus its annotation has been revised from `bool` to `Literal[True]`.