### PR TITLE
Implements prototype of hydra_zen.like

### DIFF
--- a/src/hydra_zen/__init__.py
+++ b/src/hydra_zen/__init__.py
@@ -9,6 +9,7 @@ from ._hydra_overloads import (
     to_yaml,
 )
 from ._launch import launch
+from ._like import like
 from ._version import get_versions
 from .structured_configs import (
     ZenField,
@@ -36,6 +37,7 @@ __all__ = [
     "ZenField",
     "make_custom_builds_fn",
     "launch",
+    "like",
 ]
 
 __version__ = get_versions()["version"]

--- a/src/hydra_zen/_like.py
+++ b/src/hydra_zen/_like.py
@@ -1,0 +1,41 @@
+from typing import TypeVar, cast
+
+T = TypeVar("T")
+
+
+class _Tracker:
+    def __init__(self, origin, tracks=None):
+        self.origin = origin
+
+        self.tracker = [] if tracks is None else tracks.copy()
+
+    def __repr__(self) -> str:
+        base = f"Like({repr(self.origin)})"
+        for item in self.tracker:
+            if isinstance(item, tuple):
+                _, args, kwargs = item
+                contents = ""
+                if args:
+                    contents += ", ".join(repr(x) for x in args)
+                if kwargs:
+                    if args:
+                        contents += ", "
+                    contents += ", ".join((f"{k}={v}" for k, v in kwargs.items()))
+
+                base += f"({contents})"
+            else:
+                base += f".{item}"
+        return base
+
+    def __call__(self, *args, **kwargs):
+        return _Tracker(self.origin, self.tracker + [("__call__", args, kwargs)])
+
+    def __getattr__(self, name):
+        # IPython will make attribute calls on objects; we don't want to track these.
+        if name != "_ipython_canary_method_should_not_exist_" and name != "__wrapped__":
+            return _Tracker(self.origin, self.tracker + [name])
+        return self
+
+
+def like(obj: T) -> T:
+    return cast(T, _Tracker(obj))


### PR DESCRIPTION
Potentially addresses: #205

#219  prototypes a potential solution to the above, that is much more powerful than what I had initially proposed. This is inspired by @jgbos ' [out of left field](https://github.com/mit-ll-responsible-ai/hydra-zen/issues/205#issuecomment-1017951452) idea 😄 

Let's see `hydra_zen.like` in action:

```python
>>> from hydra_zen import just, instantiate, like, to_yaml
>>> import torch

>>> GenLike = like(torch.Generator)  # 'memorizes' sequence of interactions with `torch.Generator`
>>> seeded = GenLike().manual_seed(42)
>>> seeded   
Like(<class 'torch._C.Generator'>)().manual_seed(42)

>>> Conf = just(seeded)  # creates Hydra-compatible config for performing interactions via instantiation

>>> print(to_yaml(Conf))
_target_: hydra_zen.structured_configs._implementations.make_like
_args_:
- torch._C.Generator
- - - __call__
    - []
    - {}
  - manual_seed
  - - __call__
    - - 42
    - {}

>>> generator = instantiate(Conf)  # calls torch.Generator().manual_seed(42)
<torch._C.Generator at 0x14efb92c770>
```

what is going on here?

`hydra_zen.like(<target>)` returns a `_Tracker` instance that records all subsequent interactions with `<target>`. Right now, "interactions" are restricted to accessing attributes and calling the target. `hydra_zen.just` then knows how to convert a `_Tracker` instance into a valid Hydra config.

Let's use this to make a config that actually returns the `manual_seed` method of our Generator-instance:

```python
>>> manual_seed_fn = GenLike().manual_seed

>>> instantiate(just(manual_seed_fn))
<function Generator.manual_seed>
```


Here is a silly example, just to help give more of a feel for this:

```python
>>> listy = like(list)
>>> x = listy([1, 2, 3])
>>> y = x.pop()

# note that `x` *does not* reflect any mutation
>>> instantiate(just(x)), instantiate(just(y))
([1, 2, 3], 3)
```

## Current thoughts on this prototype

One nice thing about `like` is that looks like a simple pass-through to IDEs, so you get auto-completes, static type checks, etc. as you build your "like expression" prior to creating the config.

Some obvious to-dos would include:

- Adding as much validation as possible. E.g. `GenLike().manual_seedling(42)` should raise a runtime error because `manual_seedling` is not an attribute of `Generator`.
- Making the yaml-representation of the `just(like(<...>).<...>)` expression as clean as possible 
   - doing `just(like(<target>)(*args, **kwargs))` should reduce down to `builds(<target>, *args, **kwargs)`
- Enable users to directly provide `like`'d objects in their configs without them needing to call `just` first.

I would definitely like to get feedback on this. I only just thought of it, and will have to think carefully about potential pitfalls as well as about possible use cases that I haven't anticipated yet.

## Additional functionality

`like` could also fulfill the role of [the proposed `hydra_zen.hydrate`](https://github.com/mit-ll-responsible-ai/hydra-zen/issues/93)

```python
import torch as tr

tr = like(tr)

tr.tensor([1., 2.])  # is equivalent to `like(tr.tensor)([1.0, 2.0])`
```
