### PR TITLE
Improved signature parsing: support for Annotated, Paramspec, NewType, TypeVarTuple

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ commands = pytest \
 [testenv:min-deps]  # test against minimum dependency versions
 deps = hydra-core==1.1.0
        omegaconf==2.1.1
-       typing-extensions==4.0.1
+       typing-extensions==4.1.0
        {[testenv]deps}
 basepython = python3.7
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ KEYWORDS = (
 )
 INSTALL_REQUIRES = [
     "hydra-core >= 1.1.0",
-    "typing-extensions >= 4.0.1",
+    "typing-extensions >= 4.1.0",
 ]
 TESTS_REQUIRE = [
     "pytest >= 3.8",

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -412,17 +412,6 @@ def sanitized_type(
                 _unique_type = sanitized_type(
                     args[0], primitive_only=no_nested_container, nested=True
                 )
-            elif len(unique_args) == 2 and has_variadic_unpack:
-                # E.g. Tuple[int, *Ts]
-                _a = Any
-                for item in args:
-                    if get_origin(item) is not Unpack:
-                        _a = item
-                        break
-                _unique_type = sanitized_type(
-                    _a, primitive_only=no_nested_container, nested=True
-                )
-                del _a
             else:
                 _unique_type = Any
 

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -26,6 +26,7 @@ from typing import (
 
 from omegaconf import II
 from typing_extensions import (
+    Annotated,
     Final,
     ParamSpecArgs,
     ParamSpecKwargs,
@@ -326,9 +327,25 @@ def sanitized_type(
 
     if origin is not None:
 
+        # Support for Annotated[x, y]
+
         if isinstance(type_, _AnnotatedAlias):
+            # Python 3.7-3.8
+            # type_: Annotated[x, y]; origin -> x
             return sanitized_type(
                 origin,
+                primitive_only=primitive_only,
+                wrap_optional=wrap_optional,
+                nested=nested,
+            )
+
+        if origin is Annotated:
+            # Python 3.9+
+            # # type_: Annotated[x, y]; origin -> Annotated; args -> (x, y)
+            tp, _ = get_args(origin)
+
+            return sanitized_type(
+                tp,
                 primitive_only=primitive_only,
                 wrap_optional=wrap_optional,
                 nested=nested,

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -32,8 +32,15 @@ from typing_extensions import (
     ParamSpecKwargs,
     TypeGuard,
     Unpack,
-    _AnnotatedAlias,
 )
+
+try:
+    from typing_extensions import _AnnotatedAlias
+except ImportError:  # pragma: no cover
+    # Python 3.6
+    class _AnnotatedAlias:
+        ...
+
 
 from hydra_zen._compatibility import (
     HYDRA_SUPPORTED_PRIMITIVE_TYPES,
@@ -329,9 +336,9 @@ def sanitized_type(
 
         # Support for Annotated[x, y]
 
-        if origin is Annotated:
-            # Python 3.9+
-            # # type_: Annotated[x, y]; origin -> Annotated; args -> (x, y)
+        # Python 3.9+
+        # # type_: Annotated[x, y]; origin -> Annotated; args -> (x, y)
+        if origin is Annotated:  # pragma: no cover
             tp, _ = get_args(type_)
 
             return sanitized_type(
@@ -341,9 +348,9 @@ def sanitized_type(
                 nested=nested,
             )
 
+        # Python 3.7-3.8
+        # type_: Annotated[x, y]; origin -> x
         if isinstance(type_, _AnnotatedAlias):
-            # Python 3.7-3.8
-            # type_: Annotated[x, y]; origin -> x
             return sanitized_type(
                 origin,
                 primitive_only=primitive_only,

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -329,23 +329,23 @@ def sanitized_type(
 
         # Support for Annotated[x, y]
 
-        if isinstance(type_, _AnnotatedAlias):
-            # Python 3.7-3.8
-            # type_: Annotated[x, y]; origin -> x
+        if origin is Annotated:
+            # Python 3.9+
+            # # type_: Annotated[x, y]; origin -> Annotated; args -> (x, y)
+            tp, _ = get_args(type_)
+
             return sanitized_type(
-                origin,
+                tp,
                 primitive_only=primitive_only,
                 wrap_optional=wrap_optional,
                 nested=nested,
             )
 
-        if origin is Annotated:
-            # Python 3.9+
-            # # type_: Annotated[x, y]; origin -> Annotated; args -> (x, y)
-            tp, _ = get_args(origin)
-
+        if isinstance(type_, _AnnotatedAlias):
+            # Python 3.7-3.8
+            # type_: Annotated[x, y]; origin -> x
             return sanitized_type(
-                tp,
+                origin,
                 primitive_only=primitive_only,
                 wrap_optional=wrap_optional,
                 nested=nested,

--- a/tests/test_third_party/test_type_validators.py
+++ b/tests/test_third_party/test_type_validators.py
@@ -211,7 +211,6 @@ class UserIdentity(TypedDict):
         (Union[List[str], str], dict(a=1)),
         (MyNamedTuple, (1.0, 2.0)),
         (xf.add(UserIdentity, BEAR), dict(first="bruce", last="lee")),
-        (Annotated[int, "special"], "hello"),
     ],
 )
 @pytest.mark.parametrize("validator", all_validators)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -167,10 +167,34 @@ NoneType: TypeAlias = None
         (P.args, Any),  # type: ignore
         (P.kwargs, Any),  # type: ignore
         (Ts, Any),
-        (Tuple[Unpack[Ts]], Tuple[Any, ...]),
-        (Tuple[Unpack[Ts], int], Tuple[int, ...]),
-        (Tuple[str, Unpack[Ts]], Tuple[str, ...]),
-        (Tuple[str, Unpack[Ts], int], Tuple[Any, ...]),
+        pytest.param(
+            Tuple[Unpack[Ts]],
+            Tuple[Any, ...],
+            marks=pytest.mark.skipif(
+                sys.version_info <= (3, 7), reason="Python 3.6 doesn't support Unpack"
+            ),
+        ),
+        pytest.param(
+            Tuple[Unpack[Ts], int],
+            Tuple[int, ...],
+            marks=pytest.mark.skipif(
+                sys.version_info < (3, 7), reason="Python 3.6 doesn't support Unpack"
+            ),
+        ),
+        pytest.param(
+            Tuple[str, Unpack[Ts]],
+            Tuple[str, ...],
+            marks=pytest.mark.skipif(
+                sys.version_info < (3, 7), reason="Python 3.6 doesn't support Unpack"
+            ),
+        ),
+        pytest.param(
+            Tuple[str, Unpack[Ts], int],
+            Tuple[Any, ...],
+            marks=pytest.mark.skipif(
+                sys.version_info < (3, 7), reason="Python 3.6 doesn't support Unpack"
+            ),
+        ),
         (Annotated[int, int], int),
         (Annotated[Tuple[str, str], int], Tuple[str, str]),
         (Annotated[Builds, int], Any),
@@ -267,6 +291,7 @@ def test_sanitized_type_expected_behavior(in_type, expected_type):
                 KeyValidationError,
                 ConfigIndexError,
                 ConfigValueError,
+                AttributeError,
             )
         ):
             Conf = OmegaConf.create(Bad)  # type: ignore

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -168,6 +168,7 @@ NoneType: TypeAlias = None
         (P.args, Any),  # type: ignore
         (P.kwargs, Any),  # type: ignore
         (Ts, Any),
+        (SomeProtocol[T], Any),
         pytest.param(
             Tuple[Unpack[Ts]],
             Tuple[Any, ...],
@@ -192,7 +193,7 @@ NoneType: TypeAlias = None
                 ),
                 pytest.mark.xfail(
                     HYDRA_VERSION < Version(1, 2, 0),
-                    reason="Hydra 1.1.2 doesn't parse tuples deeply.",
+                    reason="Hydra 1.1.2 doesn't parse tuples beyond first element.",
                 ),
             ],
         ),
@@ -206,7 +207,7 @@ NoneType: TypeAlias = None
                 ),
                 pytest.mark.xfail(
                     HYDRA_VERSION < Version(1, 2, 0),
-                    reason="Hydra 1.1.2 doesn't parse tuples deeply.",
+                    reason="Hydra 1.1.2 doesn't parse tuples beyond first element.",
                 ),
             ],
         ),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -167,6 +167,7 @@ NoneType: TypeAlias = None
         (P.args, Any),  # type: ignore
         (P.kwargs, Any),  # type: ignore
         (Ts, Any),
+        (Tuple[Unpack[Ts]], Tuple[Any, ...]),
         (Tuple[Unpack[Ts], int], Tuple[int, ...]),
         (Tuple[str, Unpack[Ts]], Tuple[str, ...]),
         (Tuple[str, Unpack[Ts], int], Tuple[Any, ...]),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,6 +47,7 @@ from hydra_zen import builds, instantiate, mutable_value
 from hydra_zen._compatibility import (
     HYDRA_SUPPORTS_BYTES,
     HYDRA_SUPPORTS_NESTED_CONTAINER_TYPES,
+    HYDRA_VERSION,
     HYDRA_SUPPORTS_Path,
     Version,
     _get_version,
@@ -184,16 +185,30 @@ NoneType: TypeAlias = None
         pytest.param(
             Tuple[str, Unpack[Ts]],
             Tuple[Any, ...],
-            marks=pytest.mark.skipif(
-                sys.version_info < (3, 7), reason="Python 3.6 doesn't support Unpack"
-            ),
+            marks=[
+                pytest.mark.skipif(
+                    sys.version_info < (3, 7),
+                    reason="Python 3.6 doesn't support Unpack",
+                ),
+                pytest.mark.xfail(
+                    HYDRA_VERSION < Version(1, 2, 0),
+                    reason="Hydra 1.1.2 doesn't parse tuples deeply.",
+                ),
+            ],
         ),
         pytest.param(
             Tuple[str, Unpack[Ts], int],
             Tuple[Any, ...],
-            marks=pytest.mark.skipif(
-                sys.version_info < (3, 7), reason="Python 3.6 doesn't support Unpack"
-            ),
+            marks=[
+                pytest.mark.skipif(
+                    sys.version_info < (3, 7),
+                    reason="Python 3.6 doesn't support Unpack",
+                ),
+                pytest.mark.xfail(
+                    HYDRA_VERSION < Version(1, 2, 0),
+                    reason="Hydra 1.1.2 doesn't parse tuples deeply.",
+                ),
+            ],
         ),
         (Annotated[int, int], int),
         (Annotated[Tuple[str, str], int], Tuple[str, str]),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -176,14 +176,14 @@ NoneType: TypeAlias = None
         ),
         pytest.param(
             Tuple[Unpack[Ts], int],
-            Tuple[int, ...],
+            Tuple[Any, ...],
             marks=pytest.mark.skipif(
                 sys.version_info < (3, 7), reason="Python 3.6 doesn't support Unpack"
             ),
         ),
         pytest.param(
             Tuple[str, Unpack[Ts]],
-            Tuple[str, ...],
+            Tuple[Any, ...],
             marks=pytest.mark.skipif(
                 sys.version_info < (3, 7), reason="Python 3.6 doesn't support Unpack"
             ),


### PR DESCRIPTION
Prior to this, the presence of `ParamSpecArgs` or `ParamSpecKwargs` in a signature being parsed by `builds` would cause an unhashable type error.

This PR fixes this bug and adds support for extracting information from `Annotated` and `NewType`, and adds support for extrapolating from variadic tuples (e.g. `Tuple[int, *Ts]`) 

Test cases are also added for `Protocol` and `TypeVar`

## Before

```python
# `sanitized_type` is applied to types by `hydra_zen.builds` when parsing target signatures

>>> sanitized_type(Annotated[int, range(10)])
Any

>>> sanitized_type(NewType("H", str))
Any

>>> sanitized_type(Tuple[*Ts])
Tuple[Any]

>>> sanitized_type(P.args)  # error
>>> sanitized_type(P.kwargs)  # error
```

## After

```python
>>> sanitized_type(Annotated[int, range(10)])
int

>>> sanitized_type(NewType("H", str))
str

>>> sanitized_type(Tuple[*Ts])
Tuple[Any, ...]

>>> sanitized_type(P.args)
Any

>>> sanitized_type(P.kwargs)
Any
```