### PR TITLE
Updates to `launch`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ pip_pre = true
 deps = {[testenv]deps}
        pydantic
        beartype
+       cloudpickle
 basepython = python3.8
 
 [testenv:hydra-1p1p2-pre-release]  # test against pre-releases of dependencies
@@ -61,6 +62,7 @@ deps = hydra-core==1.1.2dev
        {[testenv]deps}
        pydantic
        beartype
+       cloudpickle
 basepython = python3.8
 
 [testenv:coverage]
@@ -74,6 +76,7 @@ deps = {[testenv]deps}
        numpy
        pydantic
        beartype
+       cloudpickle
 commands = pytest --cov-report term-missing --cov-config=setup.cfg --cov-fail-under=100 --cov=hydra_zen tests
 
 

--- a/src/hydra_zen/_launch.py
+++ b/src/hydra_zen/_launch.py
@@ -1,14 +1,15 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
-from pathlib import Path
+from dataclasses import fields, is_dataclass
 from typing import Any, Callable, List, Mapping, Optional, Type, Union
 
+from hydra import initialize
 from hydra._internal.callbacks import Callbacks
 from hydra._internal.hydra import Hydra
 from hydra._internal.utils import create_config_search_path
 from hydra.core.config_store import ConfigStore
 from hydra.core.global_hydra import GlobalHydra
-from hydra.core.utils import JobReturn
+from hydra.core.utils import JobReturn, run_job
 from hydra.plugins.sweeper import Sweeper
 from hydra.types import HydraContext, RunMode
 from omegaconf import DictConfig, OmegaConf
@@ -54,11 +55,11 @@ def launch(
     config: Union[DataClass, Type[DataClass], Mapping[str, Any]],
     task_function: Callable[[DictConfig], Any],
     overrides: Optional[List[str]] = None,
-    config_dir: Optional[Union[str, Path]] = None,
     config_name: str = "zen_launch",
     job_name: str = "zen_launch",
     with_log_configuration: bool = True,
     multirun: bool = False,
+    to_dictconfig: bool = False,
 ) -> Union[JobReturn, Any]:
     r"""Launch a Hydra job using a Python-based interface.
 
@@ -84,9 +85,6 @@ def launch(
         If provided, sets/overrides values in ``config``. See [1]_ and [2]_
         for a detailed discussion of the "grammar" supported by ``overrides``.
 
-    config_dir : Optional[Union[str, Path]]
-        The config path: a directory where Hydra will search for configs.
-
     config_name : str (default: "zen_launch")
         Name of the stored configuration in Hydra's ConfigStore API.
 
@@ -97,6 +95,10 @@ def launch(
 
     multirun : bool (default: False)
         Launch a Hydra multi-run ([3]_).
+
+    to_dictconfig: bool (default: False)
+        If ``True``, convert a ``dataclasses.dataclass`` to a ``omegaconf.DictConfig``. Note, this
+        will remove Hydra's cabability for validation with structured configurations.
 
     Returns
     -------
@@ -203,46 +205,76 @@ def launch(
     'multirun/2021-10-19/17-50-07\\1',
     'multirun/2021-10-19/17-50-07\\2']
     """
+
+    if is_dataclass(config):
+        if to_dictconfig:
+            # convert Dataclass to a DictConfig
+            cfg = OmegaConf.structured(config)
+            config = OmegaConf.create(OmegaConf.to_container(cfg))
+        else:
+            if len(fields(config)) == 0:
+                raise ValueError(
+                    """There is an issue with your dataclass.  If you previously executed with a
+                `hydra/launcher` that utilizes cloudpickle (e.g., hydra-submitit-launcher), there is a known
+                issue with dataclasses (see: https://github.com/cloudpipe/cloudpickle/issues/386). You will have
+                to restart your interactive environment.  To avoid this issue you can use the option `to_dictconfig=True`."""
+                )
+
+    # store config in ConfigStore
     config_name = _store_config(config, config_name)
 
-    if config_dir is not None:
-        config_dir = str(Path(config_dir).absolute())
-    search_path = create_config_search_path(config_dir)
+    # Initializes Hydra and add the config_path to the config search path
+    with initialize(config_path=None, job_name=job_name):
 
-    hydra = Hydra.create_main_hydra2(task_name=job_name, config_search_path=search_path)
-    try:
+        # taken from hydra.compose with support for MULTIRUN
+        gh = GlobalHydra.instance()
+        assert gh.hydra is not None
+
+        # Load configuration
+        cfg = gh.hydra.compose_config(
+            config_name=config_name,
+            overrides=overrides if overrides is not None else [],
+            run_mode=RunMode.RUN if not multirun else RunMode.MULTIRUN,
+            from_shell=False,
+            with_log_configuration=with_log_configuration,
+        )
+
         if not multirun:
-            # Here we can use Hydra's `run` method
-            job = hydra.run(
-                config_name=config_name,
+            # taken from Hydra.run without compose config
+            callbacks = Callbacks(cfg)
+            callbacks.on_run_start(config=cfg, config_name=config_name)
+
+            hydra_context = HydraContext(
+                config_loader=gh.config_loader(), callbacks=callbacks
+            )
+
+            job = run_job(
+                hydra_context=hydra_context,
                 task_function=task_function,
-                overrides=overrides if overrides is not None else [],
-                with_log_configuration=with_log_configuration,
+                config=cfg,
+                job_dir_key="hydra.run.dir",
+                job_subdir_key=None,
+                configure_logging=with_log_configuration,
             )
+            callbacks.on_run_end(config=cfg, config_name=config_name, job_return=job)
 
+            # access the result to trigger an exception in case the job failed.
+            _ = job.return_value
         else:
-            # Instead of running Hydra's `multirun` method we instantiate
-            # and run the sweeper method.  This allows us to run local
-            # sweepers and launchers without installing them in `hydra_plugins`
-            # package directory.
-            cfg = hydra.compose_config(
-                config_name=config_name,
-                overrides=overrides if overrides is not None else [],
-                with_log_configuration=with_log_configuration,
-                run_mode=RunMode.MULTIRUN,
-            )
-
+            # taken from Hydra.multirun without compose_config
             callbacks = Callbacks(cfg)
             callbacks.on_multirun_start(config=cfg, config_name=config_name)
+
+            hydra_context = HydraContext(
+                config_loader=gh.config_loader(), callbacks=callbacks
+            )
 
             # Instantiate sweeper without using Hydra's Plugin discovery (Zen!)
             sweeper = instantiate(cfg.hydra.sweeper)
             assert isinstance(sweeper, Sweeper)
             sweeper.setup(
                 config=cfg,
-                hydra_context=HydraContext(
-                    config_loader=hydra.config_loader, callbacks=callbacks
-                ),
+                hydra_context=hydra_context,
                 task_function=task_function,
             )
 
@@ -250,10 +282,7 @@ def launch(
                 cfg.hydra.overrides.task, resolve=False
             )
             assert isinstance(task_overrides, list)
-
             job = sweeper.sweep(arguments=task_overrides)
             callbacks.on_multirun_end(config=cfg, config_name=config_name)
 
-    finally:
-        GlobalHydra.instance().clear()
-    return job
+        return job

--- a/src/hydra_zen/_launch.py
+++ b/src/hydra_zen/_launch.py
@@ -6,21 +6,19 @@ from typing import Any, Callable, List, Mapping, Optional, Type, Union
 
 from hydra import initialize
 from hydra._internal.callbacks import Callbacks
-from hydra._internal.hydra import Hydra
-from hydra._internal.utils import create_config_search_path
 from hydra.core.config_store import ConfigStore
 from hydra.core.global_hydra import GlobalHydra
 from hydra.core.utils import JobReturn, run_job
 from hydra.plugins.sweeper import Sweeper
 from hydra.types import HydraContext, RunMode
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from hydra_zen._hydra_overloads import instantiate
 from hydra_zen.typing._implementations import DataClass
 
 
 def _store_config(
-    cfg: Union[DataClass, Type[DataClass], DictConfig, Mapping[Any, Any]],
+    cfg: Union[DataClass, Type[DataClass], DictConfig, ListConfig, Mapping[Any, Any]],
     config_name: str = "hydra_launch",
 ) -> str:
     """Stores configuration object in Hydra's ConfigStore.

--- a/src/hydra_zen/_launch.py
+++ b/src/hydra_zen/_launch.py
@@ -282,11 +282,11 @@ def launch(
             and _num_dataclass_fields_after < _num_dataclass_fields
         ):
             warnings.warn(
-                "There may ben an issue with your dataclass.  If you just executed with a "
+                "Your dataclass-based config was mutated by this run. If you just executed with a "
                 "`hydra/launcher` that utilizes cloudpickle (e.g., hydra-submitit-launcher), there is a known "
                 "issue with dataclasses (see: https://github.com/cloudpipe/cloudpickle/issues/386). You will have "
-                "to restart your interactive environment ro run `launch` again.  To avoid this issue you can use the option "
-                "`to_dictconfig=True`."
+                "to restart your interactive environment ro run `launch` again. To avoid this issue you can use the "
+                "`launch` option: `to_dictconfig=True`."
             )
 
     return job

--- a/src/hydra_zen/_launch.py
+++ b/src/hydra_zen/_launch.py
@@ -213,8 +213,9 @@ def launch(
     # store config in ConfigStore
     if to_dictconfig and is_dataclass(config):
         # convert Dataclass to a DictConfig
-        cfg = OmegaConf.structured(config)
-        dictconfig = OmegaConf.create(OmegaConf.to_container(cfg))
+        dictconfig = OmegaConf.create(
+            OmegaConf.to_container(OmegaConf.structured(config))
+        )
         config_name = _store_config(dictconfig, config_name)
     else:
         config_name = _store_config(config, config_name)

--- a/src/hydra_zen/_launch.py
+++ b/src/hydra_zen/_launch.py
@@ -283,10 +283,10 @@ def launch(
         ):
             warnings.warn(
                 "There may ben an issue with your dataclass.  If you just executed with a "
-                + "`hydra/launcher` that utilizes cloudpickle (e.g., hydra-submitit-launcher), there is a known "
-                + "issue with dataclasses (see: https://github.com/cloudpipe/cloudpickle/issues/386). You will have "
-                + "to restart your interactive environment ro run `launch` again.  To avoid this issue you can use the option "
-                + "`to_dictconfig=True`."
+                "`hydra/launcher` that utilizes cloudpickle (e.g., hydra-submitit-launcher), there is a known "
+                "issue with dataclasses (see: https://github.com/cloudpipe/cloudpickle/issues/386). You will have "
+                "to restart your interactive environment ro run `launch` again.  To avoid this issue you can use the option "
+                "`to_dictconfig=True`."
             )
 
     return job

--- a/tests/test_launch/test_implementations.py
+++ b/tests/test_launch/test_implementations.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path
-from typing import Final
 
 import pytest
 from hydra.core.config_store import ConfigStore

--- a/tests/test_launch/test_implementations.py
+++ b/tests/test_launch/test_implementations.py
@@ -77,10 +77,6 @@ def test_launch_to_dictconfig(cfg, to_dictconfig):
             assert len(dataclasses.fields(cfg)) == 0
         else:
             assert len(dataclasses.fields(cfg)) > 0
-
-        if not to_dictconfig:
-            with pytest.warns(UserWarning):
-                launch(cfg, task_function=task_fn, to_dictconfig=to_dictconfig)
     else:
         # run again with no error
         launch(cfg, task_function=task_fn, to_dictconfig=to_dictconfig)

--- a/tests/test_launch/test_implementations.py
+++ b/tests/test_launch/test_implementations.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
-import warnings
 from pathlib import Path
 
 import pytest
@@ -80,15 +79,7 @@ def test_launch_to_dictconfig(cfg, to_dictconfig):
             assert len(dataclasses.fields(cfg)) > 0
 
         if not to_dictconfig:
-            with pytest.warns(
-                warnings.warn(
-                    "There may ben an issue with your dataclass.  If you just executed with a "
-                    + "`hydra/launcher` that utilizes cloudpickle (e.g., hydra-submitit-launcher), there is a known "
-                    + "issue with dataclasses (see: https://github.com/cloudpipe/cloudpickle/issues/386). You will have "
-                    + "to restart your interactive environment ro run `launch` again.  To avoid this issue you can use the option "
-                    + "`to_dictconfig=True`."
-                )
-            ):
+            with pytest.warns(UserWarning):
                 launch(cfg, task_function=task_fn, to_dictconfig=to_dictconfig)
     else:
         # run again with no error

--- a/tests/test_launch/test_implementations.py
+++ b/tests/test_launch/test_implementations.py
@@ -58,6 +58,9 @@ def test_launch_config_type(cfg, multirun):
     assert job.return_value == instantiate(cfg)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Your dataclass-based config was mutated by this run"
+)
 @pytest.mark.skipif(not CLOUDPICKLE_AVAIL, reason="cloudpickle not available")
 @pytest.mark.usefixtures("cleandir")
 @pytest.mark.parametrize("cfg", DATACLASS_CONFIG_TYPE_EXAMPLES)

--- a/tests/test_make_custom_builds_fn.py
+++ b/tests/test_make_custom_builds_fn.py
@@ -64,6 +64,7 @@ def f2(x, y: str):
     return
 
 
+@pytest.mark.filterwarnings("ignore:Specifying")  # deprecated builds_bases
 @pytest.mark.filterwarnings(
     "ignore:A structured config was supplied for `zen_wrappers`"
 )


### PR DESCRIPTION
This PR does two things:

- Adds flag to convert a `dataclass` input to a `DictConfig`.  This is a fix and response to the cloudpickle [issue](https://github.com/cloudpipe/cloudpickle/issues/386)
- Refactors `launch` to comform with Hydra's Compose API.  Currently we cannot use `compose` as it does not support `muliturn`, but these changes make it easy to update if `compose` eventually supports `multirun`. 

@rsokl I added cloudpickle to some of the test requirements.  I'm not sure how to test without it.