### PR TITLE
DictConfig | ListConfig -> omegaconf.Container

### DIFF
--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -26,7 +26,7 @@ from functools import wraps
 from typing import IO, Any, Callable, Type, TypeVar, Union, cast, overload
 
 from hydra.utils import instantiate as hydra_instantiate
-from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
+from omegaconf import MISSING, Container, OmegaConf
 
 from .structured_configs._just import just
 from .structured_configs._value_conversion import ConfigComplex, ConfigPath
@@ -88,7 +88,7 @@ def instantiate(
 
 @overload
 def instantiate(
-    config: Union[HasTarget, ListConfig, DictConfig, DataClass_, Type[DataClass_]],
+    config: Union[HasTarget, Container, DataClass_, Type[DataClass_]],
     *args: Any,
     **kwargs: Any
 ) -> Any:  # pragma: no cover
@@ -356,9 +356,7 @@ def save_as_yaml(
     return OmegaConf.save(config=config, f=f, resolve=resolve)
 
 
-def load_from_yaml(
-    file_: Union[str, pathlib.Path, IO[Any]]
-) -> Union[DictConfig, ListConfig]:
+def load_from_yaml(file_: Union[str, pathlib.Path, IO[Any]]) -> Container:
     """
     Load a config from a yaml-format file
 

--- a/src/hydra_zen/_launch.py
+++ b/src/hydra_zen/_launch.py
@@ -11,7 +11,7 @@ from hydra.core.global_hydra import GlobalHydra
 from hydra.core.utils import JobReturn, run_job
 from hydra.plugins.sweeper import Sweeper
 from hydra.types import HydraContext, RunMode
-from omegaconf import DictConfig, ListConfig, OmegaConf
+from omegaconf import Container, DictConfig, OmegaConf
 
 from hydra_zen._compatibility import HYDRA_VERSION
 from hydra_zen._hydra_overloads import instantiate
@@ -23,14 +23,14 @@ class _NotSet:  # pragma: no cover
 
 
 def _store_config(
-    cfg: Union[DataClass, Type[DataClass], DictConfig, ListConfig, Mapping[Any, Any]],
+    cfg: Union[DataClass, Type[DataClass], Container, Mapping[Any, Any]],
     config_name: str = "hydra_launch",
 ) -> str:
     """Stores configuration object in Hydra's ConfigStore.
 
     Parameters
     ----------
-    cfg : Union[DataClass, DictConfig, Mapping]
+    cfg : DataClass | ListConfig | DictConfig | Mapping[Any, Any]
         A configuration as a dataclass, configuration object, or a dictionary.
 
     config_name : str (default: hydra_launch)

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -28,7 +28,7 @@ from typing import (
     Union,
 )
 
-from omegaconf import DictConfig, ListConfig
+from omegaconf import Container
 from typing_extensions import (
     Literal,
     ParamSpec,
@@ -197,8 +197,7 @@ _SupportedViaBuilds = Union[
 
 _SupportedPrimitive: TypeAlias = Union[
     _HydraPrimitive,
-    ListConfig,
-    DictConfig,
+    Container,
     Callable[..., Any],
     Enum,
     DataClass_,


### PR DESCRIPTION
Broadens annotations for omegaconf-based configs: `OmegaConf.is_config` simply checks `isinstance(x, omegaconf.Container)`