### PR TITLE
Revise implementation of `PartialBuilds`

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -37,7 +37,7 @@ Improvements
 Support for Upcoming Hydra Features
 -----------------------------------
 
-Hydra 1.1.2 is introducing `support for partial instantiation of targeted configs <https://hydra.cc/docs/next/advanced/instantiate_objects/overview/#partial-instantiation>`_ via the ``_partial_`` field. ``builds(<target>, zen_partial=True)`` will now set the ``_partial_`` field on the structured config
+Hydra 1.1.2 will introduce `support for partial instantiation of targeted configs <https://hydra.cc/docs/next/advanced/instantiate_objects/overview/#partial-instantiation>`_ via the ``_partial_`` field. ``builds(<target>, zen_partial=True)`` will now set the ``_partial_`` field on the structured config
 rather than using ``hydra_zen.funcs.zen_processing`` to facilitate partial instantiation.
 
 
@@ -60,7 +60,28 @@ rather than using ``hydra_zen.funcs.zen_processing`` to facilitate partial insta
 
 This change will only occur when one's locally-installed version of ``hydra-core`` is 1.1.2 or higher. Structured configs and yamls that configure partial'd objects via ``hydra_zen.funcs.zen_processing`` are still valid and will instantiate in the same way as before. I.e. this is only a compatibility-breaking change for code that relied on the specific implementation details of the structured config produced by ``builds(<target>, zen_partial=True)``.
 
+In accordance with this change, the definition of ``hydra_zen.typing.PartialBuilds`` has been changed; it now reflects a union of protocols: ``ZenPartialBuilds[T] | HydraPartialBuilds[T]]``, both are which are now part of the public API of ``hydra_zen.typing``.
+
 (See :pull:`186` and :pull:`230` for additional details)
+
+Compatibility-Breaking Changes
+------------------------------
+
+``hydra_zen.typing.PartialBuilds`` is no longer a runtime-checkable protocol.
+Code that used ``PartialBuilds`` in this way can be updated as follows:
+
+
++---------------------------------------------------+--------------------------------------------------------------------------+
+|                                                   |                                                                          |
+| .. code-block:: pycon                             | .. code-block:: pycon                                                    |
+|    :caption: hydra-zen < 0.6.0                    |    :caption: 0.6.0 <= hydra-zen                                          |
+|                                                   |                                                                          |
+|    >>> from hydra_zen.typing import PartialBuilds |    >>> from hydra_zen.typing import HydraPartialBuilds, ZenPartialBuilds |
+|                                                   |                                                                          |
+|    >>> Conf = builds(int, zen_partial=True)       |    >>> Conf = builds(int, zen_partial=True)                              |
+|    >>> isinstance(Conf, PartialBuilds)            |    >>> isinstance(Conf, (HydraPartialBuilds, ZenPartialBuilds))          |
+|    True                                           |    True                                                                  |
++---------------------------------------------------+--------------------------------------------------------------------------+
 
 .. _v0.5.0:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ extensions = [
     "numpydoc",
     "sphinx_copybutton",
     "sphinx_tabs.tabs",
-    # "sphinx_codeautolink",
+    "sphinx_codeautolink",
 ]
 
 # Strip input prompts:

--- a/src/hydra_zen/typing/__init__.py
+++ b/src/hydra_zen/typing/__init__.py
@@ -3,11 +3,13 @@
 
 from ._implementations import (
     Builds,
+    HydraPartialBuilds,
     Importable,
     Just,
     Partial,
     PartialBuilds,
     SupportedPrimitive,
+    ZenPartialBuilds,
     ZenWrappers,
 )
 
@@ -19,4 +21,6 @@ __all__ = [
     "PartialBuilds",
     "SupportedPrimitive",
     "ZenWrappers",
+    "ZenPartialBuilds",
+    "HydraPartialBuilds",
 ]

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -33,6 +33,8 @@ __all__ = [
     "Importable",
     "SupportedPrimitive",
     "ZenWrappers",
+    "ZenPartialBuilds",
+    "HydraPartialBuilds",
 ]
 
 P = ParamSpec("P")
@@ -116,7 +118,7 @@ class Just(Builds[T], Protocol[T]):  # pragma: no cover
 
 
 @runtime_checkable
-class PartialBuilds(Builds[T], Protocol[T]):  # pragma: no cover
+class ZenPartialBuilds(Builds[T], Protocol[T]):  # pragma: no cover
     _target_: ClassVar[
         Literal["hydra_zen.funcs.zen_processing"]
     ] = "hydra_zen.funcs.zen_processing"
@@ -127,6 +129,9 @@ class PartialBuilds(Builds[T], Protocol[T]):  # pragma: no cover
 @runtime_checkable
 class HydraPartialBuilds(Builds[T], Protocol[T]):  # pragma: no cover
     _partial_: ClassVar[Literal[True]] = True
+
+
+PartialBuilds = Union[ZenPartialBuilds[T], HydraPartialBuilds[T]]
 
 
 @runtime_checkable

--- a/tests/test_compatibility/test_hydra_supports_partial.py
+++ b/tests/test_compatibility/test_hydra_supports_partial.py
@@ -11,8 +11,7 @@ from hydra_zen.structured_configs._implementations import (
     uses_zen_processing,
 )
 from hydra_zen.structured_configs._utils import get_obj_path
-from hydra_zen.typing import PartialBuilds
-from hydra_zen.typing._implementations import HydraPartialBuilds
+from hydra_zen.typing import HydraPartialBuilds, ZenPartialBuilds
 
 
 @dataclass
@@ -32,7 +31,7 @@ class ZenPartialConf:
 
 def test_HydraPartialBuilds_protocol():
     assert isinstance(HydraPartialConf(), HydraPartialBuilds)
-    assert not isinstance(HydraPartialConf(), PartialBuilds)
+    assert not isinstance(HydraPartialConf(), ZenPartialBuilds)
 
 
 def test_HYDRA_SUPPORTS_PARTIAL_is_set_properly():

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -14,7 +14,7 @@ from hydra_zen.structured_configs._implementations import (
     is_just,
     is_partial_builds,
 )
-from hydra_zen.typing import Builds, Just, Partial, PartialBuilds
+from hydra_zen.typing import Builds, Just, Partial, ZenPartialBuilds
 from hydra_zen.typing._implementations import HydraPartialBuilds
 
 
@@ -23,8 +23,8 @@ from hydra_zen.typing._implementations import HydraPartialBuilds
     [
         (just, Just),
         (builds, Builds),
-        (partial(builds, zen_partial=True), (PartialBuilds, HydraPartialBuilds)),
-        (partial(builds, zen_partial=True, zen_meta=dict(y=1)), PartialBuilds),
+        (partial(builds, zen_partial=True), (ZenPartialBuilds, HydraPartialBuilds)),
+        (partial(builds, zen_partial=True, zen_meta=dict(y=1)), ZenPartialBuilds),
     ],
 )
 def test_runtime_checkability_of_protocols(fn, protocol):
@@ -37,7 +37,7 @@ def test_runtime_checkability_of_protocols(fn, protocol):
 
 def test_Builds_is_not_ZenPartialBuilds():
     Conf = builds(dict)
-    assert not isinstance(Conf, PartialBuilds)
+    assert not isinstance(Conf, ZenPartialBuilds)
 
     PConf = builds(dict, zen_partial=True)
     assert isinstance(PConf, Builds)
@@ -64,7 +64,7 @@ def test_targeted_dataclass_is_Builds():
         (just, Just),
         (
             make_custom_builds_fn(zen_partial=True, zen_meta=dict(_y=None)),
-            PartialBuilds,
+            ZenPartialBuilds,
         ),
     ],
 )


### PR DESCRIPTION
In light of #230 this PR changes implementation of `PartialBuilds` to reflect that `builds(<target>, zen_partial=True)` can implement either the `_partial_` protocol or the `_zen_partial` protocol. Accordingly, `hydra_zen.typing` now exposes two protocols: `HydraPartialBuilds` and `ZenPartialBuilds`, and `PartialBuilds` is their union.

Any libraries that leverage `PartialBuilds` in their type annotations will likely not see any breaking changes in their static analysis. However, code that used `PartialBuilds` to perform runtime checking will need to update their code:

e.g., from

```python
>>> from hydra_zen.typing import PartialBuilds

>>> Conf = builds(int, zen_partial=True)
>>> isinstance(Conf, PartialBuilds)
True
```

to

```python
>>> from hydra_zen.typing import HydraPartialBuilds, ZenPartialBuilds

>>> Conf = builds(int, zen_partial=True)
>>> isinstance(Conf, (HydraPartialBuilds, ZenPartialBuilds))
True
```

In the future (certainly not until after Hydra 1.1.2 is released), the annotations of `builds` may be revised to more precisely reflect when `HydraPartialBuilds` vs `ZenPartialBuilds` is returned.