### PR TITLE
fix instantiate overloads for Any

### DIFF
--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -40,6 +40,17 @@ T = TypeVar("T")
 F = TypeVar("F", bound=Callable[..., Any])
 
 
+class _TightBind:  # pragma: no cover
+    ...
+
+
+@overload
+def instantiate(
+    config: _TightBind, *args: Any, **kwargs: Any
+) -> Any:  # pragma: no cover
+    ...
+
+
 @overload
 def instantiate(
     config: InstOrType[ConfigPath], *args: Any, **kwargs: Any

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -33,6 +33,7 @@ from hydra_zen import (
     make_custom_builds_fn,
     mutable_value,
 )
+from hydra_zen.structured_configs._value_conversion import ConfigComplex, ConfigPath
 from hydra_zen.typing import (
     Builds,
     HydraPartialBuilds,
@@ -1012,3 +1013,12 @@ def check_make_custom_builds_overloads(boolean: bool):
         make_custom_builds_fn(populate_full_signature=boolean, zen_partial=boolean),
         expected_text="FullBuilds | PBuilds | StdBuilds",
     )
+
+
+def check_instantiate_overrides(
+    any_: Any, complex_: ConfigComplex, path_: ConfigPath, dataclass_: DataClass_
+):
+    reveal_type(instantiate(any_), expected_text="Any")
+    reveal_type(instantiate(complex_), expected_text="complex")
+    reveal_type(instantiate(path_), expected_text="Path")
+    reveal_type(instantiate(dataclass_), expected_text="Any")


### PR DESCRIPTION
Fixes:

```python
x: Any
instantiate(x)  # type: Path
```

(Didn't realize that `Any` "tight binds" like that...)