### PR TITLE
Add support for builds(Dataclass, populate_full_signature=True) when dataclass has default factory fields

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -28,10 +28,11 @@ hydra-zen :ref:`already provides support for these <additional-types>`, but this
 
 Improvements
 ------------
-- The :ref:`automatic type refinement <type-support>` performed by :func:`~hydra_zen.builds` now has enhanced support for ``typing.Annotated``, ``typing.NewType``, and ``typing.TypeVarTuple``. (See :pull:`283`)
 - :func:`~hydra_zen.builds` no longer has restrictions on inheritance patterns involving `PartialBuilds`-type configs. (See :pull:`290`)
 - Two new utility functions were added to the public API: :func:`~hydra_zen.is_partial_builds` and :func:`~hydra_zen.uses_zen_processing`
-- Improved :ref:`automatic type refinement <type-support>` for bare sequence types, and parity with support for `dict`, `list`, and `tuple` as type annotations in omegaconf 2.2.3+. (See :pull:`297`)
+- Improved :ref:`automatic type refinement <type-support>` for bare sequence types, and adds conditional support for `dict`, `list`, and `tuple` as type annotations when omegaconf 2.2.3+ is installed. (See :pull:`297`)
+- Adds support for using `builds(<target>, populate_full_signature=True)` where `<target>` is a dataclass type that has a field with a default factory. (See :pull:`299`)
+- The :ref:`automatic type refinement <type-support>` performed by :func:`~hydra_zen.builds` now has enhanced support for ``typing.Annotated``, ``typing.NewType``, and ``typing.TypeVarTuple``. (See :pull:`283`)
 
 Bug Fixes
 ---------


### PR DESCRIPTION
Closes #295 

```python 
from typing import Any
from hydra_zen import builds, instantiate

from dataclasses import field, dataclass

@dataclass
class A:
    x: Any = field(default_factory=lambda : [1, 2, 3])
```
**Before:**

```python
>>> builds(A, populate_full_signature=True)
HydraZenUnsupportedPrimitiveError: Building: A ..
 The configured value <factory>, for field `x`, is not supported by Hydra -- serializing or instantiating this config would ultimately result in an error.

Consider using `hydra_zen.builds(<class 'dataclasses._HAS_DEFAULT_FACTORY_CLASS'>, ...)` create a config for this particular value.
```

**After**
```python
>>> Conf = builds(A, populate_full_signature=True)
>>> instantiate(Conf)
A(x=[1, 2, 3])
```
