### PR TITLE
Achieve type completeness (pyright-strict)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,5 +51,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .
-    - name: Run pyright
+    - name: Run pyright basic on src
       run: pyright --lib tests/annotations/ src/
+    - name: (pyright) verify type completeness
+      run: pyright --ignoreexternal --verifytypes hydra_zen

--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -169,5 +169,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .
-    - name: Run pyright
+    - name: Run pyright basic on src
       run: pyright --lib tests/annotations/ src/
+    - name: (pyright) verify type completeness
+      run: pyright --ignoreexternal --verifytypes hydra_zen

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
     <img src="https://github.com/mit-ll-responsible-ai/hydra-zen/workflows/Tests/badge.svg" alt="GitHub Actions" />
   <a href="https://github.com/mit-ll-responsible-ai/hydra-zen/actions?query=workflow%3ATests+branch%3Amain">
     <img src="https://img.shields.io/badge/coverage-100%25-green.svg" alt="Code Coverage" />
+  <a href="https://github.com/microsoft/pyright/blob/92b4028cd5fd483efcf3f1cdb8597b2d4edd8866/docs/typed-libraries.md#verifying-type-completeness">
+    <img src="https://img.shields.io/badge/type%20completeness-100%25-green.svg" alt="Type-Completeness Score" />
   <a href="https://hypothesis.readthedocs.io/">
     <img src="https://img.shields.io/badge/hypothesis-tested-brightgreen.svg" alt="Tested with Hypothesis" />
   </a>

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -9,4 +9,5 @@
         "**/third_party",
     ],
     "reportUnnecessaryTypeIgnoreComment": true,
+    "reportUnnecessaryIsInstance": false,
 }

--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -26,7 +26,7 @@ from hydra.utils import instantiate as hydra_instantiate
 from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
 
 from .typing import Builds, Just, Partial, PartialBuilds
-from .typing._implementations import HydraPartialBuilds, _DataClass
+from .typing._implementations import DataClass_, HydraPartialBuilds
 
 __all__ = ["instantiate", "to_yaml", "save_as_yaml", "load_from_yaml", "MISSING"]
 
@@ -106,12 +106,14 @@ def instantiate(
 
 @overload
 def instantiate(
-    config: Union[ListConfig, DictConfig, _DataClass, Type[_DataClass]], *args, **kwargs
+    config: Union[ListConfig, DictConfig, DataClass_, Type[DataClass_]],
+    *args: Any,
+    **kwargs: Any
 ) -> Any:  # pragma: no cover
     ...
 
 
-def instantiate(config: Any, *args, **kwargs) -> Any:
+def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
     """
     Instantiates the target of a targeted config.
 

--- a/src/hydra_zen/_launch.py
+++ b/src/hydra_zen/_launch.py
@@ -18,7 +18,7 @@ from hydra_zen.typing._implementations import DataClass
 
 
 def _store_config(
-    cfg: Union[DataClass, Type[DataClass], DictConfig, Mapping],
+    cfg: Union[DataClass, Type[DataClass], DictConfig, Mapping[Any, Any]],
     config_name: str = "hydra_launch",
 ) -> str:
     """Stores configuration object in Hydra's ConfigStore.

--- a/src/hydra_zen/funcs.py
+++ b/src/hydra_zen/funcs.py
@@ -6,7 +6,7 @@ Simple helper functions used to implement `just` and `builds`. This module is de
 that these functions have a legible module-path when they appear in configuration files.
 """
 import functools as _functools
-import typing as _typing
+import typing as _tp
 
 from hydra._internal import utils as _hydra_internal_utils
 from hydra.utils import log as _log
@@ -18,24 +18,22 @@ from hydra_zen.typing import Partial as _Partial
 
 __all__ = ["partial", "get_obj", "zen_processing"]
 
-_T = _typing.TypeVar("_T")
-_WrapperConf = _typing.Union[
-    str, _typing.Callable[[_typing.Callable], _typing.Callable]
-]
+_T = _tp.TypeVar("_T")
+
+_Wrapper = _tp.Callable[[_tp.Callable[..., _tp.Any]], _tp.Callable[..., _tp.Any]]
+_WrapperConf = _tp.Union[str, _Wrapper]
 
 
 def partial(
-    *args: _typing.Any,
-    _partial_target_: _typing.Callable[..., _T],
-    **kwargs: _typing.Any,
+    *args: _tp.Any,
+    _partial_target_: _tp.Callable[..., _T],
+    **kwargs: _tp.Any,
 ) -> _Partial[_T]:
     """Equivalent to ``functools.partial`` but provides a named parameter for the callable."""
-    return _typing.cast(
-        _Partial[_T], _functools.partial(_partial_target_, *args, **kwargs)
-    )
+    return _tp.cast(_Partial[_T], _functools.partial(_partial_target_, *args, **kwargs))
 
 
-def get_obj(*, path: str) -> _typing.Union[type, _typing.Callable[..., _typing.Any]]:
+def get_obj(*, path: str) -> _tp.Union[type, _tp.Callable[..., _tp.Any]]:
     """Imports an object given the specified path."""
     try:
         cl = _hydra_internal_utils._locate(path)
@@ -46,24 +44,20 @@ def get_obj(*, path: str) -> _typing.Union[type, _typing.Callable[..., _typing.A
 
 
 def zen_processing(
-    *args,
+    *args: _tp.Any,
     _zen_target: str,
     _zen_partial: bool = False,
-    _zen_exclude: _typing.Sequence[str] = tuple(),
-    _zen_wrappers: _typing.Union[
-        _WrapperConf, _typing.Sequence[_WrapperConf]
-    ] = tuple(),
-    **kwargs,
-):
-    if isinstance(_zen_wrappers, str) or not isinstance(
-        _zen_wrappers, _typing.Sequence
-    ):
-        unresolved_wrappers: _typing.Sequence[_WrapperConf] = (_zen_wrappers,)
+    _zen_exclude: _tp.Sequence[str] = tuple(),
+    _zen_wrappers: _tp.Union[_WrapperConf, _tp.Sequence[_WrapperConf]] = tuple(),
+    **kwargs: _tp.Any,
+) -> _tp.Any:
+    if isinstance(_zen_wrappers, str) or not isinstance(_zen_wrappers, _tp.Sequence):
+        unresolved_wrappers: _tp.Sequence[_WrapperConf] = (_zen_wrappers,)
     else:
-        unresolved_wrappers: _typing.Sequence[_WrapperConf] = _zen_wrappers
+        unresolved_wrappers: _tp.Sequence[_WrapperConf] = _zen_wrappers
     del _zen_wrappers
 
-    resolved_wrappers = []
+    resolved_wrappers: _tp.List[_Wrapper] = []
 
     for _unresolved in unresolved_wrappers:
         if _unresolved is None:

--- a/src/hydra_zen/third_party/beartype.py
+++ b/src/hydra_zen/third_party/beartype.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 import inspect
-from typing import Callable, TypeVar, cast
+from typing import Any, Callable, TypeVar, cast
 
 import beartype as bt
 
 from hydra_zen._utils.coerce import coerce_sequences
 
-_T = TypeVar("_T", bound=Callable)
+_T = TypeVar("_T", bound=Callable[..., Any])
 
 __all__ = ["validates_with_beartype"]
 

--- a/src/hydra_zen/third_party/pydantic.py
+++ b/src/hydra_zen/third_party/pydantic.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 import inspect
-from typing import Callable, TypeVar, cast
+from typing import Any, Callable, TypeVar, cast
 
 import pydantic as _pyd
 
-_T = TypeVar("_T", bound=Callable)
+_T = TypeVar("_T", bound=Callable[..., Any])
 
 __all__ = ["validates_with_pydantic"]
 

--- a/src/hydra_zen/typing/_builds_overloads.py
+++ b/src/hydra_zen/typing/_builds_overloads.py
@@ -3,17 +3,27 @@
 
 # Stores overloads for `builds` with different default-values for signature
 
-from typing import Callable, Mapping, Optional, Tuple, Type, TypeVar, Union, overload
+from typing import (
+    Any,
+    Callable,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from typing_extensions import Literal, ParamSpec
 
 from ._implementations import (
     Builds,
+    DataClass_,
     Importable,
     PartialBuilds,
     SupportedPrimitive,
     ZenWrappers,
-    _DataClass,
 )
 
 R = TypeVar("R")
@@ -28,7 +38,7 @@ def full_builds(
     hydra_target: Callable[P, R],
     *,
     zen_partial: Literal[False] = ...,
-    zen_wrappers: ZenWrappers = ...,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, SupportedPrimitive]] = ...,
     populate_full_signature: Literal[True] = ...,
     hydra_recursive: Optional[bool] = ...,
@@ -45,13 +55,13 @@ def full_builds(
     hydra_target: Importable,
     *pos_args: SupportedPrimitive,
     zen_partial: Literal[False] = ...,
-    zen_wrappers: ZenWrappers = ...,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, SupportedPrimitive]] = ...,
     populate_full_signature: Literal[False] = ...,
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     dataclass_name: Optional[str] = ...,
-    builds_bases: Tuple[Type[_DataClass], ...] = ...,
+    builds_bases: Tuple[Type[DataClass_], ...] = ...,
     frozen: bool = ...,
     **kwargs_for_target: SupportedPrimitive,
 ) -> Type[Builds[Importable]]:  # pragma: no cover
@@ -63,13 +73,13 @@ def full_builds(
     hydra_target: Importable,
     *pos_args: SupportedPrimitive,
     zen_partial: Literal[False] = ...,
-    zen_wrappers: ZenWrappers = ...,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, SupportedPrimitive]] = ...,
     populate_full_signature: bool = ...,
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     dataclass_name: Optional[str] = ...,
-    builds_bases: Tuple[Type[_DataClass], ...] = ...,
+    builds_bases: Tuple[Type[DataClass_], ...] = ...,
     frozen: bool = ...,
     **kwargs_for_target: SupportedPrimitive,
 ) -> Type[Builds[Importable]]:  # pragma: no cover
@@ -81,13 +91,13 @@ def full_builds(
     hydra_target: Importable,
     *pos_args: SupportedPrimitive,
     zen_partial: Literal[True] = ...,
-    zen_wrappers: ZenWrappers = ...,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, SupportedPrimitive]] = ...,
     populate_full_signature: bool = ...,
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     dataclass_name: Optional[str] = ...,
-    builds_bases: Tuple[Type[_DataClass], ...] = ...,
+    builds_bases: Tuple[Type[DataClass_], ...] = ...,
     frozen: bool = ...,
     **kwargs_for_target: SupportedPrimitive,
 ) -> Type[PartialBuilds[Importable]]:  # pragma: no cover
@@ -99,13 +109,13 @@ def full_builds(
     hydra_target: Union[Importable, Callable[P, R]],
     *pos_args: SupportedPrimitive,
     zen_partial: bool = ...,
-    zen_wrappers: ZenWrappers = ...,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, SupportedPrimitive]] = ...,
     populate_full_signature: bool = ...,
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     dataclass_name: Optional[str] = ...,
-    builds_bases: Tuple[Type[_DataClass], ...] = ...,
+    builds_bases: Tuple[Type[DataClass_], ...] = ...,
     frozen: bool = ...,
     **kwargs_for_target: SupportedPrimitive,
 ) -> Union[
@@ -116,19 +126,23 @@ def full_builds(
     ...
 
 
-def full_builds(  # type: ignore
-    *pos_args,
-    zen_partial=False,
-    zen_wrappers=tuple(),
-    zen_meta=None,
-    populate_full_signature=True,  # updated default
-    hydra_recursive=None,
-    hydra_convert=None,
+def full_builds(
+    *pos_args: Union[Importable, Callable[P, R], SupportedPrimitive],
+    zen_partial: bool = False,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = tuple(),
+    zen_meta: Optional[Mapping[str, SupportedPrimitive]] = None,
+    populate_full_signature: bool = True,
+    hydra_recursive: Optional[bool] = None,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = None,
     frozen: bool = False,
-    builds_bases=(),
-    dataclass_name=None,
-    **kwargs_for_target,
-):  # pragma: no cover
+    builds_bases: Tuple[Type[DataClass_], ...] = (),
+    dataclass_name: Optional[str] = None,
+    **kwargs_for_target: SupportedPrimitive,
+) -> Union[
+    Type[Builds[Importable]],
+    Type[PartialBuilds[Importable]],
+    Callable[P, Builds[Type[R]]],
+]:  # pragma: no cover
     raise NotImplementedError()
 
 
@@ -140,13 +154,13 @@ def partial_builds(
     hydra_target: Importable,
     *pos_args: SupportedPrimitive,
     zen_partial: Literal[True] = ...,
-    zen_wrappers: ZenWrappers = ...,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, SupportedPrimitive]] = ...,
     populate_full_signature: bool = ...,
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     dataclass_name: Optional[str] = ...,
-    builds_bases: Tuple[Type[_DataClass], ...] = ...,
+    builds_bases: Tuple[Type[DataClass_], ...] = ...,
     frozen: bool = ...,
     **kwargs_for_target: SupportedPrimitive,
 ) -> Type[PartialBuilds[Importable]]:  # pragma: no cover
@@ -158,7 +172,7 @@ def partial_builds(
     hydra_target: Callable[P, R],
     *,
     zen_partial: Literal[False] = ...,
-    zen_wrappers: ZenWrappers = ...,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, SupportedPrimitive]] = ...,
     populate_full_signature: Literal[True] = ...,
     hydra_recursive: Optional[bool] = ...,
@@ -175,13 +189,13 @@ def partial_builds(
     hydra_target: Importable,
     *pos_args: SupportedPrimitive,
     zen_partial: Literal[False] = ...,
-    zen_wrappers: ZenWrappers = ...,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, SupportedPrimitive]] = ...,
     populate_full_signature: Literal[False] = ...,
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     dataclass_name: Optional[str] = ...,
-    builds_bases: Tuple[Type[_DataClass], ...] = ...,
+    builds_bases: Tuple[Type[DataClass_], ...] = ...,
     frozen: bool = ...,
     **kwargs_for_target: SupportedPrimitive,
 ) -> Type[Builds[Importable]]:  # pragma: no cover
@@ -193,13 +207,13 @@ def partial_builds(
     hydra_target: Importable,
     *pos_args: SupportedPrimitive,
     zen_partial: Literal[False] = ...,
-    zen_wrappers: ZenWrappers = ...,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, SupportedPrimitive]] = ...,
     populate_full_signature: bool = ...,
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     dataclass_name: Optional[str] = ...,
-    builds_bases: Tuple[Type[_DataClass], ...] = ...,
+    builds_bases: Tuple[Type[DataClass_], ...] = ...,
     frozen: bool = ...,
     **kwargs_for_target: SupportedPrimitive,
 ) -> Type[Builds[Importable]]:  # pragma: no cover
@@ -211,13 +225,13 @@ def partial_builds(
     hydra_target: Union[Importable, Callable[P, R]],
     *pos_args: SupportedPrimitive,
     zen_partial: bool = ...,
-    zen_wrappers: ZenWrappers = ...,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, SupportedPrimitive]] = ...,
     populate_full_signature: bool = ...,
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     dataclass_name: Optional[str] = ...,
-    builds_bases: Tuple[Type[_DataClass], ...] = ...,
+    builds_bases: Tuple[Type[DataClass_], ...] = ...,
     frozen: bool = ...,
     **kwargs_for_target: SupportedPrimitive,
 ) -> Union[
@@ -228,17 +242,21 @@ def partial_builds(
     ...
 
 
-def partial_builds(  # type: ignore
-    *pos_args,
-    zen_partial=True,  # updated default
-    zen_wrappers=tuple(),
-    zen_meta=None,
-    populate_full_signature=False,
-    hydra_recursive=None,
-    hydra_convert=None,
+def partial_builds(
+    *pos_args: Union[Importable, Callable[P, R], SupportedPrimitive],
+    zen_partial: bool = True,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = tuple(),
+    zen_meta: Optional[Mapping[str, SupportedPrimitive]] = None,
+    populate_full_signature: bool = False,
+    hydra_recursive: Optional[bool] = None,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = None,
     frozen: bool = False,
-    builds_bases=(),
-    dataclass_name=None,
-    **kwargs_for_target,
-):  # pragma: no cover
+    builds_bases: Tuple[Type[DataClass_], ...] = (),
+    dataclass_name: Optional[str] = None,
+    **kwargs_for_target: SupportedPrimitive,
+) -> Union[
+    Type[Builds[Importable]],
+    Type[PartialBuilds[Importable]],
+    Callable[P, Builds[Type[R]]],
+]:  # pragma: no cover
     raise NotImplementedError()

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -352,9 +352,9 @@ def supported_primitives():
     # make_config(a={ADataclass: 1})
 
 
-def check_inheritance():
+def check_base_annotations():
     P1 = make_config(x=1)
-    P2 = builds(dict)
+    P2 = builds(int)
 
     @dataclass
     class P3:
@@ -369,6 +369,11 @@ def check_inheritance():
     make_config(x=1, bases=(lambda x: x,))  # type: ignore
     make_config(x=1, bases=(None,))  # type: ignore
     make_config(x=1, bases=(A,))  # type: ignore
+
+    # should fail
+    make_custom_builds_fn(builds_bases=(lambda x: x,))  # type: ignore
+    make_custom_builds_fn(builds_bases=(None,))  # type: ignore
+    make_custom_builds_fn(builds_bases=(A,))  # type: ignore
 
 
 def make_hydra_partial(x: T) -> HydraPartialBuilds[Type[T]]:


### PR DESCRIPTION
pyright provides a utility for [verifying type completeness for "py.typed" packages](https://github.com/microsoft/pyright/blob/92b4028cd5fd483efcf3f1cdb8597b2d4edd8866/docs/typed-libraries.md#verifying-type-completeness). 

This PR revamps hydra-zen's annotations so that its type completeness score is 100%. Our CI will now check that we maintain this score.

[dcb8061](https://github.com/mit-ll-responsible-ai/hydra-zen/pull/226/commits/dcb806150a7cc7e832d0e21cd06e3d46511a3b0d) confirms that our CI correctly fails when hydra-zen does not reach 100% type completeness [CI](https://github.com/mit-ll-responsible-ai/hydra-zen/runs/5227421315?check_suite_focus=true):

```
Type completeness score: 65.8%  ( 😢 )
```

[da713b6](https://github.com/mit-ll-responsible-ai/hydra-zen/pull/226/commits/da713b66f06505d8f54108cda0ba987c5d1a0d99) then brings our type-completeness to 100% woo! [CI](https://github.com/mit-ll-responsible-ai/hydra-zen/runs/5227440850?check_suite_focus=true#step:11:35)

```
Type completeness score: 100.0%  ( 🥳  )
```

### Additional notes

Most of `src/` runs clean under pyright-strict now, but CI will continue to only check pyright-basic, as some of the "strict" issues are exceedingly pedantic and unwieldy to deal with; it would only make our source code less maintainable and it would have no user-facing impact. 

That being said the type-completeness score is produced under "strict" mode settings, so the user-facing objects are in top-shape!