### PR TITLE
Adds `version_base` to `launch`

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -60,6 +60,10 @@ will no longer auto-broaden nested container types when ``OmegaConf v2.2.0+`` is
 installed. (See :pull:`261`)
 
 
+Hydra ``v1.2.0`` is introducing a ``version_base`` parameter that can control default behaviors in ``hydra.run`` and ``hydra.initialize``.
+Correspondingly, ``version_base`` is now exposed via `~hydra_zen.launch`. See :pull:`273` for more details.
+
+
 .. _0p7p0-deprecations:
 
 Deprecations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,18 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
-
 import logging
 import os
 import sys
 import tempfile
-from typing import Iterable
+from typing import Dict, Iterable, Optional
 
 import hypothesis.strategies as st
 import pkg_resources
 import pytest
 from omegaconf import DictConfig, ListConfig
+
+from hydra_zen._compatibility import HYDRA_VERSION
 
 # Skip collection of tests that don't work on the current version of Python.
 collect_ignore_glob = []
@@ -53,6 +54,17 @@ def cleandir() -> Iterable[str]:
         yield tmpdirname  # yields control to the test to be run
         os.chdir(old_dir)
         logging.shutdown()
+
+
+@pytest.fixture()
+def version_base() -> Dict[str, Optional[str]]:
+    """Return version_base according to local version, or empty dict for versions
+    preceding version_base"""
+    return (
+        {"version_base": ".".join(str(i) for i in HYDRA_VERSION)}
+        if HYDRA_VERSION >= (1, 2, 0)
+        else {}
+    )
 
 
 pytest_plugins = "pytester"

--- a/tests/test_defaults_list.py
+++ b/tests/test_defaults_list.py
@@ -13,19 +13,19 @@ from hydra_zen import builds, instantiate, launch, make_config
 from hydra_zen.errors import HydraZenValidationError
 
 
-def test_hydra_defaults_work_builds():
+def test_hydra_defaults_work_builds(version_base):
     config_store = ConfigStore.instance()
     config_store.store(group="x", name="a", node=builds(int, 10))
     Conf = builds(dict, x=None, y="hi", hydra_defaults=["_self_", {"x": "a"}])
-    job = launch(Conf, instantiate)
+    job = launch(Conf, instantiate, **version_base)
     assert job.return_value == {"x": 10, "y": "hi"}
 
 
-def test_hydra_defaults_work_make_config():
+def test_hydra_defaults_work_make_config(version_base):
     config_store = ConfigStore.instance()
     config_store.store(group="x", name="a", node=builds(int, 10))
     Conf = make_config(x=None, y="hi", hydra_defaults=["_self_", {"x": "a"}])
-    job = launch(Conf, instantiate)
+    job = launch(Conf, instantiate, **version_base)
     assert job.return_value == {"x": 10, "y": "hi"}
 
 

--- a/tests/test_launch/test_callbacks.py
+++ b/tests/test_launch/test_callbacks.py
@@ -73,7 +73,7 @@ def tracker(x=CustomCallback):
 
 @pytest.mark.usefixtures("cleandir")
 @pytest.mark.parametrize("multirun", [False, True])
-def test_hydra_run_with_callback(multirun):
+def test_hydra_run_with_callback(multirun, version_base: dict):
     # Tests that callback methods are called during appropriate
     # stages
     try:
@@ -86,6 +86,7 @@ def test_hydra_run_with_callback(multirun):
             task_function=instantiate,
             overrides=["hydra/callbacks=test_callback"],
             multirun=multirun,
+            **version_base,
         )
 
         if multirun:

--- a/tests/test_launch/test_implementations.py
+++ b/tests/test_launch/test_implementations.py
@@ -210,9 +210,17 @@ def test_version_base(version_base: Optional[str]):
 
     expected_dir = Path().cwd() if version_base != "1.1" else (Path().cwd() / "outputs")
 
-    glob_pattern = "foo.txt" if version_base != "1.1" else "**/foo.txt"
+    glob_pattern = "foo.txt" if version_base != "1.1" else "./**/foo.txt"
 
     assert len(list(expected_dir.glob(glob_pattern))) == 0
 
     launch(make_config(), task, version_base=version_base)
     assert len(list(expected_dir.glob(glob_pattern))) == 1, list(expected_dir.glob("*"))
+
+    # ensure the file isn't found in the opposite location
+    not_found = (
+        Path().cwd().glob("foo.txt")
+        if version_base == "1.1"
+        else (Path().cwd() / "outputs").glob("**/foo.txt")
+    )
+    assert len(list(not_found)) == 0

--- a/tests/test_launch/test_logging.py
+++ b/tests/test_launch/test_logging.py
@@ -18,12 +18,18 @@ def task(cfg):
 
 
 @pytest.mark.usefixtures("cleandir")
-def test_consecutive_logs():
+def test_consecutive_logs(version_base):
     job1 = launch(
-        builds(dict, message="1"), task_function=task, overrides=["hydra.run.dir=test"]
+        builds(dict, message="1"),
+        task_function=task,
+        overrides=["hydra.run.dir=test", "hydra.job.chdir=True"],
+        **version_base,
     )
     job2 = launch(
-        builds(dict, message="2"), task_function=task, overrides=["hydra.run.dir=test"]
+        builds(dict, message="2"),
+        task_function=task,
+        overrides=["hydra.run.dir=test", "hydra.job.chdir=True"],
+        **version_base,
     )
 
     assert isinstance(job1, JobReturn) and job1.working_dir is not None
@@ -38,12 +44,18 @@ def test_consecutive_logs():
 
 
 @pytest.mark.usefixtures("cleandir")
-def test_seperate_logs():
+def test_seperate_logs(version_base):
     job1 = launch(
-        builds(dict, message="1"), task_function=task, overrides=["hydra.run.dir=test1"]
+        builds(dict, message="1"),
+        task_function=task,
+        overrides=["hydra.run.dir=test1", "hydra.job.chdir=True"],
+        **version_base,
     )
     job2 = launch(
-        builds(dict, message="2"), task_function=task, overrides=["hydra.run.dir=test2"]
+        builds(dict, message="2"),
+        task_function=task,
+        overrides=["hydra.run.dir=test2", "hydra.job.chdir=True"],
+        **version_base,
     )
 
     assert isinstance(job1, JobReturn) and job1.working_dir is not None

--- a/tests/test_launch/test_logging.py
+++ b/tests/test_launch/test_logging.py
@@ -8,6 +8,7 @@ import pytest
 from hydra.core.utils import JobReturn
 
 from hydra_zen import builds, instantiate, launch
+from hydra_zen._compatibility import HYDRA_VERSION
 
 log = logging.getLogger(__name__)
 
@@ -19,16 +20,20 @@ def task(cfg):
 
 @pytest.mark.usefixtures("cleandir")
 def test_consecutive_logs(version_base):
+    overrides = ["hydra.run.dir=test"]
+    if HYDRA_VERSION >= (1, 2, 0):
+        overrides.append("hydra.job.chdir=True")
+
     job1 = launch(
         builds(dict, message="1"),
         task_function=task,
-        overrides=["hydra.run.dir=test", "hydra.job.chdir=True"],
+        overrides=overrides,
         **version_base,
     )
     job2 = launch(
         builds(dict, message="2"),
         task_function=task,
-        overrides=["hydra.run.dir=test", "hydra.job.chdir=True"],
+        overrides=overrides,
         **version_base,
     )
 
@@ -45,16 +50,18 @@ def test_consecutive_logs(version_base):
 
 @pytest.mark.usefixtures("cleandir")
 def test_seperate_logs(version_base):
+    extra_overrides = ["hydra.job.chdir=True"] if HYDRA_VERSION >= (1, 2, 0) else []
+
     job1 = launch(
         builds(dict, message="1"),
         task_function=task,
-        overrides=["hydra.run.dir=test1", "hydra.job.chdir=True"],
+        overrides=["hydra.run.dir=test1"] + extra_overrides,
         **version_base,
     )
     job2 = launch(
         builds(dict, message="2"),
         task_function=task,
-        overrides=["hydra.run.dir=test2", "hydra.job.chdir=True"],
+        overrides=["hydra.run.dir=test2"] + extra_overrides,
         **version_base,
     )
 

--- a/tests/test_launch/test_validation.py
+++ b/tests/test_launch/test_validation.py
@@ -24,11 +24,13 @@ from hydra_zen._launch import _store_config
     ],
 )
 @pytest.mark.parametrize("hydra_overrides", [[], ["hydra.run.dir=test"]])
-def test_launch_with_hydra_in_config(overrides, hydra_overrides, expected):
+def test_launch_with_hydra_in_config(
+    overrides, hydra_overrides, expected, version_base: dict
+):
     # validate hydra_launch executes properly if config contains
     # hydra configuration object
     cn = _store_config(builds(dict, a=1, b=1))
-    with initialize(config_path=None):
+    with initialize(config_path=None, **version_base):
         task_cfg = compose(
             config_name=cn, overrides=hydra_overrides, return_hydra_config=True
         )
@@ -40,8 +42,15 @@ def test_launch_with_hydra_in_config(overrides, hydra_overrides, expected):
     # Provide user override
     task_cfg.b = 10
 
+    if version_base:
+        overrides.append("hydra.job.chdir=True")
     # override works and user value is set
-    job = launch(task_cfg, task_function=instantiate, overrides=overrides)
+    job = launch(
+        task_cfg,
+        task_function=instantiate,
+        overrides=overrides,
+        **version_base,
+    )
     assert job.return_value == expected
     assert job.working_dir == "tested"
 
@@ -62,14 +71,19 @@ def test_launch_with_hydra_in_config(overrides, hydra_overrides, expected):
 )
 @pytest.mark.parametrize("hydra_overrides", [[], ["hydra.sweep.dir=test"]])
 def test_launch_with_multirun_with_hydra_in_config(
-    overrides, hydra_overrides, expected
+    overrides,
+    hydra_overrides,
+    expected,
+    version_base: dict,
 ):
     # validate hydra_launch executes properly if config contains
     # hydra configuration object
     cn = _store_config(builds(dict, a=1, b=1))
-    with initialize(config_path=None):
+    with initialize(config_path=None, **version_base):
         task_cfg = compose(
-            config_name=cn, overrides=hydra_overrides, return_hydra_config=True
+            config_name=cn,
+            overrides=hydra_overrides,
+            return_hydra_config=True,
         )
 
     assert "hydra" in task_cfg
@@ -79,9 +93,16 @@ def test_launch_with_multirun_with_hydra_in_config(
     # Provide user override
     task_cfg.b = 10
 
+    if version_base:
+        overrides.append("hydra.job.chdir=True")
+    assert version_base
     # override works and user value is set
     job = launch(
-        task_cfg, task_function=instantiate, overrides=overrides, multirun=True
+        task_cfg,
+        task_function=instantiate,
+        overrides=overrides,
+        multirun=True,
+        **version_base,
     )
     for e, j, k in zip(expected, job[0], range(len(expected))):
         assert j.return_value == e
@@ -89,16 +110,21 @@ def test_launch_with_multirun_with_hydra_in_config(
 
 
 @pytest.mark.usefixtures("cleandir")
-def test_launch_with_multirun_in_overrides():
+def test_launch_with_multirun_in_overrides(version_base):
     # hydra config is not in task_cfg but multirun overrides must be in multirun_overrides
     task_cfg = builds(dict, a=1)
 
     with pytest.raises(ConfigCompositionException):
-        launch(task_cfg, task_function=lambda _: print("hello"), overrides=["a=1,2"])
+        launch(
+            task_cfg,
+            task_function=lambda _: print("hello"),
+            overrides=["a=1,2"],
+            **version_base,
+        )
 
 
 @pytest.mark.usefixtures("cleandir")
-def test_launch_with_multirun_with_default_values():
+def test_launch_with_multirun_with_default_values(version_base):
     # Define configs in the configstore
     b2_cfg = builds(dict, b=2)
     b4_cfg = builds(dict, b=4)
@@ -114,6 +140,7 @@ def test_launch_with_multirun_with_default_values():
         task_function=lambda _: print("hello"),
         overrides=["+a=b2,b4"],
         multirun=True,
+        **version_base,
     )
 
     # need the + sign
@@ -123,6 +150,7 @@ def test_launch_with_multirun_with_default_values():
             task_function=lambda _: print("hello"),
             overrides=["a=b2,b4"],
             multirun=True,
+            **version_base,
         )
 
     # a default is set for "a"
@@ -133,4 +161,5 @@ def test_launch_with_multirun_with_default_values():
             task_function=lambda _: print("hello"),
             overrides=["a=b2,b4"],
             multirun=True,
+            **version_base,
         )

--- a/tests/test_launch/test_validation.py
+++ b/tests/test_launch/test_validation.py
@@ -95,7 +95,7 @@ def test_launch_with_multirun_with_hydra_in_config(
 
     if version_base:
         overrides.append("hydra.job.chdir=True")
-    assert version_base
+
     # override works and user value is set
     job = launch(
         task_cfg,


### PR DESCRIPTION
This mirrors functionality that will be exposed by `hydra.run` and `hydra.initialize` starting with Hydra 1.2.0:

- If the `version_base` parameter is not specified, Hydra 1.x will use defaults compatible with version 1.1. Also in this case, a warning is issued to indicate an explicit version_base is preferred.
- If the `version_base` parameter is `None`, then the defaults are chosen for the current minor Hydra version. For example for Hydra 1.2, then would imply `config_path=None` and `hydra.job.chdir=False`.
- If the `version_base` parameter is an explicit version string like "1.1", then the defaults appropriate to that version are used.

Our tests will specify `version_base` in accordance with the local version of Hydra, unless otherwise appropriate, via a pytest fixture.