### PR TITLE
Adds BuildsWithSig protocol

### DIFF
--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -62,7 +62,13 @@ from hydra_zen.typing._builds_overloads import (
     full_builds as _full_builds,
     partial_builds as _partial_builds,
 )
-from hydra_zen.typing._implementations import DataClass, DataClass_, Field, HasTarget
+from hydra_zen.typing._implementations import (
+    BuildsWithSig,
+    DataClass,
+    DataClass_,
+    Field,
+    HasTarget,
+)
 
 from ._value_conversion import ZEN_VALUE_CONVERSION
 
@@ -644,7 +650,7 @@ def builds(
     dataclass_name: Optional[str] = ...,
     builds_bases: Tuple[()] = ...,
     frozen: bool = ...,
-) -> Callable[P, Builds[Type[R]]]:  # pragma: no cover
+) -> Type[BuildsWithSig[Type[R], P]]:  # pragma: no cover
     ...
 
 
@@ -704,7 +710,7 @@ def builds(
 ) -> Union[
     Type[Builds[Importable]],
     Type[PartialBuilds[Importable]],
-    Callable[P, Builds[Type[R]]],
+    Type[BuildsWithSig[Type[R], P]],
 ]:  # pragma: no cover
     ...
 
@@ -724,7 +730,7 @@ def builds(
 ) -> Union[
     Type[Builds[Importable]],
     Type[PartialBuilds[Importable]],
-    Callable[P, Builds[Type[R]]],
+    Type[BuildsWithSig[Type[R], P]],
 ]:
     """builds(hydra_target, /, *pos_args, zen_partial=False, zen_meta=None,
     hydra_recursive=None, populate_full_signature=False, hydra_convert=None,
@@ -1730,7 +1736,7 @@ def builds(
             out.__doc__ += (
                 f"\n\nThe docstring for {_utils.safe_name(target)} :\n\n" + target_doc
             )
-    return cast(Union[Type[Builds[Importable]], Callable[P, Builds[Type[R]]]], out)
+    return cast(Union[Type[Builds[Importable]], Type[BuildsWithSig[Type[R], P]]], out)
 
 
 # We need to check if things are Builds, Just, PartialBuilds to a higher

--- a/src/hydra_zen/typing/_builds_overloads.py
+++ b/src/hydra_zen/typing/_builds_overloads.py
@@ -19,6 +19,7 @@ from typing_extensions import Literal, ParamSpec
 
 from ._implementations import (
     Builds,
+    BuildsWithSig,
     DataClass_,
     Importable,
     PartialBuilds,
@@ -46,7 +47,7 @@ def full_builds(
     dataclass_name: Optional[str] = ...,
     builds_bases: Tuple[()] = ...,
     frozen: bool = ...,
-) -> Callable[P, Builds[Type[R]]]:  # pragma: no cover
+) -> Type[BuildsWithSig[Type[R], P]]:  # pragma: no cover
     ...
 
 
@@ -121,7 +122,7 @@ def full_builds(
 ) -> Union[
     Type[Builds[Importable]],
     Type[PartialBuilds[Importable]],
-    Callable[P, Builds[Type[R]]],
+    Type[BuildsWithSig[Type[R], P]],
 ]:  # pragma: no cover
     ...
 
@@ -141,7 +142,7 @@ def full_builds(
 ) -> Union[
     Type[Builds[Importable]],
     Type[PartialBuilds[Importable]],
-    Callable[P, Builds[Type[R]]],
+    Type[BuildsWithSig[Type[R], P]],
 ]:  # pragma: no cover
     raise NotImplementedError()
 
@@ -180,7 +181,7 @@ def partial_builds(
     dataclass_name: Optional[str] = ...,
     builds_bases: Tuple[()] = ...,
     frozen: bool = ...,
-) -> Callable[P, Builds[Type[R]]]:  # pragma: no cover
+) -> Type[BuildsWithSig[Type[R], P]]:  # pragma: no cover
     ...
 
 
@@ -237,7 +238,7 @@ def partial_builds(
 ) -> Union[
     Type[Builds[Importable]],
     Type[PartialBuilds[Importable]],
-    Callable[P, Builds[Type[R]]],
+    Type[BuildsWithSig[Type[R], P]],
 ]:  # pragma: no cover
     ...
 
@@ -257,6 +258,6 @@ def partial_builds(
 ) -> Union[
     Type[Builds[Importable]],
     Type[PartialBuilds[Importable]],
-    Callable[P, Builds[Type[R]]],
+    Type[BuildsWithSig[Type[R], P]],
 ]:  # pragma: no cover
     raise NotImplementedError()

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 from omegaconf import DictConfig, ListConfig
-from typing_extensions import Literal, Protocol, TypedDict, runtime_checkable
+from typing_extensions import Literal, ParamSpec, Protocol, TypedDict, runtime_checkable
 
 __all__ = [
     "Just",
@@ -34,6 +34,9 @@ __all__ = [
     "SupportedPrimitive",
     "ZenWrappers",
 ]
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 class EmptyDict(TypedDict):
@@ -99,6 +102,11 @@ class DataClass(DataClass_, Protocol):  # pragma: no cover
 @runtime_checkable
 class Builds(DataClass, Protocol[T]):  # pragma: no cover
     _target_: ClassVar[str]
+
+
+class BuildsWithSig(Builds[T], Protocol[P]):  # pragma: no cover
+    def __init__(self, *args: P.args, **kwds: P.kwargs):  # pragma: no cover
+        ...
 
 
 @runtime_checkable

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -104,7 +104,7 @@ class Builds(DataClass, Protocol[T]):  # pragma: no cover
     _target_: ClassVar[str]
 
 
-class BuildsWithSig(Builds[T], Protocol[P]):  # pragma: no cover
+class BuildsWithSig(Builds[T], Protocol[T, P]):  # pragma: no cover
     def __init__(self, *args: P.args, **kwds: P.kwargs):  # pragma: no cover
         ...
 


### PR DESCRIPTION
This PR introduces `BuildsWithSig` as an internal protocol; it may be exposed via the public `hydra_zen.typing` API in the future.

We improve the annotation for `builds(<target>, populate_full_signature=True)` so that the resulting type, `BuildsWithSig`, is a subclass of the `Builds` protocol.



## Before

#224 modified the annotation overloads for `builds` so that `builds(<target>, populate_full_signature=True)` returned the type `Callable[P, Builds[Type[R]]]`, where `P` and `R` are the signature and type of `<target>`, respectively. 

While this enables auto-completion / signature inference to static tooling, the issue is that the return type is a generic callable and not a subclass of `Builds`. This can lead to some glaring false-positives to type-checkers; e.g.

![image](https://user-images.githubusercontent.com/29104956/155823219-267be05e-4a69-42e5-a5dd-9f04ecef8780.png)

where the type-checker raises:

```
Argument of type "(x: Unknown) -> Builds[Unknown]" cannot be assigned to parameter "x" of type "Type[Builds[Unknown]]" in function "f"
  Type "(x: Unknown) -> Builds[Unknown]" cannot be assigned to type "Type[Builds[Unknown]]"
```

## After

Now, `builds(<target>, populate_full_signature=True)` returns `Type[BuildsWithSig[Type[R], P]]`,  where `P` and `R` are the signature and type of `<target>`, respectively. Thus signature auto-complete/inference is preserved **and** the above false-positive no longer occurs:

![image](https://user-images.githubusercontent.com/29104956/155823541-67a5bad7-3060-44a6-aa6c-b01f3c54cc9d.png)




