### PR TITLE
Broaden overly-restrictive `hydra_defaults` validation

### DIFF
--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -769,7 +769,7 @@ def builds(
 
         If ``None``, the ``_convert_`` attribute is not set on the resulting config.
 
-    hydra_defaults : List['_self_' | Dict[str, str]] | None, optional (default = None)
+    hydra_defaults : None | list[str | dict[str, str | list[str] | None ]], optional (default = None)
         A list in an input config that instructs Hydra how to build the output config
         [7]_ [8]_. Each input config can have a Defaults List as a top level element. The
         Defaults List itself is not a part of output config.

--- a/src/hydra_zen/structured_configs/_make_config.py
+++ b/src/hydra_zen/structured_configs/_make_config.py
@@ -149,11 +149,10 @@ def make_config(
         If ``None``, the ``_convert_`` attribute is not set on the resulting config.
 
 
-    hydra_defaults : List['_self_' | Dict[str, str]] | None, optional (default = None)
+    hydra_defaults : None | list[str | dict[str, str | list[str] | None ]], optional (default = None)
         A list in an input config that instructs Hydra how to build the output config
-        [7]_ [8]_. Each input config can have a Defaults List as a top level element. The
-        Defaults List itself is not a part of output config.
-
+        [7]_ [8]_. Each input config can have a Defaults List as a top level element.
+        The Defaults List itself is not a part of output config.
 
     bases : Tuple[Type[DataClass], ...], optional (default=())
         Base classes that the resulting config class will inherit from.

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -23,7 +23,7 @@ from typing import (
     overload,
 )
 
-from omegaconf import II
+from omegaconf import II, MISSING, DictConfig, ListConfig
 from typing_extensions import Final, TypeGuard
 
 from hydra_zen._compatibility import (
@@ -447,7 +447,7 @@ def valid_defaults_list(hydra_defaults: Any) -> bool:
     Raises
     ------
     HydraZenValidationError: Duplicate _self_ entries"""
-    if not isinstance(hydra_defaults, list):
+    if not isinstance(hydra_defaults, (list, ListConfig)):
         return False
 
     has_self = False
@@ -461,13 +461,23 @@ def valid_defaults_list(hydra_defaults: Any) -> bool:
                 "`hydra_defaults` cannot have more than one '_self_' entry"
             )
 
-        if not isinstance(item, (dict, str)):
-            return False
+        if isinstance(item, (dict, DictConfig)):
+            for k, v in item.items():
+                if not isinstance(k, str):
+                    return False
 
-        if isinstance(item, dict) and any(
-            not isinstance(k, str) or not isinstance(v, (str, list))
-            for k, v in item.items()
-        ):
+                if (
+                    not isinstance(v, (str, list, ListConfig))
+                    and v is not None
+                    and v != MISSING
+                ):
+                    return False
+        elif isinstance(item, str):
+            continue
+        elif is_dataclass(item):
+            # no validation here
+            continue
+        else:
             return False
 
     if not has_self:

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -252,4 +252,6 @@ else:
         pass
 
 
-DefaultsList = List[Union[str, Mapping[str, Union[str, List[str]]]]]
+DefaultsList = List[
+    Union[str, DataClass_, Mapping[str, Union[None, str, Sequence[str]]]]
+]

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -1041,5 +1041,21 @@ def check_hydra_defaults(
     make_config(hydra_defaults=1)  # type: ignore
 
     builds(int, hydra_defaults=["_self_", {"a": "b"}, {1: 1}])  # type: ignore
+    builds(int, hydra_defaults=["_self_", ["a"]])  # type: ignore
+    builds(int, hydra_defaults=["_self_", {("a",): "b"}])  # type: ignore
     builds(int, hydra_defaults={"a": "b"})  # type: ignore
     builds(int, hydra_defaults="_self_")  # type: ignore
+
+    builds(
+        int,
+        hydra_defaults=[
+            "_self_",
+            {"a": "b"},
+            {"a": None},
+            {"a": MISSING},
+            {"a": ["b"]},
+            DictConfig({"a": "b"}),
+            {"a": ListConfig(["a"])},
+            make_config(a="a"),
+        ],
+    )

--- a/tests/test_defaults_list.py
+++ b/tests/test_defaults_list.py
@@ -88,3 +88,15 @@ def test_no_self_in_defaults_warns():
 def test_redundant_defaults_in_make_config_raises():
     with pytest.raises(TypeError):
         make_config(defaults=["_self_"], hydra_defaults=["_self_"])
+
+
+def test_regression_284():
+    # https://github.com/mit-ll-responsible-ai/hydra-zen/issues/284
+    make_config(
+        hydra_defaults=[
+            "_self_",
+            {"model": "resnet"},
+            {"decorators_model": None},
+            {"test_transform": "test_transformation_6ch"},
+        ]
+    )


### PR DESCRIPTION
The following default lists are valid but were not permitted by hydra-zen:
- `[{"a": None}]`  (discovered in #284 )
- `[DictConfig({"a": "b"})]`
- `[make_config(a="b")]`
- `[{"a": ListConfig(["b"])]`

This PR broadens the validation performed by hydra-zen, plus updates the type-annotations and docs for `hydra_defaults`. 

The spec for Hydra's Defaults List can be found [here](https://hydra.cc/docs/next/advanced/defaults_list/)