### PR TITLE
Adds auto-config support for `pydantic.Field`

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -148,7 +148,7 @@ with Hydra. For example, a :py:class:`complex` value can be specified directly v
    _args_:
    - 3
 
-hydra-zen provides specialized support for values of the following types:
+hydra-zen provides specialized auto-config support for values of the following types:
 
 - :py:class:`bytes` (*support provided for OmegaConf < 2.2.0*)
 - :py:class:`bytearray`
@@ -163,6 +163,9 @@ hydra-zen provides specialized support for values of the following types:
 - :py:class:`set`
 - :py:class:`frozenset`
 
+hydra-zen also provides auto-config support for some third-pary libraries:
+
+- `pydantic.Field`
 
 *********************
 Third-Party Utilities

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -23,6 +23,7 @@ Compatibility-Breaking Changes
 
 Improvements
 ------------
+- Auto-config s
 - :func:`~hydra_zen.builds` no longer has restrictions on inheritance patterns involving `PartialBuilds`-type configs. (See :pull:`290`)
 - Two new utility functions were added to the public API: :func:`~hydra_zen.is_partial_builds` and :func:`~hydra_zen.uses_zen_processing`
 - Improved :ref:`automatic type refinement <type-support>` for bare sequence types, and adds conditional support for `dict`, `list`, and `tuple` as type annotations when omegaconf 2.2.3+ is installed. (See :pull:`297`)

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -23,7 +23,7 @@ Compatibility-Breaking Changes
 
 Improvements
 ------------
-- Auto-config s
+- Adds auto-config support for `pydantic.Field`, improving hydra-zen's ability to automatically construct configs that describe pydantic models and dataclasses. (See :pull:`303`) 
 - :func:`~hydra_zen.builds` no longer has restrictions on inheritance patterns involving `PartialBuilds`-type configs. (See :pull:`290`)
 - Two new utility functions were added to the public API: :func:`~hydra_zen.is_partial_builds` and :func:`~hydra_zen.uses_zen_processing`
 - Improved :ref:`automatic type refinement <type-support>` for bare sequence types, and adds conditional support for `dict`, `list`, and `tuple` as type annotations when omegaconf 2.2.3+ is installed. (See :pull:`297`)

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -553,6 +553,14 @@ def sanitized_field(
     field_name: str = "",
     _mutable_default_permitted: bool = True,
 ) -> Field[Any]:
+
+    value = sanitized_default_value(
+        value,
+        allow_zen_conversion=allow_zen_conversion,
+        error_prefix=error_prefix,
+        field_name=field_name,
+    )
+
     type_value = type(value)
     if (
         type_value in _utils.KNOWN_MUTABLE_TYPES
@@ -563,15 +571,7 @@ def sanitized_field(
         else:  # pragma: no cover
             value = builds(type(value), value)
 
-    return _utils.field(
-        default=sanitized_default_value(
-            value,
-            allow_zen_conversion=allow_zen_conversion,
-            error_prefix=error_prefix,
-            field_name=field_name,
-        ),
-        init=init,
-    )
+    return _utils.field(default=value, init=init)
 
 
 # partial=False, pop-sig=True; no *args, **kwargs, nor builds_bases

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -488,6 +488,22 @@ def sanitized_default_value(
     ):
         return resolved_value
 
+    # check pydantic auto-config
+    pydantic = sys.modules.get("pydantic")
+    if pydantic is not None and isinstance(value, pydantic.fields.FieldInfo):
+        _val = (
+            value.default_factory()
+            if value.default_factory is not None
+            else value.default
+        )
+        return sanitized_default_value(
+            _val,
+            allow_zen_conversion=allow_zen_conversion,
+            error_prefix=error_prefix,
+            field_name=field_name,
+            structured_conf_permitted=structured_conf_permitted,
+        )
+
     if field_name:
         field_name = f", for field `{field_name}`,"
 

--- a/tests/test_third_party/test_using_pydantic.py
+++ b/tests/test_third_party/test_using_pydantic.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
+from typing import Any
+
 import hypothesis.strategies as st
 import pytest
 from hypothesis import given, settings
@@ -106,10 +108,18 @@ class HasDefault:
 
 @pyd_dataclass
 class HasDefaultFactory:
-    x: int = Field(default_factory=lambda: 1)
+    x: Any = Field(default_factory=lambda: [1 + 2j])
 
 
-@pytest.mark.parametrize("target", [HasDefault, HasDefaultFactory])
-def test_pop_sig_with_pydantic_Field(target):
+@pytest.mark.parametrize(
+    "target,kwargs",
+    [
+        (HasDefault, {}),
+        (HasDefaultFactory, {}),
+        (HasDefault, {"x": 12}),
+        (HasDefaultFactory, {"x": [[-2j, 1 + 1j]]}),
+    ],
+)
+def test_pop_sig_with_pydantic_Field(target, kwargs):
     Conf = builds(target, populate_full_signature=True)
-    assert instantiate(Conf) == target()
+    assert instantiate(Conf(**kwargs)) == target(**kwargs)

--- a/tests/test_third_party/test_using_pydantic.py
+++ b/tests/test_third_party/test_using_pydantic.py
@@ -3,7 +3,7 @@
 import hypothesis.strategies as st
 import pytest
 from hypothesis import given, settings
-from pydantic import AnyUrl, PositiveFloat
+from pydantic import AnyUrl, Field, PositiveFloat
 from pydantic.dataclasses import dataclass as pyd_dataclass
 from typing_extensions import Literal
 
@@ -97,3 +97,19 @@ def test_documented_example_raises(x):
         # using a broad exception here because of
         # re-raising incompatibilities with Hydra
         instantiate(HydraConf, x=x)
+
+
+@pyd_dataclass
+class HasDefault:
+    x: int = Field(default=1)
+
+
+@pyd_dataclass
+class HasDefaultFactory:
+    x: int = Field(default_factory=lambda: 1)
+
+
+@pytest.mark.parametrize("target", [HasDefault, HasDefaultFactory])
+def test_pop_sig_with_pydantic_Field(target):
+    Conf = builds(target, populate_full_signature=True)
+    assert instantiate(Conf) == target()


### PR DESCRIPTION
Given:

```python
from pydantic.dataclasses import dataclass as pyd_dataclass
from pydantic import Field

@pyd_dataclass
class A:
    x: int = Field(default=2, gt=0, lt=3)
```

**Before**:
```python
>>> from hydra_zen import builds
>>> builds(A, populate_full_signature=True)  # presence of `pydantic.Field` causes error
---------------------------------------------------------------------------
HydraZenUnsupportedPrimitiveError: Building: A ..
 The configured value default=2 gt=0 lt=3 extra={}, for field `x`, is not supported by Hydra -- serializing or instantiating this config would ultimately result in an error.

Consider using `hydra_zen.builds(<class 'pydantic.fields.FieldInfo'>, ...)` create a config for this particular value.
```

**After**
```python
>>> from hydra_zen import builds, just, instantiate
>>> Conf = builds(A, populate_full_signature=True)
>>> instantiate(Conf)
A(x=2)
>>> just(A.x)
2
```