### PR TITLE
Improve instantiate overload

### DIFF
--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -26,7 +26,7 @@ from hydra.utils import instantiate as hydra_instantiate
 from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
 
 from .typing import Builds, Just, Partial, PartialBuilds
-from .typing._implementations import DataClass_, HydraPartialBuilds
+from .typing._implementations import DataClass_, HasTarget, HydraPartialBuilds
 
 __all__ = ["instantiate", "to_yaml", "save_as_yaml", "load_from_yaml", "MISSING"]
 
@@ -106,7 +106,7 @@ def instantiate(
 
 @overload
 def instantiate(
-    config: Union[ListConfig, DictConfig, DataClass_, Type[DataClass_]],
+    config: Union[HasTarget, ListConfig, DictConfig, DataClass_, Type[DataClass_]],
     *args: Any,
     **kwargs: Any
 ) -> Any:  # pragma: no cover

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
-from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import (

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import (

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -136,8 +136,8 @@ class SomeDataClass:
 def f6():
     some_dataclass = SomeDataClass()
 
-    out1 = instantiate(SomeDataClass)
-    out2 = instantiate(some_dataclass)
+    reveal_type(instantiate(SomeDataClass), expected_text="Any")
+    reveal_type(instantiate(some_dataclass), expected_text="Any")
 
 
 def f7():
@@ -167,6 +167,8 @@ def f8():
     @dataclass
     class A:
         x: List[int] = mutable_value([1, 2])
+
+    reveal_type(A().x, expected_text="List[int]")
 
 
 def zen_wrappers():
@@ -718,3 +720,13 @@ def check_protocol_compatibility():
     f_partial(b)  # type: ignore
     f_partial(pb)
     f_partial(bs)  # type: ignore
+
+
+def check_targeted_dataclass():
+    @dataclass
+    class OptimizerConf:
+        _target_: str
+        _partial_: bool = True
+
+    optimizer_conf = OptimizerConf(_target_="torch.optim.SGD")
+    reveal_type(instantiate(optimizer_conf), expected_text="Any")


### PR DESCRIPTION
Closes #241 

This PR improves compatibility of `hydra_zen.instantiate` with mypy:

```python
# repro.py
from dataclasses import dataclass

from hydra_zen import instantiate


@dataclass
class OptimizerConf:
    _target_: str
    _partial_: bool = True


optimizer_conf = OptimizerConf(_target_="torch.optim.SGD")

# Before:: mypy: No overload variant of "instantiate" matches argument type "OptimizerConf"
# After:: mypy: Revealed type is "Any"
reveal_type(instantiate(optimizer_conf))

```

## Some additional notes
mypy's support for dataclasses is limited, and there does not appear to be a way to spell dataclass-based protocols for mypy. Thus this new overload introduces a false-negative: `instantiate` can accept any object with a `_target_: str` attribute. Given that the above use case is a common use case, it is worth tolerating this relatively obscure false-negative (how many things have `_target_: str` attributes?) in favor of avoiding a very common false-positive in mypy. Another bonus: `attr`-based targeted configs will be tolerated as well.

I am interested in improving hydra-zen's compatibility with mypy further, although it lacks multiple `typing` features that we use, such as recursive types. I hope to learn about mypy plugins to see if progress can be made toward that end.

Contributions from any savvy mypy users are welcome. That could include adding some mypy checks to our CI for basic quality assurance. Presently, we run pyright checks in our CI.