### PR TITLE
Deprecates `builds_bases` via `make_custom_builds`

### DIFF
--- a/src/hydra_zen/structured_configs/_make_custom_builds.py
+++ b/src/hydra_zen/structured_configs/_make_custom_builds.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 # pyright: strict
 import inspect
+import warnings
 from functools import wraps
 from typing import (
     Any,
@@ -18,6 +19,7 @@ from typing import (
 
 from typing_extensions import Final, Literal
 
+from hydra_zen.errors import HydraZenDeprecationWarning
 from hydra_zen.typing import ZenWrappers
 from hydra_zen.typing._builds_overloads import FullBuilds, PBuilds, StdBuilds
 from hydra_zen.typing._implementations import DataClass_
@@ -280,6 +282,16 @@ def make_custom_builds_fn(
 
     # let `builds` validate the new defaults!
     builds(builds, **_new_defaults)
+
+    if _new_defaults["builds_bases"]:
+        warnings.warn(
+            HydraZenDeprecationWarning(
+                "Specifying `make_custom_builds_fn(builds_bases=<...>)` is deprecated "
+                "as of hydra-zen 0.7.0. It will be an error in hydra-zen 0.8.0. "
+                "\n`builds_bases` must be specified via `builds` manually."
+            ),
+            stacklevel=2,
+        )
 
     @wraps(builds)
     def wrapped(*args: Any, **kwargs: Any):

--- a/tests/test_make_custom_builds_fn.py
+++ b/tests/test_make_custom_builds_fn.py
@@ -6,6 +6,7 @@ import pytest
 from hypothesis import assume, example, given
 
 from hydra_zen import builds, make_custom_builds_fn, to_yaml
+from hydra_zen.errors import HydraZenDeprecationWarning
 from tests.custom_strategies import partitions, valid_builds_args
 
 _builds_sig = inspect.signature(builds)
@@ -83,3 +84,8 @@ def test_make_builds_fn_produces_builds_with_expected_defaults_and_behaviors(
     # this should be the same as passing all of these args directly to vanilla builds
     via_builds = builds(target, **kwargs_passed_through, **kwargs_as_defaults)
     assert to_yaml(via_custom) == to_yaml(via_builds)
+
+
+def test_builds_bases_deprecation():
+    with pytest.warns(HydraZenDeprecationWarning):
+        make_custom_builds_fn(builds_bases=((builds(int),)))


### PR DESCRIPTION
Exposing `builds_bases` via `make_custom_builds` makes our annotation overloads substantially more complicated. This is a rarely-used (maybe never!) feature. Thus this PR deprecates the `builds_bases` argument in `make_custom_builds`. It will be removed in hydra-zen v0.8.0. Users will need to specify `builds_bases` on a per-config basis. 