### PR TITLE
add CI job for omegaconf 2.2.2

### DIFF
--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -133,6 +133,20 @@ jobs:
     - name: Test with tox
       run: tox -e hydra-1p1p2-pre-release
 
+  test-against-omegaconf-2p2p2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox -e omegaconf-2p2p2
 
   run-pyright:
     runs-on: ubuntu-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,15 @@ deps = hydra-core==1.1.2
        cloudpickle
 basepython = python3.8
 
+[testenv:omegaconf-2p2p2]  # guard against regressions for type sanitization
+pip_pre = true
+deps = omegaconf==2.2.2
+       {[testenv]deps}
+       pydantic
+       beartype
+       cloudpickle
+basepython = python3.8
+
 [testenv:coverage]
 setenv = NUMBA_DISABLE_JIT=1
 usedevelop = true


### PR DESCRIPTION
omegaconf 2.2.3 and 2.2.2 diverge in support for some annotations -- this CI job ensures that we don't silently regress for omegaconf 2.2.2