### PR TITLE
Test that type-widening for interp field is necessary

### DIFF
--- a/tests/test_signature_parsing.py
+++ b/tests/test_signature_parsing.py
@@ -415,6 +415,15 @@ def test_type_widening_with_internal_conversion_to_Builds():
     instantiate(Conf)  # shouldn't raise
 
 
+def test_type_widening_for_interpolated_field_is_needed():
+    @dataclass
+    class Config:
+        x: str = "${A}"
+
+    with pytest.raises(ValidationError):
+        instantiate(Config, x=builds(str))
+
+
 def test_type_widening_for_interpolated_field():
     C1 = make_config(x=ZenField(str, "A"))
     assert get_type_hints(C1)["x"] is str


### PR DESCRIPTION
This test ensures that the type-widening that we introduced in #207 is actually necessary - it will fail if OmegaConf/Hydra changes its validation to accommodate this case, and thus it will indicate that the widening can be removed. 