### PR TITLE
Extend the functionality of `just` to work with all Hydra/hydra-zen supported types

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,7 +41,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install pyright
-      run: sudo npm install -g pyright@"==1.1.231"
+      run: sudo npm install -g pyright@">1.1.232"
     - uses: actions/checkout@v1
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -182,7 +182,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install pyright
-      run: sudo npm install -g pyright@"==1.1.231"
+      run: sudo npm install -g pyright@">1.1.232"
     - uses: actions/checkout@v1
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -26,6 +26,7 @@ from typing import IO, Any, Callable, Type, TypeVar, Union, overload
 from hydra.utils import instantiate as hydra_instantiate
 from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
 
+from .structured_configs._value_conversion import ConfigComplex, ConfigPath
 from .typing import Builds, Just, Partial
 from .typing._implementations import DataClass_, HasTarget, InstOrType, IsPartial
 
@@ -33,6 +34,20 @@ __all__ = ["instantiate", "to_yaml", "save_as_yaml", "load_from_yaml", "MISSING"
 
 
 T = TypeVar("T")
+
+
+@overload
+def instantiate(
+    config: InstOrType[ConfigPath], *args: Any, **kwargs: Any
+) -> pathlib.Path:  # pragma: no cover
+    ...
+
+
+@overload
+def instantiate(
+    config: InstOrType[ConfigComplex], *args: Any, **kwargs: Any
+) -> complex:  # pragma: no cover
+    ...
 
 
 @overload

--- a/src/hydra_zen/structured_configs/__init__.py
+++ b/src/hydra_zen/structured_configs/__init__.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
-from ._implementations import builds, hydrated_dataclass, just, mutable_value
+from ._implementations import builds, hydrated_dataclass, mutable_value
+from ._just import just
 from ._make_config import ZenField, make_config
 from ._make_custom_builds import make_custom_builds_fn
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -375,12 +375,7 @@ def hydrated_dataclass(
 
 
 def _just(obj: Importable) -> Type[Just[Importable]]:
-    try:
-        obj_path = _utils.get_obj_path(obj)
-    except AttributeError:
-        raise AttributeError(
-            f"`just({obj})`: `obj` is not importable; it is missing the attributes `__module__` and/or `__qualname__`"
-        )
+    obj_path = _utils.get_obj_path(obj)
 
     entry: List[Tuple[Any, Any, Field[Any]]] = [
         (

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -414,13 +414,12 @@ def _is_ufunc(value: Any) -> bool:
     return isinstance(value, numpy.ufunc)
 
 
-def _is_jax_compiled_func(value: Any) -> bool:
-    # checks without importing jaxlic
+def _is_jax_compiled_func(value: Any) -> bool:  # pragma: no cover
+    # we don't require jax to be installed for our coverage metrics
 
+    # checks without importing jaxlib
     jaxlib_xla_extension = sys.modules.get("jaxlib.xla_extension")
-    if jaxlib_xla_extension is None:  # pragma: no cover
-        # we do actually cover this branch some runs of our CI,
-        # but our coverage job installs numpy
+    if jaxlib_xla_extension is None:
         return False
     try:
         CompiledFunction = getattr(jaxlib_xla_extension, "CompiledFunction")

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -419,7 +419,7 @@ def _is_ufunc(value: Any) -> bool:
     return isinstance(value, numpy.ufunc)
 
 
-@functools.lru_cache
+@functools.lru_cache(maxsize=128)
 def _throwaway():  # pragma: no cover
     pass
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -420,7 +420,7 @@ def _is_ufunc(value: Any) -> bool:
 
 
 @functools.lru_cache
-def _throwaway():
+def _throwaway():  # pragma: no cover
     pass
 
 

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -44,13 +44,11 @@ def just(obj: Importable) -> Type[Just[Importable]]:
 def just(obj: Any) -> Any:
     """Returns a structured config that "just" describes the specified value.
 
-    ``obj`` must have a type either supported natively by Hydra, in which case
-    it will be return unchanged, or a type that hydra-zen provides extended
-    support for. See "Notes" for a list of supported types.
-
     Parameters
     ----------
-    obj : HydraSupportedPrimitive | ZenSupportedPrimitive
+    obj : Type | Callable[..., Any] HydraSupportedPrimitive | ZenSupportedPrimitive
+        A type (e.g. a class-object), function-object, or a value of a type that is
+        supported by either  hydra-zen or Hydra.
 
     Returns
     -------

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -43,6 +43,11 @@ def just(obj: Importable) -> Type[Just[Importable]]:  # pragma: no cover
     ...
 
 
+@overload
+def just(obj: Any) -> Any:  # pragma: no cover
+    ...
+
+
 def just(obj: Any) -> Any:
     """Returns a structured config that "just" describes the specified value.
 

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2022 Massachusetts Institute of Technology
+# SPDX-License-Identifier: MIT
 from pathlib import Path
 from typing import Any, FrozenSet, Type, TypeVar, Union, overload
 

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -2,10 +2,8 @@ from pathlib import Path
 from typing import Any, FrozenSet, Type, TypeVar, Union, overload
 
 from hydra_zen.typing import Builds, Importable, Just
-from hydra_zen.typing._implementations import (  # type: ignore
-    _HydraPrimitive,
-    _SupportedViaBuilds,
-)
+from hydra_zen.typing._implementations import _HydraPrimitive  # type: ignore
+from hydra_zen.typing._implementations import _SupportedViaBuilds  # type: ignore
 
 from ._implementations import sanitized_default_value
 from ._value_conversion import ConfigComplex, ConfigPath

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -37,7 +37,7 @@ def just(obj: TB) -> Builds[Type[TB]]:  # pragma: no cover
 
 
 @overload
-def just(obj: Importable) -> Type[Just[Importable]]:
+def just(obj: Importable) -> Type[Just[Importable]]:  # pragma: no cover
     ...
 
 

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -1,0 +1,171 @@
+from pathlib import Path
+from typing import Any, FrozenSet, Type, TypeVar, Union, overload
+
+from hydra_zen.typing import Builds, Importable, Just
+from hydra_zen.typing._implementations import (  # type: ignore
+    _HydraPrimitive,
+    _SupportedViaBuilds,
+)
+
+from ._implementations import sanitized_default_value
+from ._value_conversion import ConfigComplex, ConfigPath
+
+# pyright: strict
+
+TP = TypeVar("TP", bound=_HydraPrimitive)
+TB = TypeVar("TB", bound=Union[_SupportedViaBuilds, FrozenSet[Any]])
+
+__all__ = ["just"]
+
+
+@overload
+def just(obj: TP) -> TP:  # pragma: no cover
+    ...
+
+
+@overload
+def just(obj: complex) -> ConfigComplex:  # pragma: no cover
+    ...
+
+
+@overload
+def just(obj: Path) -> ConfigPath:  # pragma: no cover
+    ...
+
+
+@overload
+def just(obj: TB) -> Builds[Type[TB]]:  # pragma: no cover
+    ...
+
+
+@overload
+def just(obj: Importable) -> Type[Just[Importable]]:
+    ...
+
+
+def just(obj: Any) -> Any:
+    """Returns a structured config that "just" describes the specified value.
+
+    ``obj`` must have a type either supported natively by Hydra, in which case
+    it will be return unchanged, or a type that hydra-zen provides extended
+    support for. See "Notes" for a list of supported types.
+
+    Parameters
+    ----------
+    obj : HydraSupportedPrimitive | ZenSupportedPrimitive
+
+    Returns
+    -------
+    config : HydraSupportedPrimitive | Builds
+        A structured config that describes ``obj``.
+
+    Raises
+    ------
+    hydra_zen.errors.HydraZenUnsupportedPrimitiveError
+
+    See Also
+    --------
+    builds : Create a targeted structured config designed to "build" a particular object.
+    make_config: Creates a general config with customized field names, default values, and annotations.
+
+    Notes
+    -----
+    The configs produced by ``just(<type_or_func>)`` introduce an explicit dependency
+    on hydra-zen. I.e. hydra-zen must be installed in order to instantiate any config
+    that used `just`.
+
+    hydra-zen provides specialized support for values of the following types:
+
+    - :py:class:`bytes`
+    - :py:class:`bytearray`
+    - :py:class:`complex`
+    - :py:class:`collections.Counter`
+    - :py:class:`collections.deque`
+    - :py:func:`functools.partial`
+    - :py:class:`pathlib.Path`
+    - :py:class:`pathlib.PosixPath`
+    - :py:class:`pathlib.WindowsPath`
+    - :py:class:`range`
+    - :py:class:`set`
+    - :py:class:`frozenset`
+
+    Examples
+    --------
+    **Basic usage**
+
+    >>> from hydra_zen import just, instantiate, to_yaml
+
+    Calling ``just`` on a type or function object will create a structured config
+    that, when instantiated, returns that object.
+
+    >>> class A: pass
+    >>> Conf_A = just(A)  # returns a dataclass-type
+    >>> instantiate(Conf_A) is A
+    True
+
+    >>> def my_func(x: int): pass
+    >>> Conf_func = just(my_func)  # returns a dataclass-type
+    >>> instantiate(Conf_func) is my_funct
+    True
+
+
+    Calling ``just`` on a value of a type that is natively supported by Hydra
+    will reurn that value unchanged
+
+    >>> just(1)
+    1
+    >>> just(False)
+    False
+
+    Calling ``just`` on a value of a type that has special support from hydra-zen
+    will return a structured config instance that, when instantiated, returns that
+    value
+
+    >>> just(1+2j)
+    ConfigComplex(real=1.0, imag=2.0, _target_='builtins.complex')
+
+    >>> instantiate(just(1+2j))
+    (1+2j)
+
+    >>> just({1, 2, 3})
+    Builds_set(_target_='builtins.set', _args_=((1, 2, 3),))
+
+    >>> instantiate(just({1, 2, 3})
+    {1, 2, 3}
+
+    The config produced by `just` describes how to import the target,
+    not how to instantiate/call the object.
+
+    >>> print(to_yaml(Conf))
+    _target_: hydra_zen.funcs.get_obj
+    path: builtins.range
+
+    **Auto-Application of just**
+
+    Both `builds` and `make_config` will automatically apply `just` to default values
+    that are function-objects or class objects. E.g. in the following example `just`
+    will be applied to ``sum``.
+
+    >>> from hydra_zen import make_config
+    >>> Conf2 = make_config(data=[1, 2, 3], reduction_fn=sum)
+
+    >>> print(to_yaml(Conf2))
+    data:
+    - 1
+    - 2
+    - 3
+    reduction_fn:
+      _target_: hydra_zen.funcs.get_obj
+      path: builtins.sum
+
+    >>> conf = instantiate(Conf2)
+    >>> conf.reduction_fn(conf.data)
+    6
+    """
+    return sanitized_default_value(
+        obj,
+        allow_zen_conversion=True,
+        structured_conf_permitted=True,
+        field_name="",
+        error_prefix="",
+    )

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -134,7 +134,7 @@ def just(obj: Any) -> Any:
     ``just`` operates recursively within sequences and mappings.
 
     >>> just({'a': [3-4j, 1+2j]})
-    a': [ConfigComplex(real=3.0, imag=-4.0, _target_='builtins.complex'),
+    'a': [ConfigComplex(real=3.0, imag=-4.0, _target_='builtins.complex'),
          ConfigComplex(real=1.0, imag=2.0, _target_='builtins.complex')]}
 
     **Auto-Application of just**

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -133,7 +133,7 @@ def just(obj: Any) -> Any:
 
     ``just`` operates recursively within sequences and mappings.
 
-    >>> just({'a':[3-4j, 1+2j]})
+    >>> just({'a': [3-4j, 1+2j]})
     a': [ConfigComplex(real=3.0, imag=-4.0, _target_='builtins.complex'),
          ConfigComplex(real=1.0, imag=2.0, _target_='builtins.complex')]}
 

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -131,34 +131,36 @@ def just(obj: Any) -> Any:
     >>> instantiate(just({1, 2, 3})
     {1, 2, 3}
 
-    The config produced by `just` describes how to import the target,
-    not how to instantiate/call the object.
+    ``just`` operates recursively within sequences and mappings.
 
-    >>> print(to_yaml(Conf))
-    _target_: hydra_zen.funcs.get_obj
-    path: builtins.range
+    >>> just({'a':[3-4j, 1+2j]})
+    a': [ConfigComplex(real=3.0, imag=-4.0, _target_='builtins.complex'),
+         ConfigComplex(real=1.0, imag=2.0, _target_='builtins.complex')]}
 
     **Auto-Application of just**
 
-    Both `builds` and `make_config` will automatically apply `just` to default values
-    that are function-objects or class objects. E.g. in the following example `just`
-    will be applied to ``sum``.
+    Both ``builds`` and ``make_config`` will automatically (and recursively) apply
+    ``just`` to all configured values. E.g. in the following example `just` will be
+    applied to both  the complex-valued the list and to ``sum``.
 
     >>> from hydra_zen import make_config
-    >>> Conf2 = make_config(data=[1, 2, 3], reduction_fn=sum)
+    >>> Conf2 = make_config(data=[1+2j, 2+3j], reduction_fn=sum)
 
     >>> print(to_yaml(Conf2))
     data:
-    - 1
-    - 2
-    - 3
+    - real: 1.0
+      imag: 2.0
+      _target_: builtins.complex
+    - real: 2.0
+      imag: 3.0
+      _target_: builtins.complex
     reduction_fn:
       _target_: hydra_zen.funcs.get_obj
       path: builtins.sum
 
     >>> conf = instantiate(Conf2)
     >>> conf.reduction_fn(conf.data)
-    6
+    (3+5j)
     """
     return sanitized_default_value(
         obj,

--- a/src/hydra_zen/structured_configs/_value_conversion.py
+++ b/src/hydra_zen/structured_configs/_value_conversion.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path, PosixPath, WindowsPath
-from typing import Any, Callable, Dict, Type, cast
+from typing import Any, Callable, Dict, Tuple, Type, cast
 
 from hydra_zen.typing import Builds
 
@@ -17,7 +17,7 @@ ZEN_VALUE_CONVERSION: Dict[type, Callable[[Any], Any]] = {}
 class ConfigComplex:
     real: Any
     imag: Any
-    _target_: str = get_obj_path(complex)
+    _target_: str = field(default=get_obj_path(complex), init=False)
 
 
 def convert_complex(value: complex) -> Builds[Type[complex]]:
@@ -29,8 +29,8 @@ ZEN_VALUE_CONVERSION[complex] = convert_complex
 
 @dataclass
 class ConfigPath:
-    _args_: Any
-    _target_: str = get_obj_path(Path)
+    _args_: Tuple[str]
+    _target_: str = field(default=get_obj_path(Path), init=False)
 
 
 def convert_path(value: Path) -> Builds[Type[Path]]:

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    ByteString,
     Callable,
     ClassVar,
     Dict,
@@ -183,6 +184,12 @@ _HydraPrimitive: TypeAlias = Union[
     str,
 ]
 
+_SupportedViaBuilds = Union[
+    Partial[Any],
+    range,
+    Set[Any],
+    ByteString,
+]
 
 _SupportedPrimitive: TypeAlias = Union[
     _HydraPrimitive,
@@ -193,10 +200,8 @@ _SupportedPrimitive: TypeAlias = Union[
     DataClass_,
     complex,
     Path,
-    Partial[Any],
-    range,
-    Set[Any],
-    EmptyDict,  # not covered by Mapping[..., ...]
+    _SupportedViaBuilds,
+    EmptyDict,  # not covered by Mapping[..., ...]]
 ]
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
+import functools
 from typing import Any
 
 import hypothesis.strategies as st
@@ -21,7 +22,15 @@ def everything_except(*excluded_types: type):
     )
 
 
-def check_identity(new, original):
+def is_same(new, original):
+    if isinstance(original, functools.partial):
+        if not isinstance(new, functools.partial):
+            return False
+        return (
+            new.args == original.args
+            and new.keywords == original.keywords
+            and new.func is original.func
+        )
     if not is_classmethod(original):
         return new is original
     # objects like classmethods do not satisfy `x is x`

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -129,8 +129,6 @@ def check_just():
     class A:
         ...
 
-    just(A())  # type: ignore
-
     # test just(...)
     reveal_type(just(f), expected_text="Type[Just[(x: int) -> int]]")
     reveal_type(just(A), expected_text="Type[Just[Type[A]]]")

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -122,13 +122,34 @@ def f4():
     reveal_type(instantiate(conf_f_2), expected_text="int")
 
 
-def f5():
+def check_just():
+    def f(x: int) -> int:
+        return x
+
+    class A:
+        ...
+
+    just(A())  # type: ignore
+
     # test just(...)
     reveal_type(just(f), expected_text="Type[Just[(x: int) -> int]]")
     reveal_type(just(A), expected_text="Type[Just[Type[A]]]")
     reveal_type(instantiate(just(f)), expected_text="(x: int) -> int")
     reveal_type(instantiate(just(A)), expected_text="Type[A]")
     reveal_type(instantiate(just(A)()), expected_text="Type[A]")  # instance of Just
+
+    reveal_type(just(1), expected_text="int")
+    reveal_type(just("hi"), expected_text="str")
+    reveal_type(just(1 + 2j), expected_text="ConfigComplex")
+    reveal_type(just(Path.home()), expected_text="ConfigPath")
+    reveal_type(just(partial(f, 1)), expected_text="Type[Just[partial[int]]]")
+    reveal_type(just(set([1, 2, 3])), expected_text="Builds[Type[set[int]]]")
+    reveal_type(just(b"1234"), expected_text="Builds[Type[bytes]]")
+    reveal_type(just(range(10)), expected_text="Builds[Type[range]]")
+
+    partiald_f = instantiate(just(partial(f, 1)))
+    reveal_type(partiald_f, expected_text="partial[int]")
+    reveal_type(partiald_f(), expected_text="int")
 
 
 @dataclass
@@ -858,7 +879,7 @@ def check_hydra_target_pos_only(partial_builds: PBuilds, full_builds: FullBuilds
 
 def check_partial_narrowing_builds(x: bool):
     def f(x: int):
-        1
+        return 1
 
     maybe_full_sig = builds(f, zen_partial=x, populate_full_signature=x)
     # could have full-sig; should raise
@@ -877,7 +898,7 @@ def check_partial_narrowing_std_and_partial(
     builds_fn: Union[StdBuilds, PBuilds], x: bool
 ):
     def f(x: int):
-        1
+        return 1
 
     maybe_full_sig = builds_fn(f, zen_partial=x, populate_full_signature=x)
     # could have full-sig; should raise
@@ -894,7 +915,7 @@ def check_partial_narrowing_std_and_partial(
 
 def check_partial_narrowing_full(builds_fn: FullBuilds, x: bool):
     def f(x: int):
-        1
+        return 1
 
     maybe_full_sig = builds_fn(f, zen_partial=x, populate_full_signature=x)
     # could have full-sig; should raise

--- a/tests/test_just.py
+++ b/tests/test_just.py
@@ -17,7 +17,7 @@ def f(x: int):
     pass
 
 
-@functools.lru_cache
+@functools.lru_cache(maxsize=None)
 def func_with_cache(x: int):
     pass
 

--- a/tests/test_just.py
+++ b/tests/test_just.py
@@ -1,0 +1,46 @@
+import functools
+from pathlib import Path
+
+import pytest
+
+from hydra_zen import instantiate, just
+from tests import is_same
+
+
+class A:
+    @classmethod
+    def class_method(cls):
+        pass
+
+
+def f(x: int):
+    pass
+
+
+@functools.lru_cache
+def func_with_cache(x: int):
+    pass
+
+
+# this function is tested more rigorously via test_value_conversion
+@pytest.mark.parametrize(
+    "obj",
+    [
+        b"123",
+        bytearray([1, 2, 3]),
+        1 + 2j,
+        Path.cwd(),
+        A,
+        f,
+        func_with_cache,
+        A.class_method,
+        functools.partial(f, x=1),
+    ],
+)
+def test_just_roundtrip(obj):
+    out = instantiate(just(obj))
+
+    if callable(out):
+        assert is_same(out, obj)
+    else:
+        assert out == obj

--- a/tests/test_roundtrips.py
+++ b/tests/test_roundtrips.py
@@ -19,8 +19,8 @@ from hypothesis import given
 from omegaconf import OmegaConf
 
 from hydra_zen import builds, get_target, instantiate, just, to_yaml
-from hydra_zen.structured_configs._utils import is_classmethod
-from tests import check_identity, valid_hydra_literals
+from hydra_zen.structured_configs._type_guards import is_builds
+from tests import is_same, valid_hydra_literals
 
 arbitrary_kwargs = st.dictionaries(
     keys=st.text(alphabet=string.ascii_letters, min_size=1, max_size=1),
@@ -166,8 +166,8 @@ def with_eq(x, y):
 def test_just_roundtrip(obj):
     # local classmethods have weird identity behaviors
     cfg = just(obj)
-    assert check_identity(instantiate(cfg), obj)
-    assert check_identity(instantiate(OmegaConf.create(to_yaml(cfg))), obj)
+    assert is_same(instantiate(cfg), obj)
+    assert is_same(instantiate(OmegaConf.create(to_yaml(cfg))), obj)
 
 
 @pytest.mark.parametrize("x", a_bunch_of_objects)
@@ -183,10 +183,11 @@ def test_just_roundtrip(obj):
 )
 def test_get_target_roundtrip(x, fn):
     conf = fn(x)
-    assert check_identity(x, get_target(conf))
+    assert is_same(x, get_target(conf))
 
     loaded = OmegaConf.create(to_yaml(conf))
-    assert check_identity(x, get_target(loaded))
+    assert is_builds(loaded)
+    assert is_same(x, get_target(loaded))
 
 
 @dataclass

--- a/tests/test_roundtrips.py
+++ b/tests/test_roundtrips.py
@@ -197,3 +197,8 @@ class A:
 
 def test_get_target_with_non_string_target():
     assert get_target(A) is int
+
+
+def test_recursive_just():
+    x = {"a": [3 - 4j, 1 + 2j]}
+    assert instantiate(just(x)) == x

--- a/tests/test_third_party/test_against_torch.py
+++ b/tests/test_third_party/test_against_torch.py
@@ -35,14 +35,14 @@ torch_objects = [
     tr.autograd.functional.jacobian,
     tr.cuda.current_device,
     tr.cuda.device_count,
-    tr.backends.cuda.is_built,
-    tr.distributed.is_available,
+    tr.backends.cuda.is_built,  # type: ignore
+    tr.distributed.is_available,  # type: ignore
     tr.distributions.bernoulli.Bernoulli,
     tr.fft.fft,
-    tr.jit.script,
+    tr.jit.script,  # type: ignore
     tr.linalg.cholesky,
-    tr.overrides.get_ignored_functions,
-    tr.profiler.profile,
+    tr.overrides.get_ignored_functions,  # type: ignore
+    tr.profiler.profile,  # type: ignore
     DataLoader,
 ]
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -18,6 +18,7 @@ from hydra_zen.structured_configs._globals import (
     HYDRA_FIELD_NAMES,
     ZEN_TARGET_FIELD_NAME,
 )
+from hydra_zen.structured_configs._utils import get_obj_path
 from tests import everything_except
 
 
@@ -435,3 +436,8 @@ def test_meta_fields_colliding_with_user_provided_kwargs_raises(
             builds(dict, x=1, y=2, zen_meta=meta_fields, zen_partial=partial)
     else:
         builds(dict, x=1, y=2, zen_meta=meta_fields, zen_partial=partial)
+
+
+def test_get_obj_path_raises_for_unknown_name():
+    with pytest.raises(AttributeError):
+        get_obj_path(1)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -13,6 +13,7 @@ from hypothesis import assume, given, settings
 from omegaconf import OmegaConf
 
 from hydra_zen import builds, get_target, hydrated_dataclass, instantiate, just, to_yaml
+from hydra_zen.errors import HydraZenUnsupportedPrimitiveError
 from hydra_zen.structured_configs._globals import (
     HYDRA_FIELD_NAMES,
     ZEN_TARGET_FIELD_NAME,
@@ -331,9 +332,8 @@ def test_builds_input_validation(param_name: str, value):
 
 
 def test_just_raises_with_legible_message():
-    with pytest.raises(AttributeError) as exec_info:
-        just(1)  # type: ignore
-    assert "just(1)" in str(exec_info.value)
+    with pytest.raises(HydraZenUnsupportedPrimitiveError):
+        just(Class())  # type: ignore
 
 
 def test_hydrated_dataclass_from_instance_raise():


### PR DESCRIPTION
Closes #201 


hydra-zen can [automatically construct targeted configs for values of certain types](https://mit-ll-responsible-ai.github.io/hydra-zen/api_reference.html#additional-types-supported-via-hydra-zen).

E.g.

```python
>>> from hydra_zen import make_config, to_yaml
>>> Conf = make_config(value=2.0 + 3.0j)
>>> print(to_yaml(Conf))
value:
  real: 2.0
  imag: 3.0
  _target_: builtins.complex
```

Prior to this PR, this functionality could only be leveraged indirectly, via `builds` and `make_config`. Now, `just` can directly convert values to corresponding structured config instances. E.g.

```python
>>> from hydra_zen import just
>>> just(1+2j)
ConfigComplex(real=1.0, imag=2.0, _target_='builtins.complex')
```

`just` operates recursively within sequences and mappings.

```python
>>> just({'a': [3-4j, 1+2j]})
'a': [ConfigComplex(real=3.0, imag=-4.0, _target_='builtins.complex'),
     ConfigComplex(real=1.0, imag=2.0, _target_='builtins.complex')]}
```

## Future improvements
- Enable users to register their own converters for "pickling" values of a custom type to a structured config.
- Improve annotations for `just` to be less permissive.