### PR TITLE
Adds (recursive) auto-config support for dataclass types and instances

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
     - id: flake8
       args: [--ignore, "F811,D1,D205,D209,D213,D400,D401,D999,D202,E203,E501,W503,E721,F403,F405",
-      --exclude, "versioneer.py,docs/*,tests/annotations/*"]
+      --exclude, "versioneer.py,docs/*,tests/annotations/*, tests/test_py310.py"]
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.10.1
     hooks:

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -95,6 +95,17 @@ The following utilities can be used to work with YAML-serialized configs.
    load_from_yaml
 
 
+hydra_zen.typing
+****************
+.. currentmodule:: hydra_zen.typing
+
+.. autosummary::
+   :toctree: generated/
+
+
+   ZenConvert
+
+
 .. _valid-types:
 
 **********************************************************
@@ -181,6 +192,8 @@ with Hydra. For example, a :py:class:`complex` value can be specified directly v
    Bar(reduce_fn=<built-in function sum>)
 
 
+Auto-config behaviors can be configured via the :ref:`zen-convert API <zen-convert>`.
+
 hydra-zen provides specialized auto-config support for values of the following types:
 
 - :py:class:`bytes` (*support provided for OmegaConf < 2.2.0*)
@@ -202,47 +215,6 @@ hydra-zen also provides auto-config support for some third-pary libraries:
 - `pydantic.dataclasses.dataclass`
 - `pydantic.Field`
 
-.. _zen-convert:
-
-Controlling Value-Conversion Behavior
-*************************************
-Each of hydra-zen's config-creation functions has a `zen_config` parameter, which can 
-be passed a dictionary to modify the function's value and type conversion behaviors.
-`hydra_zen.typing.ZenConfig` is a :py:class:`typing.TypedDict` that can be used as a 
-convenience function to view and override these options.
-
-The following are the current zen-config options
-
-**dataclass : bool** 
-
-If `True` any dataclass type/instance without a `_target_` field is automatically 
-converted to a targeted config that will instantiate to that type/instance. Otherwise 
-the dataclass type/instance will be passed through as-is.
-
-.. code-block:: pycon
-   
-   >>> from hydra_zen import instantiate as I
-   >>> from hydra_zen import builds, just
-   >>> from dataclasses import dataclass
-   >>> @dataclass
-   ... class B:
-   ...     x: int
-   >>> b = B(x=1)
-
-   >>> I(just(b))
-   B(x=1)
-   >>> I(just(b, zen_convert={"dataclass": False}))  # returns omegaconf.DictConfig
-   {"x": 1}
-
-   >>> I(builds(dict, y=b))
-   {'y': B(x=1)}
-   >>> I(builds(dict, y=b, zen_convert={"dataclass": False}))  # returns omegaconf.DictConfig
-   {'y': {'x': 1}}   
-
-   >>> I(make_config(y=b))  # returns omegaconf.DictConfig
-   {'y': {'x': 1}}
-   >>> I(make_config(y=b, zen_convert={"dataclass": True}, hydra_convert="all"))
-   {'y': B(x=1)}
 
 
 *********************

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -138,14 +138,14 @@ Auto-Config Support for Additional Types via hydra-zen
 ******************************************************
 
 Values of additional types can be specified directly via hydra-zen's 
-:ref:`config-creation functions <create-config>` (and other utility functions like ``to_yaml``) and those functions will automatically 
+:ref:`config-creation functions <create-config>` (and other utility functions like :func:`~hydra_zen.to_yaml`) and those functions will automatically 
 create targeted configs to represent those values in a way that is compatible 
 with Hydra. For example, a :py:class:`complex` value can be specified directly via :func:`~hydra_zen.make_config`, and a targeted config will be created for that value.
 
 .. code-block:: pycon
    :caption: Demonstrating auto-config support for `complex`, `functools.partial` and `dataclasses.dataclass`
 
-   >>> from hydra_zen import just, make_config, to_yaml, instantiate
+   >>> from hydra_zen import builds, just, make_config, to_yaml, instantiate
    >>> def print_yaml(x): print(to_yaml(x))
 
    >>> Conf = make_config(value=2.0 + 3.0j)

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -178,7 +178,7 @@ with Hydra. For example, a :py:class:`complex` value can be specified directly v
      path: builtins.sum
    
    >>> instantiate(just_bar)
-   Foo(reduce_fn=<built-in function sum>)
+   Bar(reduce_fn=<built-in function sum>)
 
 
 hydra-zen provides specialized auto-config support for values of the following types:

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -16,18 +16,25 @@ chronological order. All previous releases should still be available on pip.
 
 .. note:: This is documentation for an unreleased version of hydra-zen. You can try out this version pre-release version using `pip install --pre hydra-zen`
 
+Release Highlights
+------------------
+Outstanding among this release's improvements is the added capability for hydra-zen to automatically and recursively convert dataclasses to Hydra-compatible forms. 
+
+
+Previously, all dataclass types and instances
+
 Compatibility-Breaking Changes
 ------------------------------
-- This release drops support for Python 3.6. If you require Python 3.6, please restrict your hydra-zen installation dependency as `hydra-zen<0.8.0`.
+This release drops support for Python 3.6. If you require Python 3.6, please restrict your hydra-zen installation dependency as `hydra-zen<0.8.0`.
 
 
 Improvements
 ------------
+- Adds support for using `builds(<target>, populate_full_signature=True)` where `<target>` is a dataclass type that has a field with a default factory. (See :pull:`299`)
 - Adds auto-config support for `pydantic.Field`, improving hydra-zen's ability to automatically construct configs that describe pydantic models and dataclasses. (See :pull:`303`) 
 - :func:`~hydra_zen.builds` no longer has restrictions on inheritance patterns involving `PartialBuilds`-type configs. (See :pull:`290`)
 - Two new utility functions were added to the public API: :func:`~hydra_zen.is_partial_builds` and :func:`~hydra_zen.uses_zen_processing`
 - Improved :ref:`automatic type refinement <type-support>` for bare sequence types, and adds conditional support for `dict`, `list`, and `tuple` as type annotations when omegaconf 2.2.3+ is installed. (See :pull:`297`)
-- Adds support for using `builds(<target>, populate_full_signature=True)` where `<target>` is a dataclass type that has a field with a default factory. (See :pull:`299`)
 - The :ref:`automatic type refinement <type-support>` performed by :func:`~hydra_zen.builds` now has enhanced support for ``typing.Annotated``, ``typing.NewType``, and ``typing.TypeVarTuple``. (See :pull:`283`)
 
 

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -393,7 +393,7 @@ New Features
    - `Read about hydra-zen compatibility with pydantic <https://github.com/mit-ll-responsible-ai/hydra-zen/pull/126>`_
    - `Read about hydra-zen compatibility with beartype <https://github.com/mit-ll-responsible-ai/hydra-zen/pull/128>`_
    
-  The type-checking capabilities offered by :func:`~hydra_zen.third_party.pydantic.validates_with_pydantic` and :func:`~hydra_zen.third_party.beartype.validates_with_beartype`, respectively, are both far more robust than those `offered by Hydra <https://hydra.cc/docs/next/tutorials/structured_config/intro/#structured-configs-supports>`_.
+  The type-checking capabilities offered by :func:`~hydra_zen.third_party.pydantic.validates_with_pydantic` and :func:`~hydra_zen.third_party.beartype.validates_with_beartype`, respectively, are both far more robust than those `offered by Hydra <https://hydra.cc/docs/tutorials/structured_config/intro/#structured-configs-supports>`_.
 - A new, simplified method for creating a structured config, via :func:`~hydra_zen.make_config`.
   
    This serves as a much more succinct way to create a dataclass, where specifying type-annotations is optional. Additionally, provided type-annotations and default values are automatically adapted to be made compatible with Hydra. `Read more here <https://github.com/mit-ll-responsible-ai/hydra-zen/pull/130>`_.

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -42,7 +42,7 @@ automatically create a Hydra-compatible config that, when instantiated, returns 
 .. code-block:: pycon
    :caption: Using :func:`~hydra_zen.just` to create a Hydra-compatible structured config
 
-   >>> from hydra_zen import just, instantiate
+   >>> from hydra_zen import builds, just, instantiate, to_yaml
    >>> just_bar = just(Bar())
    
    >>> print(to_yaml(just_bar))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,6 +46,9 @@ extensions = [
     # "sphinx_codeautolink",
 ]
 
+autosummary_generate = False
+numpydoc_show_inherited_class_members = False
+
 # Strip input prompts:
 # https://sphinx-copybutton.readthedocs.io/en/latest/#strip-and-configure-input-prompts-for-code-cells
 copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "

--- a/docs/source/explanation/type_refinement.rst
+++ b/docs/source/explanation/type_refinement.rst
@@ -14,7 +14,7 @@ robust support for more general type annotations.
 Hydra's Limited Type Support
 ----------------------------
 
-Hydra permits only `a narrow subset of type annotations <https://hydra.cc/docs/next/tutorials/structured_config/intro#structured-configs-supports>`_ to be present in a 
+Hydra permits only `a narrow subset of type annotations <https://hydra.cc/docs/tutorials/structured_config/intro#structured-configs-supports>`_ to be present in a 
 config:
 
    - ``Any``

--- a/docs/source/generated/hydra_zen.ZenField.rst
+++ b/docs/source/generated/hydra_zen.ZenField.rst
@@ -14,16 +14,3 @@
    .. autosummary::
    
       ~ZenField.__init__
-   
-   
-
-   
-   
-   .. rubric:: Attributes
-
-   .. autosummary::
-   
-      ~ZenField.hint
-      ~ZenField.zen_convert
-   
-   

--- a/docs/source/generated/hydra_zen.ZenField.rst
+++ b/docs/source/generated/hydra_zen.ZenField.rst
@@ -24,5 +24,6 @@
    .. autosummary::
    
       ~ZenField.hint
+      ~ZenField.zen_convert
    
    

--- a/docs/source/how_to/partial_config.rst
+++ b/docs/source/how_to/partial_config.rst
@@ -3,7 +3,7 @@
 
 .. admonition:: The Answer
    
-   Simply use ``builds(<target>, zen_partial=True)`` to create a partial config.
+   Simply use ``builds(<target>, zen_partial=True, [...])`` or ``just(functools.partial(<target>, [...]))`` to create a partial config for ``<target>``.
 
 .. _partial-config:
 
@@ -82,11 +82,6 @@ Lastly, let's inspect the YAML-serialized config for :class:`OptimConf`.
    >>> from hydra_zen import to_yaml
 
    >>> print(to_yaml(OptimConf))
-   _target_: hydra_zen.funcs.zen_processing
-   _zen_target: __main__.Optimizer
-   _zen_partial: true
+   _target_: __main__.Optimizer
+   _partial_: true
    learning_rate: 0.1
-
-See that leveraging the ``zen_partial=True`` feature of :func:`~hydra_zen.builds` 
-introduces an explicit dependency on hydra-zen -- hydra-zen must be installed in order 
-to instantiate this YAML-based config.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,16 +18,21 @@
 Welcome to hydra-zen's documentation!
 =====================================
 
-hydra-zen is a Python library that simplifies the process of writing code (be it research-grade or production-grade) that is:
+hydra-zen is a Python library that makes the `Hydra framework <https://hydra.cc/>`_  
+simpler and more elegant to use. Use hydra-zen to design your project to be:
 
 - **Configurable**: change deeply-nested parameters and swap out entire pieces of your program, all from the command line. 
 - **Repeatable**: each run of your code will be self-documenting; the full configuration of your software is saved alongside your results.
 - **Scalable**: launch multiple runs of your software, be it on your local machine or across multiple nodes on a cluster.
 
-It builds off -- and is fully compatible with -- `Hydra <https://hydra.cc/>`_, a 
-framework for elegantly configuring complex applications. hydra-zen helps simplify the 
-process of using Hydra by providing specialized functions for :ref:`creating configs <create-config>` and 
-launching Hydra jobs. 
+It provides functions that :ref:`dynamically <create-config>` and :ref:`automatically <additional-types>` generate configs for your code, which help to eliminate 
+Hydra-specific boilerplate from your project. 
+
+hydra-zen is fully compatible with Hydra, and is appropriate for use in both rapid 
+prototypes and production-grade code. It is also great for designing your data science 
+and machine learning research to be reproducible. hydra-zen provides specialized 
+support for using NumPy, Jax, PyTorch, and Lightning (a.k.a PyTorch-Lightning) in your 
+Hydra application. 
 
 
 .. admonition:: Attention, Hydra users:
@@ -61,7 +66,7 @@ launching Hydra jobs.
 
      FooConf = builds(foo, bar=2, baz=["abc"], populate_full_signature=True)
   
-  You can even write dataclasses that aren't natively compatible with Hydra and dynamically convert them to Hydra-compatible structured configs.
+  You can even write dataclasses that aren't natively compatible with Hydra and then use hydra-zen to dynamically convert them to Hydra-compatible structured configs.
 
   .. code-block:: python
      :caption: Converting a general dataclass to a Hydra-compatible structured config
@@ -102,7 +107,7 @@ launching Hydra jobs.
 hydra-zen also also provides Hydra users with powerful, novel functionality. With it, we can:
 
 - Add :ref:`enhanced runtime type-checking <runtime-type-checking>` for our Hydra application, via :ref:`pydantic <pydantic-support>`, `beartype <https://github.com/beartype/beartype>`_, and other third-party libraries.
-- Design configs with specialized behaviors, like :ref:`partial configs <partial-config>`, or :ref:`configs with meta-fields <meta-field>`. 
+- Design configs specialized behaviors, like :ref:`configs with meta-fields <meta-field>`. 
 - Leverage a powerful :ref:`functionality-injection framework <zen-wrapper>` in our Hydra applications.
 - Run static type-checkers on our config-creation code to catch incompatibilities with Hydra.
 

--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -140,7 +140,7 @@ def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
 
     References
     ----------
-    .. [1] https://hydra.cc/docs/next/advanced/instantiate_objects/overview
+    .. [1] https://hydra.cc/docs/advanced/instantiate_objects/overview
     .. [2] https://omegaconf.readthedocs.io/en/latest/structured_config.html#simple-types
     .. [3] https://omegaconf.readthedocs.io/en/latest/structured_config.html#runtime-type-validation-and-conversion
     .. [4] https://omegaconf.readthedocs.io/en/latest/usage.html#variable-interpolation

--- a/src/hydra_zen/_launch.py
+++ b/src/hydra_zen/_launch.py
@@ -128,8 +128,8 @@ def launch(
 
     References
     ----------
-    .. [1] https://hydra.cc/docs/next/advanced/override_grammar/basic
-    .. [2] https://hydra.cc/docs/next/configure_hydra/intro
+    .. [1] https://hydra.cc/docs/advanced/override_grammar/basic
+    .. [2] https://hydra.cc/docs/configure_hydra/intro
     .. [3] https://hydra.cc/docs/tutorials/basic/running_your_app/multi-run
 
     Examples

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1161,18 +1161,12 @@ def builds(
             f"`populate_full_signature` must be a boolean type, got: {populate_full_signature}"
         )
 
-    if hydra_recursive is not None and not isinstance(hydra_recursive, bool):
-        raise TypeError(
-            f"`hydra_recursive` must be a boolean type, got {hydra_recursive}"
-        )
-
     if zen_partial is not None and not isinstance(zen_partial, bool):
         raise TypeError(f"`zen_partial` must be a boolean type, got: {zen_partial}")
 
-    if hydra_convert is not None and hydra_convert not in {"none", "partial", "all"}:
-        raise ValueError(
-            f"`hydra_convert` must be 'none', 'partial', or 'all', got: {hydra_convert}"
-        )
+    _utils.validate_hydra_options(
+        hydra_recursive=hydra_recursive, hydra_convert=hydra_convert
+    )
 
     if not isinstance(frozen, bool):
         raise TypeError(f"frozen must be a bool, got: {frozen}")

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -606,7 +606,7 @@ def sanitized_default_value(
             return _v
 
     # `value` could no be converted to Hydra-compatible representation.
-    # Raise error/
+    # Raise error
     if field_name:
         field_name = f", for field `{field_name}`,"
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -127,7 +127,7 @@ def _retain_type_info(type_: type, value: Any, hydra_recursive: Optional[bool]):
     return False
 
 
-def mutable_value(x: _T, *, zen_config: Optional[ZenConvert] = None) -> _T:
+def mutable_value(x: _T, *, zen_convert: Optional[ZenConvert] = None) -> _T:
     """Used to set a mutable object as a default value for a field
     in a dataclass.
 
@@ -160,7 +160,7 @@ def mutable_value(x: _T, *, zen_config: Optional[ZenConvert] = None) -> _T:
     HasMutableDefault(a_list=[1, 2, 3])"""
     cast = type(x)  # ensure that we return a copy of the default value
     convert_dataclass = (
-        zen_config.get("dataclass", False) if zen_config is not None else False
+        zen_convert.get("dataclass", False) if zen_convert is not None else False
     )
     x = sanitize_collection(x, convert_dataclass=convert_dataclass)
     return field(default_factory=lambda: cast(x))
@@ -609,7 +609,10 @@ def sanitized_field(
         and type_value in HYDRA_SUPPORTED_PRIMITIVES
     ):
         if _mutable_default_permitted:
-            return cast(Field[Any], mutable_value(value))
+            return cast(
+                Field[Any],
+                mutable_value(value, zen_convert={"dataclass": convert_dataclass}),
+            )
         else:  # pragma: no cover
             value = builds(
                 type(value), value, zen_convert={"dataclass": convert_dataclass}

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1482,7 +1482,7 @@ def builds(
                         sanitized_default_value(
                             x,
                             error_prefix=BUILDS_ERROR_PREFIX,
-                            convert_dataclass=False,
+                            convert_dataclass=zen_convert_settings["dataclass"],
                         )
                         for x in _pos_args
                     ),

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -575,6 +575,9 @@ def sanitized_default_value(
             if value.default_factory is not None  # type: ignore
             else value.default  # type: ignore
         )
+        if isinstance(_val, pydantic.fields.UndefinedType):
+            return MISSING
+
         return sanitized_default_value(
             _val,
             allow_zen_conversion=allow_zen_conversion,

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -198,6 +198,7 @@ def hydrated_dataclass(
     hydra_recursive: Optional[bool] = None,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = None,
     frozen: bool = False,
+    zen_convert: Optional[ZenConvert] = None,
 ) -> Callable[[Type[_T]], Type[_T]]:
     """A decorator that uses `builds` to create a dataclass with the appropriate
     Hydra-specific fields for specifying a targeted config [1]_.
@@ -373,6 +374,7 @@ def hydrated_dataclass(
             builds_bases=(decorated_obj,),
             dataclass_name=decorated_obj.__name__,
             frozen=frozen,
+            zen_convert=zen_convert,
         )
 
     return wrapper
@@ -460,6 +462,8 @@ def sanitized_default_value(
     field_name: str = "",
     structured_conf_permitted: bool = True,
     convert_dataclass: bool,
+    hydra_recursive: Optional[bool] = None,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = None,
 ) -> Any:
     if value is None or type(value) in {str, int, bool, float}:
         return value
@@ -496,7 +500,12 @@ def sanitized_default_value(
                     convert_dataclass=convert_dataclass,
                 )
 
-        out = builds(type(value), **converted_fields)
+        out = builds(
+            type(value),
+            **converted_fields,
+            hydra_recursive=hydra_recursive,
+            hydra_convert=hydra_convert,
+        )
         _check_for_dynamically_defined_dataclass_type(
             getattr(out, TARGET_FIELD_NAME), value
         )

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -584,6 +584,12 @@ def sanitized_default_value(
             hydra_recursive=hydra_recursive,
         )
 
+    if isinstance(value, str):
+        # Supports pydantic.AnyURL
+        _v = str(value)
+        if type(_v) is str:
+            return _v
+
     if field_name:
         field_name = f", for field `{field_name}`,"
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -258,6 +258,16 @@ def hydrated_dataclass(
         This option is not available for objects with inaccessible signatures, such as
         NumPy's various ufuncs.
 
+    zen_convert : Optional[ZenConvert]
+        A dictionary that modifies hydra-zen's value and type conversion behavior.
+        Consists of the following optional key-value pairs (:ref:`zen-convert`):
+
+        - `dataclass` : `bool` (default=True):
+            If `True` any dataclass type/instance without a
+            `_target_` field is automatically converted to a targeted config
+            that will instantiate to that type/instance. Otherwise the dataclass
+            type/instance will be passed through as-is.
+
     hydra_recursive : Optional[bool], optional (default=True)
         If ``True``, then Hydra will recursively instantiate all other
         hydra-config objects nested within this config [3]_.

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -547,7 +547,7 @@ def sanitized_default_value(
         # `value` is importable callable -- create config that will import
         # `value` upon instantiation
         out = _just(value)  # type: ignore
-        if is_dataclass(value):
+        if convert_dataclass and is_dataclass(value):
             _check_for_dynamically_defined_dataclass_type(
                 getattr(out, JUST_FIELD_NAME), value
             )

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -292,10 +292,10 @@ def hydrated_dataclass(
 
     References
     ----------
-    .. [1] https://hydra.cc/docs/next/tutorials/structured_config/intro/
+    .. [1] https://hydra.cc/docs/tutorials/structured_config/intro/
     .. [2] https://omegaconf.readthedocs.io/en/2.1_branch/usage.html#variable-interpolation
-    .. [3] https://hydra.cc/docs/next/advanced/instantiate_objects/overview/#recursive-instantiation
-    .. [4] https://hydra.cc/docs/next/advanced/instantiate_objects/overview/#parameter-conversion-strategies
+    .. [3] https://hydra.cc/docs/advanced/instantiate_objects/overview/#recursive-instantiation
+    .. [4] https://hydra.cc/docs/advanced/instantiate_objects/overview/#parameter-conversion-strategies
 
     Examples
     --------
@@ -811,8 +811,8 @@ def builds(
 ]:
     """builds(hydra_target, /, *pos_args, zen_partial=None, zen_wrappers=(), zen_meta=None, populate_full_signature=False, hydra_recursive=None, hydra_convert=None, hydra_defaults=None, frozen=False, dataclass_name=None, builds_bases=(), **kwargs_for_target)
 
-    Returns a structured config, which describes how to instantiate/call
-    ``<hydra_target>`` with both user-specified and auto-populated parameter values.
+    `builds(target, *args, **kw)` returns a config that builds `target` when
+    instantiated: `instantiate(builds(target, *args, **kw)) == target(*args, **kw)`
 
     Consult the Examples section of the docstring to see the various features of
     `builds` in action.
@@ -894,7 +894,7 @@ def builds(
 
     hydra_defaults : None | list[str | dict[str, str | list[str] | None ]], optional (default = None)
         A list in an input config that instructs Hydra how to build the output config
-        [7]_ [8]_. Each input config can have a Defaults List as a top level element. The
+        [6]_ [7]_. Each input config can have a Defaults List as a top level element. The
         Defaults List itself is not a part of output config.
 
     frozen : bool, optional (default=False)
@@ -924,7 +924,7 @@ def builds(
     Notes
     -----
     The resulting "config" is a dataclass-object [5]_ with Hydra-specific attributes
-    attached to it [1]_.
+    attached to it [1]_. It posseses a `_target_` attribute is a
 
     Using any of the ``zen_xx`` features will result in a config that depends
     explicitly on hydra-zen. I.e. hydra-zen must be installed in order to
@@ -943,14 +943,13 @@ def builds(
 
     References
     ----------
-    .. [1] https://hydra.cc/docs/next/tutorials/structured_config/intro/
+    .. [1] https://hydra.cc/docs/tutorials/structured_config/intro/
     .. [2] https://omegaconf.readthedocs.io/en/2.1_branch/usage.html#variable-interpolation
-    .. [3] https://hydra.cc/docs/next/advanced/instantiate_objects/overview/#recursive-instantiation
-    .. [4] https://hydra.cc/docs/next/advanced/instantiate_objects/overview/#parameter-conversion-strategies
+    .. [3] https://hydra.cc/docs/advanced/instantiate_objects/overview/#recursive-instantiation
+    .. [4] https://hydra.cc/docs/advanced/instantiate_objects/overview/#parameter-conversion-strategies
     .. [5] https://docs.python.org/3/library/dataclasses.html
-    .. [6] https://omegaconf.readthedocs.io/en/2.1_branch/usage.html#variable-interpolation
-    .. [7] https://hydra.cc/docs/next/tutorials/structured_config/defaults/
-    .. [8] https://hydra.cc/docs/next/advanced/defaults_list/
+    .. [6] https://hydra.cc/docs/tutorials/structured_config/defaults/
+    .. [7] https://hydra.cc/docs/advanced/defaults_list/
 
     See Also
     --------
@@ -1085,7 +1084,7 @@ def builds(
     instantiation process. Thus arbitrary metadata can be attached to a config.
 
     Let's create a config whose fields reference a meta-field via
-    relative-interpolation [6]_.
+    relative-interpolation [2]_.
 
     >>> Conf = builds(dict, a="${.s}", b="${.s}", zen_meta=dict(s=-10))
     >>> instantiate(Conf)

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -489,7 +489,7 @@ def sanitized_default_value(
                     field_name=_field.name,
                     dataclass_passthrough=False,
                 )
-        print("HEE")
+
         out = builds(type(value), **converted_fields)
         _check_for_dynamically_defined_dataclass_type(
             getattr(out, TARGET_FIELD_NAME), value

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -481,8 +481,8 @@ def sanitized_default_value(
     if (
         structured_conf_permitted
         and convert_dataclass
-        and (is_dataclass(value) and not isinstance(value, type))
         and not is_builds(value)
+        and (is_dataclass(value) and not isinstance(value, type))
     ):
         # Auto-config dataclass instance
         # TODO: handle position-only arguments

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -56,12 +56,14 @@ from hydra_zen.typing import (
     ZenWrappers,
 )
 from hydra_zen.typing._implementations import (
+    AllConvert,
     BuildsWithSig,
     DataClass_,
     DefaultsList,
     Field,
     HasTarget,
     InstOrType,
+    ZenConvert,
 )
 
 from ._globals import (
@@ -162,6 +164,8 @@ def mutable_value(x: _T) -> _T:
 
 
 Field_Entry = Tuple[str, type, Field[Any]]
+
+_BUILDS_CONVERT_SETTINGS = AllConvert(dataclass=True)
 
 
 # Alternate form, from PEP proposal:
@@ -632,6 +636,7 @@ def builds(
     dataclass_name: Optional[str] = ...,
     builds_bases: Tuple[()] = ...,
     frozen: bool = ...,
+    zen_convert: Optional[ZenConvert] = ...,
 ) -> Type[BuildsWithSig[Type[R], P]]:  # pragma: no cover
     ...
 
@@ -651,6 +656,7 @@ def builds(
     dataclass_name: Optional[str] = ...,
     builds_bases: Tuple[Type[DataClass_], ...] = ...,
     frozen: bool = ...,
+    zen_convert: Optional[ZenConvert] = ...,
     **kwargs_for_target: SupportedPrimitive,
 ) -> Type[Builds[Importable]]:  # pragma: no cover
     ...
@@ -671,6 +677,7 @@ def builds(
     dataclass_name: Optional[str] = ...,
     builds_bases: Tuple[Type[DataClass_], ...] = ...,
     frozen: bool = ...,
+    zen_convert: Optional[ZenConvert] = ...,
     **kwargs_for_target: SupportedPrimitive,
 ) -> Type[PartialBuilds[Importable]]:  # pragma: no cover
     ...
@@ -691,6 +698,7 @@ def builds(
     dataclass_name: Optional[str] = ...,
     builds_bases: Tuple[Type[DataClass_], ...] = ...,
     frozen: bool = ...,
+    zen_convert: Optional[ZenConvert] = ...,
     **kwargs_for_target: SupportedPrimitive,
 ) -> Union[
     Type[Builds[Importable]],
@@ -714,6 +722,7 @@ def builds(
     dataclass_name: Optional[str] = ...,
     builds_bases: Tuple[Type[DataClass_], ...] = ...,
     frozen: bool = ...,
+    zen_convert: Optional[ZenConvert] = ...,
     **kwargs_for_target: SupportedPrimitive,
 ) -> Union[
     Type[Builds[Importable]],
@@ -735,6 +744,7 @@ def builds(
     frozen: bool = False,
     builds_bases: Tuple[Type[DataClass_], ...] = (),
     dataclass_name: Optional[str] = None,
+    zen_convert: Optional[ZenConvert] = None,
     **kwargs_for_target: SupportedPrimitive,
 ) -> Union[
     Type[Builds[Importable]],
@@ -1077,6 +1087,9 @@ def builds(
     >>> instantiate(Conf(a=-4))  # equivalent to calling: `partiald_dict(a=-4)`
     {'a': -4, 'b': 2}
     """
+
+    if not zen_convert:
+        zen_convert = {}
 
     if not pos_args and not kwargs_for_target:
         # `builds()`

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -816,8 +816,7 @@ def builds(
 ]:
     """builds(hydra_target, /, *pos_args, zen_partial=None, zen_wrappers=(), zen_meta=None, populate_full_signature=False, hydra_recursive=None, hydra_convert=None, hydra_defaults=None, frozen=False, dataclass_name=None, builds_bases=(), **kwargs_for_target)
 
-    `builds(target, *args, **kw)` returns a config that builds `target` when
-    instantiated.
+    `builds(target, *args, **kw)` returns a config that, when instantiated, builds `target`.
 
     `instantiate(builds(target, *args, **kw)) == target(*args, **kw)`
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -159,10 +159,9 @@ def mutable_value(x: _T, *, zen_convert: Optional[ZenConvert] = None) -> _T:
     >>> HasMutableDefault()
     HasMutableDefault(a_list=[1, 2, 3])"""
     cast = type(x)  # ensure that we return a copy of the default value
-    convert_dataclass = (
-        zen_convert.get("dataclass", False) if zen_convert is not None else False
-    )
-    x = sanitize_collection(x, convert_dataclass=convert_dataclass)
+    settings = _utils.merge_settings(zen_convert, _BUILDS_CONVERT_SETTINGS)
+    del zen_convert
+    x = sanitize_collection(x, convert_dataclass=settings["dataclass"])
     return field(default_factory=lambda: cast(x))
 
 

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -103,11 +103,11 @@ def just(
     hydra_recursive: Optional[bool] = None,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = None,
 ) -> Any:
-    """`just(obj)` returns a config that just returns `obj` when instantiated.
+    """`just(obj)` returns a config that, when instantiated, just returns `obj`.
 
     `instantiate(just(obj)) == obj`
 
-    `just` is designed to be idempotent: `just(obj) is just(just(obj))`
+    `just` is designed to be idempotent: `just(obj) == just(just(obj))`
 
     Parameters
     ----------
@@ -223,24 +223,27 @@ def just(
 
     `just` operates recursively within sequences and mappings.
 
-    >>> just({'a': [3-4j, 1+2j]})
-    'a': [ConfigComplex(real=3.0, imag=-4.0, _target_='builtins.complex'),
-         ConfigComplex(real=1.0, imag=2.0, _target_='builtins.complex')]}
-
     By default, `just` will convert a dataclass instance (including pydantic
     dataclasses) to a targeted config that will recreate the instance upon
-    Hydra-instantiation.
+    Hydra-instantiation. This enables users to leverage annotations and datatypes
+    that are not supported directly by Hydra.
 
     >>> from dataclasses import dataclass
     >>> @dataclass
     ... class B:
-    ...     x: int
+    ...     x: complex
     >>>
-    >>> Conf = just(B(x=1))
+    >>> Conf = just(B(x=2+3j))
     >>> Conf._target_, Conf.x
-    ('__main__.B', 1)
+    (__main__.B, ConfigComplex(real=2.0, imag=3.0, _target_='builtins.complex'))
     >>> instantiate(Conf)
-    B(x=1)
+    B(x=(2+3j))
+
+    >>> z_dict = {'a': [3-4j, 1+2j]}
+    >>> just(z_dict)
+    'a': [ConfigComplex(real=3.0, imag=-4.0, _target_='builtins.complex'),
+         ConfigComplex(real=1.0, imag=2.0, _target_='builtins.complex')]}
+    >>> assert instantiate(just(z_dict)) == z_dict
 
     This behavior can be modified via :ref:`zen-convert settings<zen-convert>`.
 

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -15,6 +15,7 @@ from hydra_zen.typing._implementations import (
 )
 
 from ._implementations import sanitized_default_value
+from ._utils import merge_settings
 from ._value_conversion import ConfigComplex
 
 # pyright: strict
@@ -198,17 +199,14 @@ def just(obj: Any, *, zen_convert: Optional[ZenConvert] = None) -> Any:
     >>> conf.reduction_fn(conf.data)
     (3+5j)
     """
-    if not zen_convert:
-        zen_convert = {}
+    convert_settings = merge_settings(zen_convert, _JUST_CONVERT_SETTINGS)
+    del zen_convert
 
-    dataclass_passthrough = not zen_convert.get(
-        "dataclass", _JUST_CONVERT_SETTINGS["dataclass"]
-    )
     return sanitized_default_value(
         obj,
         allow_zen_conversion=True,
         structured_conf_permitted=True,
         field_name="",
         error_prefix="",
-        dataclass_passthrough=dataclass_passthrough,
+        convert_dataclass=convert_settings["dataclass"],
     )

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -167,4 +167,5 @@ def just(obj: Any) -> Any:
         structured_conf_permitted=True,
         field_name="",
         error_prefix="",
+        dataclass_passthrough=False,
     )

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
-from typing import Any, FrozenSet, Literal, Optional, Type, TypeVar, Union, overload
+from typing import Any, FrozenSet, Optional, Type, TypeVar, Union, overload
+
+from typing_extensions import Literal
 
 from hydra_zen.typing import Builds, Importable, Just
 from hydra_zen.typing._implementations import _HydraPrimitive  # type: ignore

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -4,6 +4,7 @@ from typing import Any, FrozenSet, Optional, Type, TypeVar, Union, overload
 
 from typing_extensions import Literal
 
+from hydra_zen.structured_configs import _utils
 from hydra_zen.typing import Builds, Importable, Just
 from hydra_zen.typing._implementations import _HydraPrimitive  # type: ignore
 from hydra_zen.typing._implementations import _SupportedViaBuilds  # type: ignore
@@ -233,6 +234,9 @@ def just(
     """
     convert_settings = merge_settings(zen_convert, _JUST_CONVERT_SETTINGS)
     del zen_convert
+    _utils.validate_hydra_options(
+        hydra_recursive=hydra_recursive, hydra_convert=hydra_convert
+    )
 
     return sanitized_default_value(
         obj,

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -103,9 +103,7 @@ def just(
     hydra_recursive: Optional[bool] = None,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = None,
 ) -> Any:
-    """`just(obj)` returns a config that "just" returns `obj` when instantiated.
-
-    `instantiate(just(obj)) == obj`
+    """`just(obj)` returns a config that just returns `obj` when instantiated: `instantiate(just(obj)) == obj`
 
     Parameters
     ----------

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -30,46 +30,78 @@ _JUST_CONVERT_SETTINGS = AllConvert(dataclass=True)
 
 
 @overload
-def just(obj: TP, *, zen_convert: Optional[ZenConvert] = ...) -> TP:  # pragma: no cover
+def just(
+    obj: TP,
+    *,
+    zen_convert: Optional[ZenConvert] = ...,
+    hydra_recursive: Optional[bool] = ...,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
+) -> TP:  # pragma: no cover
     ...
 
 
 @overload
 def just(
-    obj: complex, *, zen_convert: Optional[ZenConvert] = ...
+    obj: complex,
+    *,
+    zen_convert: Optional[ZenConvert] = ...,
+    hydra_recursive: Optional[bool] = ...,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
 ) -> ConfigComplex:  # pragma: no cover
     ...
 
 
 @overload
 def just(
-    obj: TB, *, zen_convert: Optional[ZenConvert] = ...
+    obj: TB,
+    *,
+    zen_convert: Optional[ZenConvert] = ...,
+    hydra_recursive: Optional[bool] = ...,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
 ) -> Builds[Type[TB]]:  # pragma: no cover
     ...
 
 
 @overload
 def just(
-    obj: InstOrType[TD], *, zen_convert: Literal[None] = ...
+    obj: InstOrType[TD],
+    *,
+    zen_convert: Literal[None] = ...,
+    hydra_recursive: Optional[bool] = ...,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
 ) -> Type[Builds[Type[TD]]]:  # pragma: no cover
     ...
 
 
 @overload
 def just(
-    obj: Importable, *, zen_convert: Optional[ZenConvert] = ...
+    obj: Importable,
+    *,
+    zen_convert: Optional[ZenConvert] = ...,
+    hydra_recursive: Optional[bool] = ...,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
 ) -> Type[Just[Importable]]:  # pragma: no cover
     ...
 
 
 @overload
 def just(
-    obj: Any, *, zen_convert: Optional[ZenConvert] = ...
+    obj: Any,
+    *,
+    zen_convert: Optional[ZenConvert] = ...,
+    hydra_recursive: Optional[bool] = ...,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
 ) -> Any:  # pragma: no cover
     ...
 
 
-def just(obj: Any, *, zen_convert: Optional[ZenConvert] = None) -> Any:
+def just(
+    obj: Any,
+    *,
+    zen_convert: Optional[ZenConvert] = None,
+    hydra_recursive: Optional[bool] = None,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = None,
+) -> Any:
     """`just(obj)` returns a config that "just" returns `obj` when instantiated.
 
     `instantiate(just(obj)) == obj`
@@ -209,4 +241,6 @@ def just(obj: Any, *, zen_convert: Optional[ZenConvert] = None) -> Any:
         field_name="",
         error_prefix="",
         convert_dataclass=convert_settings["dataclass"],
+        hydra_convert=hydra_convert,
+        hydra_recursive=hydra_recursive,
     )

--- a/src/hydra_zen/structured_configs/_make_config.py
+++ b/src/hydra_zen/structured_configs/_make_config.py
@@ -242,14 +242,14 @@ def make_config(
 
     References
     ----------
-    .. [1] https://hydra.cc/docs/next/tutorials/structured_config/intro/
-    .. [2] https://hydra.cc/docs/next/advanced/instantiate_objects/overview/#recursive-instantiation
-    .. [3] https://hydra.cc/docs/next/advanced/instantiate_objects/overview/#parameter-conversion-strategies
+    .. [1] https://hydra.cc/docs/tutorials/structured_config/intro/
+    .. [2] https://hydra.cc/docs/advanced/instantiate_objects/overview/#recursive-instantiation
+    .. [3] https://hydra.cc/docs/advanced/instantiate_objects/overview/#parameter-conversion-strategies
     .. [4] https://docs.python.org/3/library/dataclasses.html
-    .. [5] https://hydra.cc/docs/next/tutorials/structured_config/intro/#structured-configs-supports
+    .. [5] https://hydra.cc/docs/tutorials/structured_config/intro/#structured-configs-supports
     .. [6] https://docs.python.org/3/library/dataclasses.html#default-factory-functions
-    .. [7] https://hydra.cc/docs/next/tutorials/structured_config/defaults/
-    .. [8] https://hydra.cc/docs/next/advanced/defaults_list/
+    .. [7] https://hydra.cc/docs/tutorials/structured_config/defaults/
+    .. [8] https://hydra.cc/docs/advanced/defaults_list/
 
     Examples
     --------

--- a/src/hydra_zen/structured_configs/_make_config.py
+++ b/src/hydra_zen/structured_configs/_make_config.py
@@ -115,7 +115,7 @@ def _repack_zenfield(
     bases: Tuple[DataClass_, ...],
     zen_convert: ZenConvert,
 ):
-    default = (value.default,)
+    default = value.default
 
     if (
         PATCH_OMEGACONF_830

--- a/src/hydra_zen/structured_configs/_make_config.py
+++ b/src/hydra_zen/structured_configs/_make_config.py
@@ -498,7 +498,7 @@ def make_config(
         )
 
     if hydra_defaults is not None:
-        hydra_defaults = sanitize_collection(hydra_defaults)
+        hydra_defaults = sanitize_collection(hydra_defaults, convert_dataclass=False)
         config_fields.append(
             (
                 DEFAULTS_LIST_FIELD_NAME,

--- a/src/hydra_zen/structured_configs/_make_config.py
+++ b/src/hydra_zen/structured_configs/_make_config.py
@@ -88,7 +88,8 @@ class ZenField:
 
         if self.default is not NOTHING:
             self.default = sanitized_field(
-                self.default, _mutable_default_permitted=_permit_default_factory
+                self.default,
+                _mutable_default_permitted=_permit_default_factory,
             )
 
 
@@ -389,7 +390,7 @@ def make_config(
         hydra_convert=hydra_convert,
         hydra_recursive=hydra_recursive,
         hydra_defaults=hydra_defaults,
-        **fields_as_kwargs,
+        **{k: None for k in fields_as_kwargs},
     )
 
     normalized_fields: Dict[str, ZenField] = {}

--- a/src/hydra_zen/structured_configs/_make_config.py
+++ b/src/hydra_zen/structured_configs/_make_config.py
@@ -169,6 +169,19 @@ def make_config(
 
         Named parameters of the forms ``hydra_xx``, ``zen_xx``, and ``_zen_xx`` are reserved to ensure future-compatibility, and cannot be specified by the user.
 
+    zen_convert : Optional[ZenConvert]
+        A dictionary that modifies hydra-zen's value and type conversion behavior.
+        Consists of the following optional key-value pairs (:ref:`zen-convert`):
+
+        - `dataclass` : `bool` (default=False):
+            If `True` any dataclass type/instance without a
+            `_target_` field is automatically converted to a targeted config
+            that will instantiate to that type/instance. Otherwise the dataclass
+            type/instance will be passed through as-is.
+
+    bases : Tuple[Type[DataClass], ...], optional (default=())
+        Base classes that the resulting config class will inherit from.
+
     hydra_recursive : Optional[bool], optional (default=True)
         If ``True``, then Hydra will recursively instantiate all other
         hydra-config objects nested within this dataclass [2]_.
@@ -189,10 +202,6 @@ def make_config(
         A list in an input config that instructs Hydra how to build the output config
         [7]_ [8]_. Each input config can have a Defaults List as a top level element. The
         Defaults List itself is not a part of output config.
-
-
-    bases : Tuple[Type[DataClass], ...], optional (default=())
-        Base classes that the resulting config class will inherit from.
 
     frozen : bool, optional (default=False)
         If ``True``, the resulting config class will produce 'frozen' (i.e. immutable) instances.

--- a/src/hydra_zen/structured_configs/_make_custom_builds.py
+++ b/src/hydra_zen/structured_configs/_make_custom_builds.py
@@ -22,7 +22,7 @@ from typing_extensions import Final, Literal
 from hydra_zen.errors import HydraZenDeprecationWarning
 from hydra_zen.typing import ZenWrappers
 from hydra_zen.typing._builds_overloads import FullBuilds, PBuilds, StdBuilds
-from hydra_zen.typing._implementations import DataClass_
+from hydra_zen.typing._implementations import DataClass_, ZenConvert
 
 from ._implementations import builds
 
@@ -50,6 +50,7 @@ def make_custom_builds_fn(
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
     builds_bases: Tuple[()] = ...,
+    zen_convert: Optional[ZenConvert] = ...,
 ) -> FullBuilds:  # pragma: no cover
     ...
 
@@ -66,6 +67,7 @@ def make_custom_builds_fn(
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
     builds_bases: Tuple[Type[DataClass_], ...] = ...,
+    zen_convert: Optional[ZenConvert] = ...,
 ) -> PBuilds:  # pragma: no cover
     ...
 
@@ -82,6 +84,7 @@ def make_custom_builds_fn(
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
     builds_bases: Tuple[()] = ...,
+    zen_convert: Optional[ZenConvert] = ...,
 ) -> StdBuilds:  # pragma: no cover
     ...
 
@@ -98,6 +101,7 @@ def make_custom_builds_fn(
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
     builds_bases: Tuple[()] = ...,
+    zen_convert: Optional[ZenConvert] = ...,
 ) -> Union[FullBuilds, StdBuilds]:  # pragma: no cover
     ...
 
@@ -114,6 +118,7 @@ def make_custom_builds_fn(
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
     builds_bases: Tuple[Type[DataClass_], ...],
+    zen_convert: Optional[ZenConvert] = ...,
 ) -> StdBuilds:  # pragma: no cover
     ...
 
@@ -130,6 +135,7 @@ def make_custom_builds_fn(
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
     builds_bases: Tuple[Type[DataClass_], ...] = ...,
+    zen_convert: Optional[ZenConvert] = ...,
 ) -> Union[PBuilds, StdBuilds]:  # pragma: no cover
     ...
 
@@ -146,6 +152,7 @@ def make_custom_builds_fn(
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
     builds_bases: Tuple[Type[DataClass_], ...],
+    zen_convert: Optional[ZenConvert] = ...,
 ) -> Union[PBuilds, StdBuilds]:  # pragma: no cover
     ...
 
@@ -162,6 +169,7 @@ def make_custom_builds_fn(
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
     builds_bases: Tuple[()] = ...,
+    zen_convert: Optional[ZenConvert] = ...,
 ) -> Union[FullBuilds, PBuilds, StdBuilds]:  # pragma: no cover
     ...
 
@@ -176,6 +184,7 @@ def make_custom_builds_fn(
     hydra_convert: Optional[Literal["none", "partial", "all"]] = None,
     frozen: bool = False,
     builds_bases: Tuple[Type[DataClass_], ...] = (),
+    zen_convert: Optional[ZenConvert] = None,
 ) -> Union[FullBuilds, PBuilds, StdBuilds]:
     """Returns the `builds` function, but with customized default values.
 

--- a/src/hydra_zen/structured_configs/_make_custom_builds.py
+++ b/src/hydra_zen/structured_configs/_make_custom_builds.py
@@ -309,4 +309,5 @@ def make_custom_builds_fn(
         merged_kwargs.update(kwargs)
         return builds(*args, **merged_kwargs)
 
+    setattr(wrapped, "_zen_convert", zen_convert)
     return cast(Union[FullBuilds, PBuilds, StdBuilds], wrapped)

--- a/src/hydra_zen/structured_configs/_make_custom_builds.py
+++ b/src/hydra_zen/structured_configs/_make_custom_builds.py
@@ -206,6 +206,16 @@ def make_custom_builds_fn(
     populate_full_signature : bool, optional (default=False)
         Specifies a new the default value for ``builds(..., populate_full_signature=<..>)``
 
+    zen_convert : Optional[ZenConvert]
+        A dictionary that modifies hydra-zen's value and type conversion behavior.
+        Consists of the following optional key-value pairs (:ref:`zen-convert`):
+
+        - `dataclass` : `bool` (default=True):
+            If `True` any dataclass type/instance without a
+            `_target_` field is automatically converted to a targeted config
+            that will instantiate to that type/instance. Otherwise the dataclass
+            type/instance will be passed through as-is.
+
     hydra_recursive : Optional[bool], optional (default=True)
         Specifies a new the default value for ``builds(..., hydra_recursive=<..>)``
 
@@ -296,7 +306,7 @@ def make_custom_builds_fn(
         warnings.warn(
             HydraZenDeprecationWarning(
                 "Specifying `make_custom_builds_fn(builds_bases=<...>)` is deprecated "
-                "as of hydra-zen 0.7.0. It will be an error in hydra-zen 0.8.0. "
+                "as of hydra-zen 0.7.0. It will be an error in hydra-zen 0.9.0. "
                 "\n`builds_bases` must be specified via `builds` manually."
             ),
             stacklevel=2,

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -594,7 +594,7 @@ def merge_settings(
 def validate_hydra_options(
     hydra_recursive: Optional[bool] = None,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = None,
-):
+) -> None:
     if hydra_recursive is not None and not isinstance(hydra_recursive, bool):
         raise TypeError(
             f"`hydra_recursive` must be a boolean type, got {hydra_recursive}"

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -570,6 +570,7 @@ def valid_defaults_list(hydra_defaults: Any) -> bool:
 def merge_settings(
     user_settings: Optional[ZenConvert], default_settings: AllConvert
 ) -> AllConvert:
+    """Merges settings as `default_settings.update(user_settings)`"""
     if user_settings is not None and not isinstance(user_settings, Mapping):
         raise TypeError(
             f"`zen_convert` is None or a Mapping (e.g. dict). Got {user_settings}"

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -574,7 +574,7 @@ def merge_settings(
     """Merges settings as `default_settings.update(user_settings)`"""
     if user_settings is not None and not isinstance(user_settings, Mapping):
         raise TypeError(
-            f"`zen_convert` is None or a Mapping (e.g. dict). Got {user_settings}"
+            f"`zen_convert` must be None or Mapping[str, Any] (e.g. dict). Got {user_settings}"
         )
     settings = default_settings.copy()
     if user_settings:

--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -28,6 +28,7 @@ from omegaconf import II, DictConfig, ListConfig
 from typing_extensions import (
     Annotated,
     Final,
+    Literal,
     ParamSpecArgs,
     ParamSpecKwargs,
     TypeGuard,
@@ -588,3 +589,18 @@ def merge_settings(
                 )
             settings[k] = v
     return settings
+
+
+def validate_hydra_options(
+    hydra_recursive: Optional[bool] = None,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = None,
+):
+    if hydra_recursive is not None and not isinstance(hydra_recursive, bool):
+        raise TypeError(
+            f"`hydra_recursive` must be a boolean type, got {hydra_recursive}"
+        )
+
+    if hydra_convert is not None and hydra_convert not in {"none", "partial", "all"}:
+        raise ValueError(
+            f"`hydra_convert` must be 'none', 'partial', or 'all', got: {hydra_convert}"
+        )

--- a/src/hydra_zen/structured_configs/_value_conversion.py
+++ b/src/hydra_zen/structured_configs/_value_conversion.py
@@ -1,18 +1,18 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
-
+import functools
+from collections import Counter, deque
 from dataclasses import dataclass, field
 from pathlib import Path, PosixPath, WindowsPath
-from typing import Any, Callable, Dict, Tuple, Type, cast
+from typing import Any, Callable, Tuple, Type, TypeVar, cast
 
 from hydra_zen._compatibility import ZEN_SUPPORTED_PRIMITIVES
-from hydra_zen.typing import Builds
+from hydra_zen.typing import Builds, Partial, PartialBuilds
 
+from ._implementations import ZEN_VALUE_CONVERSION, builds
 from ._utils import get_obj_path
 
-# Some primitive support implemented in _implementations.py
-
-ZEN_VALUE_CONVERSION: Dict[type, Callable[[Any], Any]] = {}
+_T = TypeVar("_T")
 
 
 @dataclass
@@ -43,3 +43,31 @@ if Path in ZEN_SUPPORTED_PRIMITIVES:  # pragma no cover
     ZEN_VALUE_CONVERSION[Path] = convert_path
     ZEN_VALUE_CONVERSION[PosixPath] = convert_path
     ZEN_VALUE_CONVERSION[WindowsPath] = convert_path
+
+
+# registering value-conversions that depend on `builds`
+def _cast_via_tuple(dest_type: Type[_T]) -> Callable[[_T], Builds[Type[_T]]]:
+    def converter(value):
+        return builds(dest_type, tuple(value))()
+
+    return converter
+
+
+def _unpack_partial(value: Partial[_T]) -> PartialBuilds[Type[_T]]:
+    target = cast(Type[_T], value.func)
+    return builds(target, *value.args, **value.keywords, zen_partial=True)()
+
+
+ZEN_VALUE_CONVERSION[set] = _cast_via_tuple(set)
+ZEN_VALUE_CONVERSION[frozenset] = _cast_via_tuple(frozenset)
+ZEN_VALUE_CONVERSION[deque] = _cast_via_tuple(deque)
+
+if bytes in ZEN_SUPPORTED_PRIMITIVES:  # pragma: no cover
+    ZEN_VALUE_CONVERSION[bytes] = _cast_via_tuple(bytes)
+
+ZEN_VALUE_CONVERSION[bytearray] = _cast_via_tuple(bytearray)
+ZEN_VALUE_CONVERSION[range] = lambda value: builds(
+    range, value.start, value.stop, value.step
+)()
+ZEN_VALUE_CONVERSION[Counter] = lambda counter: builds(Counter, dict(counter))()
+ZEN_VALUE_CONVERSION[functools.partial] = _unpack_partial

--- a/src/hydra_zen/typing/__init__.py
+++ b/src/hydra_zen/typing/__init__.py
@@ -9,6 +9,7 @@ from ._implementations import (
     Partial,
     PartialBuilds,
     SupportedPrimitive,
+    ZenConvert,
     ZenPartialBuilds,
     ZenWrappers,
 )
@@ -23,4 +24,5 @@ __all__ = [
     "ZenWrappers",
     "ZenPartialBuilds",
     "HydraPartialBuilds",
+    "ZenConvert",
 ]

--- a/src/hydra_zen/typing/_builds_overloads.py
+++ b/src/hydra_zen/typing/_builds_overloads.py
@@ -26,6 +26,7 @@ from ._implementations import (
     Importable,
     PartialBuilds,
     SupportedPrimitive,
+    ZenConvert,
     ZenWrappers,
 )
 
@@ -53,6 +54,7 @@ class StdBuilds(Protocol):  # pragma: no cover
         dataclass_name: Optional[str] = ...,
         builds_bases: Tuple[()] = ...,
         frozen: bool = ...,
+        zen_convert: Optional[ZenConvert] = ...,
     ) -> Type[BuildsWithSig[Type[R], P]]:  # pragma: no cover
         ...
 
@@ -72,6 +74,7 @@ class StdBuilds(Protocol):  # pragma: no cover
         dataclass_name: Optional[str] = ...,
         builds_bases: Tuple[Type[DataClass_], ...] = ...,
         frozen: bool = ...,
+        zen_convert: Optional[ZenConvert] = ...,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Type[Builds[Importable]]:  # pragma: no cover
         ...
@@ -92,6 +95,7 @@ class StdBuilds(Protocol):  # pragma: no cover
         dataclass_name: Optional[str] = ...,
         builds_bases: Tuple[Type[DataClass_], ...] = ...,
         frozen: bool = ...,
+        zen_convert: Optional[ZenConvert] = ...,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Type[PartialBuilds[Importable]]:  # pragma: no cover
         ...
@@ -112,6 +116,7 @@ class StdBuilds(Protocol):  # pragma: no cover
         dataclass_name: Optional[str] = ...,
         builds_bases: Tuple[Type[DataClass_], ...] = ...,
         frozen: bool = ...,
+        zen_convert: Optional[ZenConvert] = ...,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Union[
         Type[Builds[Importable]],
@@ -135,6 +140,7 @@ class StdBuilds(Protocol):  # pragma: no cover
         dataclass_name: Optional[str] = ...,
         builds_bases: Tuple[Type[DataClass_], ...] = ...,
         frozen: bool = ...,
+        zen_convert: Optional[ZenConvert] = ...,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Union[
         Type[Builds[Importable]],
@@ -157,6 +163,7 @@ class StdBuilds(Protocol):  # pragma: no cover
         frozen: bool = False,
         builds_bases: Tuple[Type[DataClass_], ...] = (),
         dataclass_name: Optional[str] = None,
+        zen_convert: Optional[ZenConvert] = None,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Union[
         Type[Builds[Importable]],
@@ -185,6 +192,7 @@ class FullBuilds(Protocol):  # pragma: no cover
         dataclass_name: Optional[str] = ...,
         builds_bases: Tuple[()] = ...,
         frozen: bool = ...,
+        zen_convert: Optional[ZenConvert] = ...,
     ) -> Type[BuildsWithSig[Type[R], P]]:
         ...
 
@@ -204,6 +212,7 @@ class FullBuilds(Protocol):  # pragma: no cover
         dataclass_name: Optional[str] = ...,
         builds_bases: Tuple[Type[DataClass_], ...] = ...,
         frozen: bool = ...,
+        zen_convert: Optional[ZenConvert] = ...,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Type[Builds[Importable]]:
         ...
@@ -224,6 +233,7 @@ class FullBuilds(Protocol):  # pragma: no cover
         dataclass_name: Optional[str] = ...,
         builds_bases: Tuple[Type[DataClass_], ...] = ...,
         frozen: bool = ...,
+        zen_convert: Optional[ZenConvert] = ...,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Type[PartialBuilds[Importable]]:
         ...
@@ -244,6 +254,7 @@ class FullBuilds(Protocol):  # pragma: no cover
         frozen: bool = ...,
         builds_bases: Tuple[Type[DataClass_], ...] = ...,
         dataclass_name: Optional[str] = ...,
+        zen_convert: Optional[ZenConvert] = ...,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Union[Type[Builds[Importable]], Type[PartialBuilds[Importable]]]:
         ...
@@ -264,6 +275,7 @@ class FullBuilds(Protocol):  # pragma: no cover
         frozen: bool = ...,
         builds_bases: Tuple[Type[DataClass_], ...] = ...,
         dataclass_name: Optional[str] = ...,
+        zen_convert: Optional[ZenConvert] = ...,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Union[
         Type[Builds[Importable]],
@@ -286,6 +298,7 @@ class FullBuilds(Protocol):  # pragma: no cover
         frozen: bool = False,
         builds_bases: Tuple[Type[DataClass_], ...] = (),
         dataclass_name: Optional[str] = None,
+        zen_convert: Optional[ZenConvert] = None,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Union[
         Type[Builds[Importable]],
@@ -314,6 +327,7 @@ class PBuilds(Protocol):  # pragma: no cover
         dataclass_name: Optional[str] = ...,
         builds_bases: Tuple[Type[DataClass_], ...] = ...,
         frozen: bool = ...,
+        zen_convert: Optional[ZenConvert] = ...,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Type[PartialBuilds[Importable]]:
         ...
@@ -334,6 +348,7 @@ class PBuilds(Protocol):  # pragma: no cover
         dataclass_name: Optional[str] = ...,
         builds_bases: Tuple[()] = ...,
         frozen: bool = ...,
+        zen_convert: Optional[ZenConvert] = ...,
     ) -> Type[BuildsWithSig[Type[R], P]]:
         ...
 
@@ -353,6 +368,7 @@ class PBuilds(Protocol):  # pragma: no cover
         dataclass_name: Optional[str] = ...,
         builds_bases: Tuple[Type[DataClass_], ...] = ...,
         frozen: bool = ...,
+        zen_convert: Optional[ZenConvert] = ...,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Union[
         Type[Builds[Importable]],
@@ -376,6 +392,7 @@ class PBuilds(Protocol):  # pragma: no cover
         dataclass_name: Optional[str] = ...,
         builds_bases: Tuple[Type[DataClass_], ...] = ...,
         frozen: bool = ...,
+        zen_convert: Optional[ZenConvert] = ...,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Union[
         Type[Builds[Importable]],
@@ -400,6 +417,7 @@ class PBuilds(Protocol):  # pragma: no cover
         dataclass_name: Optional[str] = ...,
         builds_bases: Tuple[Type[DataClass_], ...] = ...,
         frozen: bool = ...,
+        zen_convert: Optional[ZenConvert] = ...,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Union[
         Type[Builds[Importable]],
@@ -422,6 +440,7 @@ class PBuilds(Protocol):  # pragma: no cover
         frozen: bool = False,
         builds_bases: Tuple[Type[DataClass_], ...] = (),
         dataclass_name: Optional[str] = None,
+        zen_convert: Optional[ZenConvert] = None,
         **kwargs_for_target: SupportedPrimitive,
     ) -> Union[
         Type[Builds[Importable]],

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -31,6 +31,7 @@ from typing import (
 from omegaconf import DictConfig, ListConfig
 from typing_extensions import (
     Literal,
+    NotRequired,
     ParamSpec,
     Protocol,
     Self,
@@ -249,3 +250,11 @@ else:
 DefaultsList = List[
     Union[str, DataClass_, Mapping[str, Union[None, str, Sequence[str]]]]
 ]
+
+
+class AllConvert(TypedDict):
+    dataclass: bool
+
+
+class ZenConvert(TypedDict, total=False):
+    dataclass: NotRequired[bool]

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -275,9 +275,11 @@ class ZenConvert(TypedDict, total=False):
         If `True` any dataclass type/instance without a `_target_` field is
         automatically converted to a targeted config that will instantiate to that type/
         instance. Otherwise the dataclass type/instance will be passed through as-is.
-        Note that this only works with statically-defined dataclass types, where
+
+        Note that this only works with statically-defined dataclass types, whereas
         :func:`~hydra_zen.make_config` and :py:func:`dataclasses.make_dataclass`
-        dynamically generate dataclass types.
+        dynamically generate dataclass types. Additionally, this feature is not
+        compatible with a dataclass instance whose type possesses an `InitVar` field.
 
     Examples
     --------

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -32,7 +32,6 @@ from omegaconf import DictConfig, ListConfig
 from typing_extensions import (
     Final,
     Literal,
-    NotRequired,
     ParamSpec,
     Protocol,
     Self,
@@ -51,6 +50,7 @@ __all__ = [
     "ZenWrappers",
     "ZenPartialBuilds",
     "HydraPartialBuilds",
+    "ZenConvert",
 ]
 
 P = ParamSpec("P")
@@ -262,4 +262,4 @@ convert_types: Final = {"dataclass": bool}
 
 
 class ZenConvert(TypedDict, total=False):
-    dataclass: NotRequired[bool]
+    dataclass: bool

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -30,6 +30,7 @@ from typing import (
 
 from omegaconf import DictConfig, ListConfig
 from typing_extensions import (
+    Final,
     Literal,
     NotRequired,
     ParamSpec,
@@ -252,8 +253,12 @@ DefaultsList = List[
 ]
 
 
-class AllConvert(TypedDict):
+class AllConvert(TypedDict, total=True):
     dataclass: bool
+
+
+# used for runtime type-checking
+convert_types: Final = {"dataclass": bool}
 
 
 class ZenConvert(TypedDict, total=False):

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -253,6 +253,7 @@ DefaultsList = List[
 ]
 
 
+# Lists all zen-convert settings and their types. Not part of public API
 class AllConvert(TypedDict, total=True):
     dataclass: bool
 
@@ -262,4 +263,74 @@ convert_types: Final = {"dataclass": bool}
 
 
 class ZenConvert(TypedDict, total=False):
+    """A TypedDict that provides a type-checked interface for specifying zen-convert
+    options that configure the hydra-zen config-creation functions (e.g., `builds`,
+    `just`, and `make_config`).
+
+    Note that, at runtime, `ZenConvert` is simply a dictionary with type-annotations. There is no enforced runtime validation of its keys and values.
+
+    Parameters
+    ----------
+    dataclass : bool
+        If `True` any dataclass type/instance without a `_target_` field is
+        automatically converted to a targeted config that will instantiate to that type/
+        instance. Otherwise the dataclass type/instance will be passed through as-is.
+        Note that this only works with statically-defined dataclass types, where
+        :func:`~hydra_zen.make_config` and :py:func:`dataclasses.make_dataclass`
+        dynamically generate dataclass types.
+
+    Examples
+    --------
+    >>> from hydra_zen.typing import ZenConvert as zc
+    >>> zc()
+    {}
+    >>> zc(dataclass=True)
+    {"dataclass": True}
+    >>> zc(apple=1)  # static type-checker will raise, but runtime will not
+    {"apple": 1}
+
+    **Configuring dataclass auto-config behaviors**
+
+    >>> from hydra_zen import instantiate as I
+    >>> from hydra_zen import builds, just
+    >>> from dataclasses import dataclass
+    >>> @dataclass
+    ... class B:
+    ...     x: int
+    >>> b = B(x=1)
+
+    >>> I(just(b))
+    B(x=1)
+    >>> I(just(b, zen_convert=zc(dataclass=False)))  # returns omegaconf.DictConfig
+    {"x": 1}
+
+    >>> I(builds(dict, y=b))
+    {'y': B(x=1)}
+    >>> I(builds(dict, y=b, zen_convert=zc(dataclass=False)))  # returns omegaconf.DictConfig
+    {'y': {'x': 1}}
+
+    >>> I(make_config(y=b))  # returns omegaconf.DictConfig
+    {'y': {'x': 1}}
+    >>> I(make_config(y=b, zen_convert=zc(dataclass=True, hydra_convert="all"))
+    {'y': B(x=1)}
+
+    Auto-config support does not work with dynamically-generated dataclass types
+
+    >>> just(make_config(z=1))
+    HydraZenUnsupportedPrimitiveError: ...
+    >>> I(just(make_config(z=1), zen_convert=zc(dataclass=False)))
+    {'z': 1}
+
+    A dataclass with a `_target_` field will not be converted:
+
+    >>> @dataclass
+    ... class BuildsStr:
+    ...     _target_: str = 'builtins.str'
+    ...
+    >>> BuildsStr is just(BuildsStr)
+    True
+    >>> (builds_str := BuildsStr()) is just(builds_str)
+    True
+    """
+
     dataclass: bool

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -150,6 +150,15 @@ def check_just():
     reveal_type(partiald_f, expected_text="partial[int]")
     reveal_type(partiald_f(), expected_text="int")
 
+    # test dataclass conversion
+    @dataclass
+    class B:
+        ...
+
+    reveal_type(just(B), expected_text="Type[Just[Type[B]]]")
+    reveal_type(just(B()), expected_text="Type[Builds[Type[B]]]")
+    reveal_type(just(B(), zen_convert={"dataclass": False}), expected_text="Any")
+
 
 @dataclass
 class SomeDataClass:
@@ -1084,15 +1093,3 @@ def check_launch():
 
     f(Xonf)
     launch(Xonf, f)
-
-
-def check_just_support_for_dataclass():
-    from dataclasses import dataclass
-
-    @dataclass
-    class A:
-        ...
-
-    reveal_type(just(A), expected_text="Type[Builds[Type[A]]]")
-    reveal_type(just(A()), expected_text="Type[Builds[Type[A]]]")
-    reveal_type(just(A(), zen_convert={"dataclass": False}), expected_text="Any")

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -1084,3 +1084,15 @@ def check_launch():
 
     f(Xonf)
     launch(Xonf, f)
+
+
+def check_just_support_for_dataclass():
+    from dataclasses import dataclass
+
+    @dataclass
+    class A:
+        ...
+
+    reveal_type(just(A), expected_text="Type[Builds[Type[A]]]")
+    reveal_type(just(A()), expected_text="Type[Builds[Type[A]]]")
+    reveal_type(just(A(), zen_convert={"dataclass": False}), expected_text="Any")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,17 +32,21 @@ for _module_name in OPTIONAL_TEST_DEPENDENCIES:
     if _module_name not in _installed:
         collect_ignore_glob.append(f"**/*{_module_name}*.py")
 
-if sys.version_info < (3, 8):
-    collect_ignore_glob.append("*py38*")
-
-if sys.version_info < (3, 9):
-    collect_ignore_glob.append("*py39*")
 
 if sys.version_info > (3, 6):
     collect_ignore_glob.append("*py36*")
 
 if sys.version_info < (3, 7):
     collect_ignore_glob.append("**/*test_sequence_coercion.py")
+
+if sys.version_info < (3, 8):
+    collect_ignore_glob.append("*py38*")
+
+if sys.version_info < (3, 9):
+    collect_ignore_glob.append("*py39*")
+
+if sys.version_info < (3, 10):
+    collect_ignore_glob.append("*py310*")
 
 
 @pytest.fixture()

--- a/tests/custom_strategies.py
+++ b/tests/custom_strategies.py
@@ -5,6 +5,7 @@ import hypothesis.strategies as st
 
 from hydra_zen import builds
 from hydra_zen.structured_configs._utils import get_obj_path
+from hydra_zen.typing._implementations import ZenConvert
 
 __all__ = ["valid_builds_args", "partitions"]
 
@@ -39,6 +40,7 @@ _valid_builds_strats = dict(
     builds_bases=st.lists(
         st.sampled_from([builds(x) for x in (int, len, dict)]), unique=True
     ).map(tuple),
+    zen_convert=st.none() | st.from_type(ZenConvert),
 )
 
 

--- a/tests/test_compatibility/test_omegaconf_830.py
+++ b/tests/test_compatibility/test_omegaconf_830.py
@@ -78,12 +78,8 @@ def mutable_if_needed(x):
     "config_maker",
     [
         lambda x, Parent: make_config(x=x, bases=(Parent,)),
-        lambda x, Parent: make_config(
-            x=ZenField(Any, x, zen_convert={"dataclass": False}), bases=(Parent,)
-        ),
-        lambda x, Parent: make_config(
-            ZenField(Any, x, "x", zen_convert={"dataclass": False}), bases=(Parent,)
-        ),
+        lambda x, Parent: make_config(x=ZenField(Any, x), bases=(Parent,)),
+        lambda x, Parent: make_config(ZenField(Any, x, "x"), bases=(Parent,)),
         lambda x, Parent: builds(A_inheritance, x=x, builds_bases=(Parent,)),
         # TODO: add case where x is populated via pop-full-sig
         # we currently support specifing fields-as-args in builds
@@ -119,7 +115,7 @@ def test_known_inheritance_issues_in_omegaconf_are_circumvented(
         and not isinstance(parent_default, (list, dict))
         and parent_field_name == "x"  # parent field overlaps
     ):
-        # ensure we only case to dataclass when necessary
+        # ensure we only cast to dataclass when necessary
         assert is_dataclass(Child.x)
     else:
         assert Child().x == child_default

--- a/tests/test_compatibility/test_omegaconf_830.py
+++ b/tests/test_compatibility/test_omegaconf_830.py
@@ -78,8 +78,12 @@ def mutable_if_needed(x):
     "config_maker",
     [
         lambda x, Parent: make_config(x=x, bases=(Parent,)),
-        lambda x, Parent: make_config(x=ZenField(Any, x), bases=(Parent,)),
-        lambda x, Parent: make_config(ZenField(Any, x, "x"), bases=(Parent,)),
+        lambda x, Parent: make_config(
+            x=ZenField(Any, x, zen_convert={"dataclass": False}), bases=(Parent,)
+        ),
+        lambda x, Parent: make_config(
+            ZenField(Any, x, "x", zen_convert={"dataclass": False}), bases=(Parent,)
+        ),
         lambda x, Parent: builds(A_inheritance, x=x, builds_bases=(Parent,)),
         # TODO: add case where x is populated via pop-full-sig
         # we currently support specifing fields-as-args in builds

--- a/tests/test_dataclass_conversion.py
+++ b/tests/test_dataclass_conversion.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2022 Massachusetts Institute of Technology
+# SPDX-License-Identifier: MIT
+from collections.abc import Callable
+from dataclasses import InitVar, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import hypothesis.strategies as st
+import pytest
+from hypothesis import given
+from omegaconf import OmegaConf
+from typing_extensions import TypeAlias
+
+from hydra_zen import builds, instantiate, just
+from hydra_zen.errors import HydraZenUnsupportedPrimitiveError
+
+from .test_just import list_of_objects
+
+Interface1: TypeAlias = Callable[[int], int]
+Interface2: TypeAlias = Callable[[str], str]
+
+
+@dataclass
+class Nested:
+    x: Any
+
+
+def foo(i: int) -> int:
+    return i
+
+
+def bar(s: str) -> str:
+    return s
+
+
+def baz(f: float) -> float:
+    return f
+
+
+@dataclass
+class Stuff:
+    field1: Interface1
+    field2: Interface2
+    field3: Nested = Nested(baz)
+    field4: Any = field(default_factory=lambda: [1, 2, 3])
+
+
+@pytest.mark.parametrize("via_just", [True, False])
+def test_293_proposal(via_just: bool):
+    # https://github.com/mit-ll-responsible-ai/hydra-zen/discussions/293
+    foobar = Stuff(foo, bar, Nested(baz))
+    BuildsFooBar2 = (
+        just(foobar)
+        if via_just
+        else builds(Stuff, field1=foo, field2=bar, populate_full_signature=True)
+    )
+    inst = instantiate(BuildsFooBar2)
+    assert isinstance(inst, Stuff)
+    assert inst == foobar
+    assert (
+        OmegaConf.to_yaml(BuildsFooBar2)
+        == """\
+_target_: tests.test_dataclass_conversion.Stuff
+field1:
+  _target_: hydra_zen.funcs.get_obj
+  path: tests.test_dataclass_conversion.foo
+field2:
+  _target_: hydra_zen.funcs.get_obj
+  path: tests.test_dataclass_conversion.bar
+field3:
+  _target_: tests.test_dataclass_conversion.Nested
+  x:
+    _target_: hydra_zen.funcs.get_obj
+    path: tests.test_dataclass_conversion.baz
+field4:
+- 1
+- 2
+- 3
+"""
+    )
+
+
+list_of_objects = [
+    1,
+    None,
+    True,
+    1 + 2j,
+    "hi",
+    b"hi",
+    dict(a=1),
+    [1, 2],
+    Path().home(),
+    Stuff,
+    Stuff(foo, bar, Nested(baz)),
+]
+
+
+def test_recursive_manual():
+    Conf = just(Nested(Nested(Nested)))
+    assert just(Conf) is Conf
+    out = instantiate(Conf)
+    assert isinstance(out, Nested)
+    assert isinstance(out.x, Nested)
+    assert out.x.x is Nested
+
+
+@given(
+    st.recursive(
+        st.sampled_from(list_of_objects), lambda x: st.builds(Nested, x), max_leaves=5
+    )
+)
+def test_recursive_conversion(x):
+    if not isinstance(x, Nested):
+        x = Nested(x)
+    assert instantiate(just(x)) == x
+    assert instantiate(builds(Nested, x=x.x)) == x
+    assert instantiate(OmegaConf.create(OmegaConf.to_yaml(just(x)))) == x
+
+
+@dataclass
+class NoDefault:
+    x: Any
+
+
+@dataclass
+class HasDefault:
+    x: Any = 1
+
+
+@dataclass
+class HasDefaultFactory:
+    x: Any = field(default_factory=lambda: [1 + 2j, "a", 3])
+
+
+@dataclass
+class HasNonInit:
+    x: float
+    y: float = field(init=False)
+
+    def __post_init__(self):
+        self.y = self.x * 2
+
+
+@dataclass
+class HasInitVarNoDefault:
+    x: InitVar[Any]
+
+
+@dataclass
+class HasInitVarWithDefault:
+    x: InitVar[Any] = 22
+
+
+@pytest.mark.parametrize(
+    "dataclass_inst",
+    [
+        NoDefault(x=1),
+        HasDefault(),
+        HasDefaultFactory(),
+        HasDefaultFactory([Path.home(), 2 - 4j]),
+        HasNonInit(x=22),
+    ],
+)
+def test_flavors_of_dataclasses(dataclass_inst):
+    Config = just(dataclass_inst)
+    inst = instantiate(Config)
+    assert isinstance(inst, type(dataclass_inst))
+    assert inst.x == dataclass_inst.x
+
+
+@pytest.mark.parametrize(
+    "dataclass_inst",
+    [
+        HasInitVarNoDefault(x=1),
+        HasInitVarWithDefault(),
+    ],
+)
+def test_just_raises_on_initvar_field(dataclass_inst):
+    with pytest.raises(HydraZenUnsupportedPrimitiveError):
+        just(dataclass_inst)
+
+
+@pytest.mark.parametrize(
+    "dataclass_type",
+    [
+        HasInitVarNoDefault,
+        HasInitVarWithDefault,
+    ],
+)
+def test_builds_with_initvar_field(dataclass_type):
+    assert instantiate(
+        builds(dataclass_type, populate_full_signature=True), x=1
+    ) == dataclass_type(x=1)

--- a/tests/test_dataclass_conversion.py
+++ b/tests/test_dataclass_conversion.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
-from collections.abc import Callable
 from dataclasses import InitVar, dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import hypothesis.strategies as st
 import pytest

--- a/tests/test_dataclass_conversion.py
+++ b/tests/test_dataclass_conversion.py
@@ -11,7 +11,7 @@ from hypothesis import given
 from omegaconf import OmegaConf
 from typing_extensions import TypeAlias
 
-from hydra_zen import builds, instantiate, just
+from hydra_zen import builds, instantiate, just, make_config
 from hydra_zen.errors import HydraZenUnsupportedPrimitiveError
 
 from .test_just import list_of_objects
@@ -191,3 +191,24 @@ def test_builds_with_initvar_field(dataclass_type):
     assert instantiate(
         builds(dataclass_type, populate_full_signature=True), x=1
     ) == dataclass_type(x=1)
+
+
+@pytest.mark.parametrize(
+    "dataclass_obj",
+    [
+        NoDefault(x=1),
+        HasDefault(),
+        HasDefaultFactory(),
+        HasDefaultFactory([Path.home(), 2 - 4j]),
+        HasNonInit(x=22),
+        builds(int)(),
+        NoDefault,
+        HasDefault,
+        HasDefaultFactory,
+        HasDefaultFactory,
+        HasNonInit,
+        builds(int),
+    ],
+)
+def test_make_config_doesnt_convert_dataclasses(dataclass_obj):
+    assert make_config(x=dataclass_obj).x is dataclass_obj

--- a/tests/test_dataclass_conversion.py
+++ b/tests/test_dataclass_conversion.py
@@ -13,6 +13,7 @@ from typing_extensions import TypeAlias
 from hydra_zen import (
     ZenField,
     builds,
+    hydrated_dataclass,
     instantiate,
     just,
     make_config,
@@ -377,3 +378,27 @@ def test_zen_convert(config, expected):
     actual = instantiate(config)
     assert actual == expected
     assert isinstance(actual["x"], type(expected["x"]))
+
+
+def f(x=HasDefault()):
+    return x
+
+
+def test_hydrated_dataclass():
+    @hydrated_dataclass(f, populate_full_signature=True)
+    class A:
+        ...
+
+    @hydrated_dataclass(
+        f, populate_full_signature=True, zen_convert={"dataclass": False}
+    )
+    class B:
+        ...
+
+    out_a = instantiate(A)
+    assert isinstance(out_a, HasDefault)
+    assert out_a == HasDefault()
+
+    out_b = instantiate(B)
+    assert not isinstance(out_b, HasDefault)
+    assert out_b == HasDefault()

--- a/tests/test_dataclass_conversion.py
+++ b/tests/test_dataclass_conversion.py
@@ -212,3 +212,9 @@ def test_builds_with_initvar_field(dataclass_type):
 )
 def test_make_config_doesnt_convert_dataclasses(dataclass_obj):
     assert make_config(x=dataclass_obj).x is dataclass_obj
+
+
+@pytest.mark.parametrize("obj", [make_config(), make_config()()])
+def test_just_auto_config_raises_on_dynamically_generated_types(obj):
+    with pytest.raises(HydraZenUnsupportedPrimitiveError):
+        just(obj)

--- a/tests/test_dataclass_conversion.py
+++ b/tests/test_dataclass_conversion.py
@@ -282,6 +282,32 @@ def test_yes_dataclass_conversion(
     assert inst_out == dataclass_obj
 
 
+def identity(x):
+    return x
+
+
+def test_builds_with_positional_arg():
+    out1 = instantiate(
+        builds(
+            identity,
+            HasDefault(),
+            hydra_convert="all",
+            zen_convert={"dataclass": True},
+        )
+    )
+    assert isinstance(out1, HasDefault) and out1 == HasDefault()
+
+    out2 = instantiate(
+        builds(
+            identity,
+            HasDefault(),
+            hydra_convert="all",
+            zen_convert={"dataclass": False},
+        )
+    )
+    assert not isinstance(out2, HasDefault)
+
+
 @pytest.mark.parametrize(
     "dataclass_obj",
     [

--- a/tests/test_hydra_behaviors.py
+++ b/tests/test_hydra_behaviors.py
@@ -100,6 +100,7 @@ def test_hydra_convert(
                 a_list=[1, 2],
                 a_struct_config=A,
                 an_int=1,
+                zen_convert={"dataclass": False},
                 **kwargs,
             )
         )

--- a/tests/test_just.py
+++ b/tests/test_just.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
-
 import functools
+from dataclasses import dataclass
 
 import pytest
 
-from hydra_zen import instantiate, just, make_config
+from hydra_zen import builds, instantiate, just, to_yaml
 from tests import is_same
 
 
@@ -13,6 +13,11 @@ class A:
     @classmethod
     def class_method(cls):
         pass
+
+
+@dataclass
+class ADataclass:
+    x: int
 
 
 def f(x: int):
@@ -24,19 +29,21 @@ def func_with_cache(x: int):
     pass
 
 
+list_of_objects = [
+    bytearray([1, 2, 3]),
+    1 + 2j,
+    A,
+    f,
+    func_with_cache,
+    A.class_method,
+    functools.partial(f, x=1),
+    ADataclass,
+    ADataclass(x=2),
+]
+
+
 # this function is tested more rigorously via test_value_conversion
-@pytest.mark.parametrize(
-    "obj",
-    [
-        bytearray([1, 2, 3]),
-        1 + 2j,
-        A,
-        f,
-        func_with_cache,
-        A.class_method,
-        functools.partial(f, x=1),
-    ],
-)
+@pytest.mark.parametrize("obj", list_of_objects)
 def test_just_roundtrip(obj):
     out = instantiate(just(obj))
 
@@ -46,6 +53,23 @@ def test_just_roundtrip(obj):
         assert out == obj
 
 
-def test_just_of_structured_config_is_identity():
-    cfg = make_config(x=1)
+@pytest.mark.parametrize("obj", list_of_objects)
+def test_just_idempotence_via_instantiate(obj):
+    expected = instantiate(just(obj))
+    actual = instantiate(just(just(obj)))
+    if callable(expected):
+        assert is_same(actual, expected)
+    else:
+        assert actual == expected
+
+
+@pytest.mark.parametrize("obj", list_of_objects)
+def test_just_idempotence_via_yaml(obj):
+    expected = to_yaml(just(obj))
+    actual = to_yaml(just(just(obj)))
+    assert actual == expected
+
+
+def test_just_of_targeted_config_is_identity():
+    cfg = builds(dict, x=1)
     assert just(cfg) is cfg

--- a/tests/test_just.py
+++ b/tests/test_just.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from hydra_zen import builds, instantiate, just, to_yaml
+from hydra_zen import builds, instantiate, just, make_config, to_yaml
 from tests import is_same
 
 
@@ -73,3 +73,10 @@ def test_just_idempotence_via_yaml(obj):
 def test_just_of_targeted_config_is_identity():
     cfg = builds(dict, x=1)
     assert just(cfg) is cfg
+
+
+def test_just_no_dataclass_autoconfig():
+    Cfg = make_config()
+    instt = Cfg()
+    assert just(Cfg, zen_convert={"dataclass": False}) is Cfg
+    assert just(instt, zen_convert={"dataclass": False}) is instt

--- a/tests/test_just.py
+++ b/tests/test_just.py
@@ -80,3 +80,11 @@ def test_just_no_dataclass_autoconfig():
     instt = Cfg()
     assert just(Cfg, zen_convert={"dataclass": False}) is Cfg
     assert just(instt, zen_convert={"dataclass": False}) is instt
+
+
+@pytest.mark.parametrize(
+    "kwargs", [{"hydra_convert": "mall"}, {"hydra_recursive": make_config()}]
+)
+def test_validate_hydra_options(kwargs):
+    with pytest.raises((ValueError, TypeError)):
+        just(ADataclass(x=1), **kwargs)

--- a/tests/test_py310.py
+++ b/tests/test_py310.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2022 Massachusetts Institute of Technology
+# SPDX-License-Identifier: MIT
+import sys
+
+assert sys.version_info > (3, 9)
+
+from dataclasses import KW_ONLY, dataclass
+from typing import Any, Dict, List, Tuple
+
+import pytest
+from omegaconf import OmegaConf
+
+from hydra_zen import builds, instantiate, just
+
+
+@dataclass
+class Point:
+    x: float
+    _: KW_ONLY
+    y: float
+    z: float
+
+
+def test_just_on_dataclass_w_kwonly_field():
+    pt = Point(0, y=1.5, z=2.0)
+    assert instantiate(just(pt)) == pt
+
+
+def test_builds_on_dataclass_w_kwonly_field():
+    pt = Point(0, y=1.5, z=2.0)
+    Conf = builds(Point, populate_full_signature=True)
+    assert instantiate(Conf(0, y=1.5, z=2.0)) == pt

--- a/tests/test_signature_parsing.py
+++ b/tests/test_signature_parsing.py
@@ -272,9 +272,10 @@ def test_builds_partial_with_full_sig_excludes_non_specified_params(
         **user_specified_values,
         populate_full_signature=True,
         zen_partial=True,
+        zen_convert={"dataclass": False},
     )
 
-    expected_sig = [  # type: ignore
+    expected_sig = [
         (var_name, name_to_type[var_name], user_specified_values[var_name])
         for var_name in sorted(user_specified_values)
     ] + [

--- a/tests/test_third_party/test_using_pydantic.py
+++ b/tests/test_third_party/test_using_pydantic.py
@@ -185,3 +185,16 @@ def test_nested_dataclasses(via_yaml: bool):
         assert instantiate(OmegaConf.create(to_yaml(conf))) == navbar
     else:
         assert instantiate(conf) == navbar
+
+
+@pyd_dataclass
+class PydFieldNoDefault:
+    btwn_0_and_3: int = Field(gt=0, lt=3)
+
+
+def test_pydantic_Field_no_default():
+    Conf = builds(PydFieldNoDefault, populate_full_signature=True)
+    out = instantiate(OmegaConf.create(to_yaml(Conf)), btwn_0_and_3=2)
+    assert isinstance(out, PydFieldNoDefault) and out == PydFieldNoDefault(
+        btwn_0_and_3=2
+    )

--- a/tests/test_third_party/test_using_pydantic.py
+++ b/tests/test_third_party/test_using_pydantic.py
@@ -1,13 +1,16 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
+import dataclasses
+from typing import List, Optional
+
 import hypothesis.strategies as st
 import pytest
 from hypothesis import given, settings
-from pydantic import AnyUrl, PositiveFloat
+from pydantic import AnyUrl, Field, PositiveFloat
 from pydantic.dataclasses import dataclass as pyd_dataclass
 from typing_extensions import Literal
 
-from hydra_zen import builds, instantiate
+from hydra_zen import builds, instantiate, just
 from hydra_zen.third_party.pydantic import validates_with_pydantic
 
 parametrize_pydantic_fields = pytest.mark.parametrize(
@@ -39,7 +42,7 @@ def test_pydantic_specific_fields_class(custom_type, good_val, bad_val):
             pass
 
     A.__init__.__annotations__["x"] = custom_type
-    validates_with_pydantic(A)  # type: ignore
+    validates_with_pydantic(A)
 
     A(good_val)
     with pytest.raises(Exception):
@@ -97,3 +100,42 @@ def test_documented_example_raises(x):
         # using a broad exception here because of
         # re-raising incompatibilities with Hydra
         instantiate(HydraConf, x=x)
+
+
+@pyd_dataclass
+class User:
+    id: int
+    name: str = "John Doe"
+    friends: List[int] = dataclasses.field(default_factory=lambda: [0])
+    age: Optional[int] = dataclasses.field(
+        default=None,
+        metadata=dict(title="The age of the user", description="do not lie!"),
+    )
+
+    # TODO: add support for pydantic.Field
+    height: Optional[int] = Field(None, title="The height in cm", ge=50, le=300)
+
+
+@pytest.mark.parametrize(
+    "config_maker",
+    [
+        lambda u1: just(u1, hydra_convert="all"),
+        # test hydra-convert applies within container
+        lambda u1: just([u1], hydra_convert="all")[0],
+    ],
+)
+def test_just_on_pydantic_dataclass(config_maker):
+    u1 = User(id="42")  # type: ignore
+    Conf = config_maker(u1)
+    ju1 = instantiate(Conf)
+    assert ju1 == u1 and isinstance(ju1, User)
+
+
+# def test_pydantic_runtime_type_checking():
+#     from hydra.errors import InstantiationException
+#     Conf = builds(User, populate_full_signature=True)
+#     inst_bad = Conf(id=22, height=10, age=-100)
+#     inst_good = Conf(id=22, height=10, age=25)
+#     with pytest.raises(InstantiationException):
+#         instantiate(inst_bad)
+#     assert inst_good == User(id=22, height=10, age=25) and isinstance(inst_good, User)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -475,3 +475,9 @@ def test_merge_settings_retains_user_settings(
     merged["apple"] = 22  # type: ignore
     assert "apple" not in user_settings
     assert "apple" not in default_settings
+
+
+@pytest.mark.parametrize("bad_settings", [1, {"not a field": True}, {"dataclass": 1.0}])
+def test_merge_settings_validation(bad_settings):
+    with pytest.raises((TypeError, ValueError)):
+        merge_settings(bad_settings, {"dataclass": True})

--- a/tests/test_zen_processing/test_zen_wrappers.py
+++ b/tests/test_zen_processing/test_zen_wrappers.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 import string
+import warnings
 from typing import Any, Callable, Dict, List, TypeVar, Union
 
 import hypothesis.strategies as st
@@ -296,6 +297,5 @@ def test_bad_relative_interp_warns(wrappers, expected_match):
     ["${s}", "${.s}", ["${.s}"], ["${..s}", "${..s}"], ["${..s}", "${..s}", "${..s}"]],
 )
 def test_interp_doesnt_warn(wrappers):
-    with pytest.warns(None) as record:  # type: ignore
+    with warnings.catch_warnings():
         builds(dict, zen_wrappers=wrappers, zen_meta=dict(s=1))
-    assert not record


### PR DESCRIPTION
Based off of the proposal for `recursive_just` (https://github.com/mit-ll-responsible-ai/hydra-zen/discussions/293) this PR adds auto-config support for dataclass types and instances to `just` , `builds`, and `make_config`. This only applies to "non-targeted" dataclass objects (i.e. those that do not have a `_target_` field).

### Overview
Auto-config support for dataclasses means that hydra-zen can take a nearly arbitrary dataclass type/instance – one that uses values that have [auto-config support from hydra-zen](https://mit-ll-responsible-ai.github.io/hydra-zen/api_reference.html#additional-types-supported-via-hydra-zen) and that is *unrestricted in the type-annotations that it uses* – and convert it to a Hydra/omegaconf-compatible intermediate structured config. Instantiating this intermediate config will then exactly reanimate the original dataclass object. (see bottom of post to see this incorporated in a full "Hydra app")

```python
from typing import Callable, Sequence
from dataclasses import dataclass
from statistics import mean

@dataclass
class Bar:
   reduce_fn: Callable[[Sequence[float]], float]  # <- not compat w/ Hydra
```
```python
>>> from hydra_zen import just, instantiate, to_yaml

>>> conf_sum = just(Bar(sum))  # creating Hydra-compatible intermediate dataclass type
>>> conf_mean = just(Bar(mean))

>>> print(to_yaml(conf_sum))  # yaml-serialized form of Hydra-compatible intermediate
_target_: __main__.Bar
reduce_fn:
  _target_: hydra_zen.funcs.get_obj
  path: builtins.sum

>>> instantiate(conf_sum)  # "reanimating" the original dataclass instances
Bar(reduce_fn=<built-in function sum>)
>>> instantiate(conf_mean)
Bar(reduce_fn=<function mean at 0x0000025C4F5C3D30>)
```

This works recursively (note that we use pydantic dataclasses here!)

```python
from pydantic import AnyUrl
from pydantic.dataclasses import dataclass as pyd_dataclass

@pyd_dataclass
class NavbarButton:
    href: AnyUrl

@pyd_dataclass
class Navbar:
    button: NavbarButton
```
```python
>>> from hydra_zen import to_yaml
>>> navbar = Navbar(button=NavbarButton("https://example.com"))
>>> conf = just(navbar)
>>> print(to_yaml(conf))
_target_: __main__.Navbar
button:
  _target_: __main__.NavbarButton
  href: https://example.com
```


### Implementation Details

Previously, hydra-zen's config-creation functions would pass all dataclass types and instances through unchanged, without inspecting them whatsoever. If the dataclass happened to be Hydra-compatible, Hydra would by default convert any non-targeted dataclass to a `omegaconf.DictConfig`. Dataclasses with unsupported annotations or fields would simply raise an error.

```python
from hydra_zen import make_config, just, instantiate
from dataclasses import dataclass
from typing import Any

@dataclass
class A:
    x: Any = 1
```

**Before**
```python
>>> instantiate(just(A(x=A(1))))  # returns DictConfig
{'x': {'x': 1}}

>>> instantiate(just(A))  # returns DictConfig
{'x': 1}

>>> instantiate(builds(A, x=A(A(1))))
A(x={'x': {'x': 1}})
```

**After**
```python
>>> instantiate(just(A(x=A(1))))  # returns instance of A
A(x=A(x=1))

>>> instantiate(just(A))  # returns type-A
__main__.A

>>> instantiate(builds(A, x=A(A(1))))
A(x=A(x=A(x=1)))
```

A dataclass with a `_target_` field will not be converted:

```python
>>> @dataclass
... class BuildsStr:
...     _target_: str = 'builtins.str'
...
>>> BuildsStr is just(BuildsStr)
True
>>> (builds_str := BuildsStr()) is just(builds_str)
True
```

this preserves the idempotence of `just`, `(x := just(obj)) is just(x)`, and ensures that we will not construct a targeted config that instantiates to a targeted config.

**Avoiding compatibility-breaking changes for `make_config`**

Given that `make_config` is frequently passed non-targeted dataclasses as fields, we require users to explicitly opt-in to this new auto-config behavior:

```python
>>> instantiate(make_config(x=A(1)))  # default behavior remains unchanged
{'x': {'x': 1}}

>>> instantiate(
...     make_config(
...         x=A(1),
...         zen_convert={"dataclass": True},
...         hydra_convert="all",  # note that hydra_convert is necessary here
...     )
... )
{'x': A(x=1)}
```

**Incompatibility with Dynamically-Generated Dataclass Types**
This auto-config behavior only works for statically-generated dataclass types, given that dynamically-generated dataclass types are automatically registered to the `typing` namespace and are not actually importable from that location.

We raise when one attempts to create a targeted config for a dynamically-generated dataclass type:

```python
>>> from hydra_zen import make_config
>>> just(make_config())
---------------------------------------------------------------------------
HydraZenUnsupportedPrimitiveError: Configuring <class 'types.Config'>: Cannot auto-config an instance of a dynamically-generated dataclass type (e.g. one created from `hydra_zen.make_config` or `dataclasses.make_dataclass`). Consider disabling auto-config support for dataclasses here.
```

**Incompatibility with Dataclasses with `InitVar` Fields**
A dataclass instance that leverages an `InitVar` field cannot be auto-config'd because the information used to create the instance cannot be recovered from the instance itself.

```python
from dataclasses import InitVar

@dataclass
class A:
    x: InitVar[int]

just(A(1))  # raises...
# HydraZenUnsupportedPrimitiveError: Configuring A(): Cannot auto-config a dataclass instance whose type has an Init-only # 
# field. Consider using `builds(A, ...)` instead.
```

### zen-convert and `hydra_zen.typing.ZenConvert`
This PR also introduces `zen_convert` to the config-creation function API. This enables users to toggle this new auto-config behavior for dataclasses.

```python
# restoring old behavior
from hydra_zen import just, make_custom_builds_fn
from functools import partial
   
old_just = partial(just, zen_convert={"dataclass": False})
old_builds = make_custom_builds_fn(zen_convert={"dataclass": False})
```
```python
>>> instantiate(old_just(A(x=A(1))))  # returns DictConfig
{'x': {'x': 1}}
>>> instantiate(old_builds(A, x=A(A(1))))
A(x={'x': {'x': 1}})
```

Upcoming PRs will add more functionality to `zen_convert`, including disabling recursive auto-config behavior.

We provide a typed-dict, `hydra_zen.typing.ZenConvert`, that can be used both as a type-annotation and as a nice means for users to specify zen-convert settings in a tool-assisted way (i.e. IDEs will auto-complete and type-check their settings).

```python
>>> from hydra_zen.typing import ZenConvert as zc
>>> zc()
{}
>>> zc(dataclass=True)
{"dataclass": True}
>>> zc(apple=1)  # static type-checker will raise, but runtime will not
{"apple": 1}
```

### Leveraging dataclass auto-config in a Hydra App
Here we show what it would look like to leverage this feature in a toy Hydra app. 

```python
# contents of `scratch.py`

from hydra_zen.typing import Builds
from dataclasses import dataclass
from typing import Callable, Sequence, Type, TYPE_CHECKING

import hydra
from hydra.core.config_store import ConfigStore

from hydra_zen import instantiate, just


# Structured config need not limit its type annotations
# Could use `pydantic.dataclasses.dataclass` to add enhanced runtime type-checking
@dataclass
class Reducer:
    reduce_fn: Callable[[Sequence[float]], float]  # <- not compat w/ Hydra
    data: Sequence[float] = (1.0, 2.0, 32.0)


# dynamically generating a Hydra-compatible for `Reducer` configured with `builtins.sum` 
# as the reduction function
hydra_compat_sum_reducer = just(Reducer(sum))

# Register the Hydra-compatible intermediate with Hydra
cs = ConfigStore.instance()
cs.store(name="my_app", node=hydra_compat_sum_reducer )


@hydra.main(config_path=None, config_name="my_app", version_base="1.2")
def task(cfg: Builds[Type[Reducer]]):
    obj = instantiate(cfg)  # Reanimate `Reducer(sum)` !
    
    # In lieu of using the annotation Builds[Type[Reducer]] in our task-fn sig,
    # one could instead use `assert(obj, Reducer)` to narrow the type of `obj` in the
    # eyes of mypy/pyright
    assert isinstance(obj, Reducer)
    
    result = obj.reduce_fn(obj.data)
    
    if TYPE_CHECKING:
        reveal_type(result)  # mypy and pyright reveal: float

    print("RESULT:", result)


if __name__ == "__main__":
    task()
```
```console
$ python scratch.py
RESULT: 35.0
```

The main benefits here are:
1. Our app's structured config can use rich, unrestricted type-annotations, which then let our task function type-check accurately
2. We don't have to worry about writing a specialized config for the `sum` function. `just` will recurse to this field and auto-generate a config for it.

This example does not highlight just how powerful hydra-zen's recursive auto-config behavior is; users can writing increasingly nested and sophisticated structured configs, and the boilerplate code for creating the Hydra-compatible intermediate remains as simple as: `hydra_compat = just(struct_conf)`

## Additional details
- This PR also adds support for `pydantic.Field` when no default value is specified
- Our tests using pydantic are more robust now 
- The type-annotations for `just` are updated to reflect these new behaviors.
- Users can now specify `hydra_convert` in `just` to control Hydra's behavior when instantiating the resulting structured configs