### PR TITLE
Enable `_partial_` for Hydra > 1.1.1

### DIFF
--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -138,7 +138,7 @@ jobs:
     - name: Test with tox
       run: tox -e pre-release
 
-  test-against-hydra-1.1.2dev:
+  test-against-hydra-1_1_2dev:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -138,6 +138,29 @@ jobs:
     - name: Test with tox
       run: tox -e pre-release
 
+  test-against-hydra-1.1.2dev:
+    runs-on: ubuntu-latest
+
+    strategy:
+      max-parallel: 3
+      matrix:
+        python-version: [3.8]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox -e hydra-1p1p2-pre-release
+
+
   run-pyright:
     runs-on: ubuntu-latest
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,13 @@ deps = {[testenv]deps}
        beartype
 basepython = python3.8
 
+[testenv:hydra-1p1p2-pre-release]  # test against pre-releases of dependencies
+pip_pre = true
+deps = hydra-core==1.1.2dev
+       {[testenv]deps}
+       pydantic
+       beartype
+basepython = python3.8
 
 [testenv:coverage]
 setenv = NUMBA_DISABLE_JIT=1

--- a/src/hydra_zen/_compatibility.py
+++ b/src/hydra_zen/_compatibility.py
@@ -52,7 +52,7 @@ PATCH_OMEGACONF_830: Final = True  # OMEGACONF_VERSION < Version(2, 1, 1)
 #
 # Uncomment dynamice setting of `HYDRA_SUPPORTS_PARTIAL` once we can
 # begin testing against nightly builds of Hydra
-HYDRA_SUPPORTS_PARTIAL: Final = False  # Version(1, 1, 1) < HYDRA_VERSION
+HYDRA_SUPPORTS_PARTIAL: Final = Version(1, 1, 1) < HYDRA_VERSION
 
 # Indicates primitive types permitted in type-hints of structured configs
 HYDRA_SUPPORTED_PRIMITIVE_TYPES: Final = {int, float, bool, str, Enum}

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -87,7 +87,7 @@ _names = [
     _POS_ARG_FIELD_NAME,
 ]
 
-if HYDRA_SUPPORTS_PARTIAL:
+if HYDRA_SUPPORTS_PARTIAL:  # pragma: no cover
     _names.append(_PARTIAL_FIELD_NAME)
 
 _HYDRA_FIELD_NAMES: FrozenSet[str] = frozenset(_names)

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -15,6 +15,7 @@ from hydra_zen.structured_configs._implementations import (
     is_partial_builds,
 )
 from hydra_zen.typing import Builds, Just, Partial, PartialBuilds
+from hydra_zen.typing._implementations import HydraPartialBuilds
 
 
 @pytest.mark.parametrize(
@@ -22,7 +23,8 @@ from hydra_zen.typing import Builds, Just, Partial, PartialBuilds
     [
         (just, Just),
         (builds, Builds),
-        (partial(builds, zen_partial=True), PartialBuilds),
+        (partial(builds, zen_partial=True), (PartialBuilds, HydraPartialBuilds)),
+        (partial(builds, zen_partial=True, zen_meta=dict(y=1)), PartialBuilds),
     ],
 )
 def test_runtime_checkability_of_protocols(fn, protocol):

--- a/tests/test_zen_wrappers.py
+++ b/tests/test_zen_wrappers.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, List, TypeVar, Union
 
 import hypothesis.strategies as st
 import pytest
+from hydra.errors import InstantiationException
 from hypothesis import given, settings
 from omegaconf import OmegaConf
 from omegaconf.errors import InterpolationKeyError, InterpolationResolutionError
@@ -34,7 +35,7 @@ def _coordinate_meta_fields_for_interpolation(wrappers, zen_meta):
     # interpolated strings map to the named decorators
     if is_interpolated_string(wrappers):
         # change level of interpolation
-        wrappers = wrappers.replace("..", ".")  # type: ignore
+        wrappers = wrappers.replace("..", ".")
         dec_name: str = wrappers[3:-1]
         item = decorators_by_name[dec_name]
         zen_meta[dec_name] = item if item is None else just(item)
@@ -134,7 +135,7 @@ a_tracked_wrapper = st.sampled_from(tracked_funcs)
     as_yaml=st.booleans(),
 )
 def test_zen_wrappers_expected_behavior(
-    wrappers: Union[  # type: ignore
+    wrappers: Union[
         Union[TrackedFunc, Just[TrackedFunc], PartialBuilds[TrackedFunc], InterpStr],
         List[
             Union[TrackedFunc, Just[TrackedFunc], PartialBuilds[TrackedFunc], InterpStr]
@@ -231,7 +232,7 @@ class NotAWrapper:
     ],
 )
 def test_zen_wrappers_validation_during_builds(bad_wrapper):
-    with pytest.raises(TypeError):
+    with pytest.raises((TypeError, InstantiationException)):
         builds(int, zen_wrappers=bad_wrapper)
 
 
@@ -246,7 +247,7 @@ def test_zen_wrappers_validation_during_builds(bad_wrapper):
 )
 def test_zen_wrappers_validation_during_instantiation(bad_wrapper):
     conf = builds(int, zen_wrappers=bad_wrapper)
-    with pytest.raises(TypeError):
+    with pytest.raises((TypeError, InstantiationException)):
         instantiate(conf)
 
 


### PR DESCRIPTION
This PR enables compatibility with Hydra's new support for `_partial_` in its instantiate API. For Hydra > 1.1.1, "partial'd" configs will no longer need to leverage `zen_processing` (assuming no other zen-features are utilized):

Before:

```python
>>> from hydra_zen import builds, to_yaml
>>> Conf = builds(int, zen_partial=True)
>>> print(to_yaml(Conf))
_target_: hydra_zen.funcs.zen_processing
_zen_target: builtins.int
_zen_partial: true
```

After (assuming `hydra-core>1.1.1` is installed):

```python
>>> Conf = builds(int, zen_partial=True)
>>> print(to_yaml(Conf))
_target_: builtins.int
_partial_: true
```

This PR also adds CI tests against 1.1.2dev, so that we test against both 1.1.2dev and 1.2.0dev in our suite.