### PR TITLE
Add missing overloads for `make_custom_builds_fn`

### DIFF
--- a/src/hydra_zen/structured_configs/_make_custom_builds.py
+++ b/src/hydra_zen/structured_configs/_make_custom_builds.py
@@ -105,7 +105,7 @@ def make_custom_builds_fn(
 def make_custom_builds_fn(
     *,
     zen_partial: Literal[False] = ...,
-    populate_full_signature: bool,
+    populate_full_signature: bool = ...,
     zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, Any]] = ...,
     hydra_recursive: Optional[bool] = ...,

--- a/src/hydra_zen/structured_configs/_make_custom_builds.py
+++ b/src/hydra_zen/structured_configs/_make_custom_builds.py
@@ -133,8 +133,6 @@ def make_custom_builds_fn(
 
 
 # partial=bool, pop-sig=bool, with parents
-
-
 @overload
 def make_custom_builds_fn(
     *,

--- a/src/hydra_zen/structured_configs/_make_custom_builds.py
+++ b/src/hydra_zen/structured_configs/_make_custom_builds.py
@@ -36,7 +36,7 @@ __BUILDS_DEFAULTS: Final[Dict[str, Any]] = {
 del _builds_sig
 
 
-# partial=False, pop-sig=True; no builds-bases
+# partial=False, pop-sig=True; no parents
 @overload
 def make_custom_builds_fn(
     *,
@@ -68,33 +68,100 @@ def make_custom_builds_fn(
     ...
 
 
-# partial=False, pop-sig=bool
+# partial=False, pop-sig=False, no parents
 @overload
 def make_custom_builds_fn(
     *,
     zen_partial: Literal[False] = ...,
+    populate_full_signature: Literal[False] = ...,
     zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, Any]] = ...,
-    populate_full_signature: bool = ...,
+    hydra_recursive: Optional[bool] = ...,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
+    frozen: bool = ...,
+    builds_bases: Tuple[()] = ...,
+) -> StdBuilds:  # pragma: no cover
+    ...
+
+
+# partial=False, pop-sig=bool, no parents
+@overload
+def make_custom_builds_fn(
+    *,
+    zen_partial: Literal[False] = ...,
+    populate_full_signature: bool,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
+    zen_meta: Optional[Mapping[str, Any]] = ...,
+    hydra_recursive: Optional[bool] = ...,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
+    frozen: bool = ...,
+    builds_bases: Tuple[()] = ...,
+) -> Union[FullBuilds, StdBuilds]:  # pragma: no cover
+    ...
+
+
+# partial=False, pop-sig=bool, with parents
+@overload
+def make_custom_builds_fn(
+    *,
+    zen_partial: Literal[False] = ...,
+    populate_full_signature: bool,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
+    zen_meta: Optional[Mapping[str, Any]] = ...,
+    hydra_recursive: Optional[bool] = ...,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
+    frozen: bool = ...,
+    builds_bases: Tuple[Type[DataClass_], ...],
+) -> StdBuilds:  # pragma: no cover
+    ...
+
+
+# partial=bool, pop-sig=False
+@overload
+def make_custom_builds_fn(
+    *,
+    zen_partial: bool,
+    populate_full_signature: Literal[False] = ...,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
+    zen_meta: Optional[Mapping[str, Any]] = ...,
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
     builds_bases: Tuple[Type[DataClass_], ...] = ...,
-) -> StdBuilds:  # pragma: no cover
+) -> Union[PBuilds, StdBuilds]:  # pragma: no cover
     ...
+
+
+# partial=bool, pop-sig=bool, with parents
 
 
 @overload
 def make_custom_builds_fn(
     *,
     zen_partial: bool,
+    populate_full_signature: bool,
     zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, Any]] = ...,
-    populate_full_signature: bool,
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
-    builds_bases: Tuple[Type[DataClass_], ...] = ...,
+    builds_bases: Tuple[Type[DataClass_], ...],
+) -> Union[PBuilds, StdBuilds]:  # pragma: no cover
+    ...
+
+
+# partial=bool, pop-sig=bool, no parents
+@overload
+def make_custom_builds_fn(
+    *,
+    zen_partial: bool,
+    populate_full_signature: bool,
+    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
+    zen_meta: Optional[Mapping[str, Any]] = ...,
+    hydra_recursive: Optional[bool] = ...,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
+    frozen: bool = ...,
+    builds_bases: Tuple[()] = ...,
 ) -> Union[FullBuilds, PBuilds, StdBuilds]:  # pragma: no cover
     ...
 
@@ -102,9 +169,9 @@ def make_custom_builds_fn(
 def make_custom_builds_fn(
     *,
     zen_partial: bool = False,
+    populate_full_signature: bool = False,
     zen_wrappers: ZenWrappers[Callable[..., Any]] = tuple(),
     zen_meta: Optional[Mapping[str, Any]] = None,
-    populate_full_signature: bool = False,
     hydra_recursive: Optional[bool] = None,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = None,
     frozen: bool = False,

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -910,15 +910,17 @@ def check_partial_narrowing_full(builds_fn: FullBuilds, x: bool):
 
 
 def check_make_custom_builds_overloads(boolean: bool):
-    # partial = True
+    Parent = builds(int)
+
+    # Returns `StdBuilds`
     reveal_type(
-        make_custom_builds_fn(zen_partial=True, populate_full_signature=boolean),
-        expected_text="PBuilds",
+        make_custom_builds_fn(populate_full_signature=boolean, builds_bases=(Parent,)),
+        expected_text="StdBuilds",
     )
-    reveal_type(make_custom_builds_fn(zen_partial=True), expected_text="PBuilds")
+
     reveal_type(
-        make_custom_builds_fn(zen_partial=True, populate_full_signature=False),
-        expected_text="PBuilds",
+        make_custom_builds_fn(builds_bases=(Parent,)),
+        expected_text="StdBuilds",
     )
 
     # partial = False, pop-sig = False
@@ -929,12 +931,30 @@ def check_make_custom_builds_overloads(boolean: bool):
         expected_text="StdBuilds",
     )
 
+    # Returns `PBuilds`
+    reveal_type(
+        make_custom_builds_fn(zen_partial=True, populate_full_signature=boolean),
+        expected_text="PBuilds",
+    )
+    reveal_type(make_custom_builds_fn(zen_partial=True), expected_text="PBuilds")
+    reveal_type(
+        make_custom_builds_fn(zen_partial=True, populate_full_signature=False),
+        expected_text="PBuilds",
+    )
+
+    reveal_type(
+        make_custom_builds_fn(
+            zen_partial=True, populate_full_signature=False, builds_bases=(Parent,)
+        ),
+        expected_text="PBuilds",
+    )
+
+    # Returns `PBuilds | StdBuilds``
     reveal_type(
         make_custom_builds_fn(zen_partial=False, populate_full_signature=boolean),
         expected_text="FullBuilds | StdBuilds",
     )
 
-    # partial = bool
     reveal_type(
         make_custom_builds_fn(zen_partial=boolean),
         expected_text="PBuilds | StdBuilds",
@@ -944,19 +964,6 @@ def check_make_custom_builds_overloads(boolean: bool):
         make_custom_builds_fn(populate_full_signature=False, zen_partial=boolean),
         expected_text="PBuilds | StdBuilds",
     )
-
-    Parent = builds(int)
-
-    reveal_type(
-        make_custom_builds_fn(populate_full_signature=True, zen_partial=boolean),
-        expected_text="FullBuilds | PBuilds | StdBuilds",
-    )
-
-    reveal_type(
-        make_custom_builds_fn(populate_full_signature=boolean, zen_partial=boolean),
-        expected_text="FullBuilds | PBuilds | StdBuilds",
-    )
-
     reveal_type(
         make_custom_builds_fn(
             populate_full_signature=True, zen_partial=boolean, builds_bases=(Parent,)
@@ -969,4 +976,20 @@ def check_make_custom_builds_overloads(boolean: bool):
             populate_full_signature=boolean, zen_partial=boolean, builds_bases=(Parent,)
         ),
         expected_text="PBuilds | StdBuilds",
+    )
+
+    reveal_type(
+        make_custom_builds_fn(zen_partial=boolean, builds_bases=(Parent,)),
+        expected_text="PBuilds | StdBuilds",
+    )
+
+    # Returns `FullBuilds | PBuilds | StdBuilds`
+    reveal_type(
+        make_custom_builds_fn(populate_full_signature=True, zen_partial=boolean),
+        expected_text="FullBuilds | PBuilds | StdBuilds",
+    )
+
+    reveal_type(
+        make_custom_builds_fn(populate_full_signature=boolean, zen_partial=boolean),
+        expected_text="FullBuilds | PBuilds | StdBuilds",
     )

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -907,3 +907,66 @@ def check_partial_narrowing_full(builds_fn: FullBuilds, x: bool):
     yes_full_sig = builds_fn(f, zen_partial=x)
     # can't have full-sig
     yes_full_sig()  # type: ignore
+
+
+def check_make_custom_builds_overloads(boolean: bool):
+    # partial = True
+    reveal_type(
+        make_custom_builds_fn(zen_partial=True, populate_full_signature=boolean),
+        expected_text="PBuilds",
+    )
+    reveal_type(make_custom_builds_fn(zen_partial=True), expected_text="PBuilds")
+    reveal_type(
+        make_custom_builds_fn(zen_partial=True, populate_full_signature=False),
+        expected_text="PBuilds",
+    )
+
+    # partial = False, pop-sig = False
+    reveal_type(make_custom_builds_fn(zen_partial=False), expected_text="StdBuilds")
+
+    reveal_type(
+        make_custom_builds_fn(zen_partial=False, populate_full_signature=False),
+        expected_text="StdBuilds",
+    )
+
+    reveal_type(
+        make_custom_builds_fn(zen_partial=False, populate_full_signature=boolean),
+        expected_text="FullBuilds | StdBuilds",
+    )
+
+    # partial = bool
+    reveal_type(
+        make_custom_builds_fn(zen_partial=boolean),
+        expected_text="PBuilds | StdBuilds",
+    )
+
+    reveal_type(
+        make_custom_builds_fn(populate_full_signature=False, zen_partial=boolean),
+        expected_text="PBuilds | StdBuilds",
+    )
+
+    Parent = builds(int)
+
+    reveal_type(
+        make_custom_builds_fn(populate_full_signature=True, zen_partial=boolean),
+        expected_text="FullBuilds | PBuilds | StdBuilds",
+    )
+
+    reveal_type(
+        make_custom_builds_fn(populate_full_signature=boolean, zen_partial=boolean),
+        expected_text="FullBuilds | PBuilds | StdBuilds",
+    )
+
+    reveal_type(
+        make_custom_builds_fn(
+            populate_full_signature=True, zen_partial=boolean, builds_bases=(Parent,)
+        ),
+        expected_text="PBuilds | StdBuilds",
+    )
+
+    reveal_type(
+        make_custom_builds_fn(
+            populate_full_signature=boolean, zen_partial=boolean, builds_bases=(Parent,)
+        ),
+        expected_text="PBuilds | StdBuilds",
+    )


### PR DESCRIPTION
Overloads now handle bool-type inputs; previously only `Literal[True/False])` were handled properly. 

Added much more complete type tests. Confirmed manually that `mypy` parses the overloads correctly too