### PR TITLE
Broaden overly-restrictive hydra_defaults validation

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -36,6 +36,20 @@ Bug Fixes
 - :func:`~hydra_zen.builds` would raise a ``TypeError`` if it encountered a target whose signature contained the annotations ``ParamSpecArgs`` or  ``ParamSpecKwargs``. It can now sanitize these annotations properly. (See :pull:`283`)
 
 
+.. _v0.7.1:
+
+---------------------
+0.7.1rc1 - 2022-05-10
+---------------------
+
+Bug Fixes
+---------
+
+The validation that hydra-zen performs on ``hydra_defaults`` was overly restrictive. E.g. it would flag ``[{"some_group": None}]`` as invalid, even though null is permitted in `Hydra's default list syntax <https://hydra.cc/docs/advanced/defaults_list/>`_.
+This patch fixes this validation and updates the docs & annotations for ``hydra_defaults`` in :func:`~hydra_zen.builds` and :func:`~hydra_zen.make_config`.
+See :pull:`287` for more details.
+
+
 .. _v0.7.0:
 
 ------------------

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -765,7 +765,7 @@ def builds(
 
         If ``None``, the ``_convert_`` attribute is not set on the resulting config.
 
-    hydra_defaults : List['_self_' | Dict[str, str]] | None, optional (default = None)
+    hydra_defaults : None | list[str | dict[str, str | list[str] | None ]], optional (default = None)
         A list in an input config that instructs Hydra how to build the output config
         [7]_ [8]_. Each input config can have a Defaults List as a top level element. The
         Defaults List itself is not a part of output config.
@@ -1273,7 +1273,7 @@ def builds(
     if hydra_defaults is not None:
         if not _utils.valid_defaults_list(hydra_defaults):
             raise HydraZenValidationError(
-                f"`hydra_defaults` must be type `list[str | dict[str, str | list[str]]`"
+                f"`hydra_defaults` must be type `None | list[str | dict[str, str | list[str] | None ]]`"
                 f", Got: {repr(hydra_defaults)}"
             )
         hydra_defaults = sanitize_collection(hydra_defaults)

--- a/src/hydra_zen/structured_configs/_make_config.py
+++ b/src/hydra_zen/structured_configs/_make_config.py
@@ -149,7 +149,7 @@ def make_config(
         If ``None``, the ``_convert_`` attribute is not set on the resulting config.
 
 
-    hydra_defaults : List['_self_' | Dict[str, str]] | None, optional (default = None)
+    hydra_defaults : None | list[str | dict[str, str | list[str] | None ]], optional (default = None)
         A list in an input config that instructs Hydra how to build the output config
         [7]_ [8]_. Each input config can have a Defaults List as a top level element. The
         Defaults List itself is not a part of output config.

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -246,4 +246,6 @@ else:
         pass
 
 
-DefaultsList = List[Union[str, Mapping[str, Union[str, List[str]]]]]
+DefaultsList = List[
+    Union[str, DataClass_, Mapping[str, Union[None, str, Sequence[str]]]]
+]

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -1041,5 +1041,21 @@ def check_hydra_defaults(
     make_config(hydra_defaults=1)  # type: ignore
 
     builds(int, hydra_defaults=["_self_", {"a": "b"}, {1: 1}])  # type: ignore
+    builds(int, hydra_defaults=["_self_", ["a"]])  # type: ignore
+    builds(int, hydra_defaults=["_self_", {("a",): "b"}])  # type: ignore
     builds(int, hydra_defaults={"a": "b"})  # type: ignore
     builds(int, hydra_defaults="_self_")  # type: ignore
+
+    builds(
+        int,
+        hydra_defaults=[
+            "_self_",
+            {"a": "b"},
+            {"a": None},
+            {"a": MISSING},
+            {"a": ["b"]},
+            DictConfig({"a": "b"}),
+            {"a": ListConfig(["a"])},
+            make_config(a="a"),
+        ],
+    )


### PR DESCRIPTION
The following default lists are valid but were not permitted by hydra-zen:
- `[{"a": None}]`  (discovered in #284 )
- `[DictConfig({"a": "b"})]`
- `[make_config(a="b")]`
- `[{"a": ListConfig(["b"])]`

This PR broadens the validation performed by hydra-zen, plus updates the type-annotations and docs for `hydra_defaults`. 

The spec for Hydra's Defaults List can be found [here](https://hydra.cc/docs/next/advanced/defaults_list/)