### PR TITLE
Remove `builds_bases` option from `make_custom_builds_fn`

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -79,6 +79,10 @@ Compatibility-Breaking Changes
 ------------------------------
 This release drops support for Python 3.6. If you require Python 3.6, please restrict your hydra-zen installation dependency as `hydra-zen<0.8.0`.
 
+Specifing `make_custom_builds_fn([...], builds_bases=<...>)` was deprecated in 
+hydra-zen 0.7.0 (:pull:`263`). This option has now been removed from
+:func:`hydra_zen.make_custom_builds_fn`.
+
 The addition of auto-config support for dataclasses (:pull:`301`) changes the default 
 behaviors of :func:`~hydra_zen.just` and :func:`~hydra_zen.builds`. Previously, all 
 dataclass types and instances lacking a `_target_` field would be left unprocessed by 

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -80,7 +80,7 @@ Compatibility-Breaking Changes
 This release drops support for Python 3.6. If you require Python 3.6, please restrict your hydra-zen installation dependency as `hydra-zen<0.8.0`.
 
 Specifing `make_custom_builds_fn([...], builds_bases=<...>)` was deprecated in 
-hydra-zen 0.7.0 (:pull:`263`). This option has now been removed from
+hydra-zen 0.7.0 (:pull:`263`). Accordingly, this option has now been removed from
 :func:`hydra_zen.make_custom_builds_fn`.
 
 The addition of auto-config support for dataclasses (:pull:`301`) changes the default 

--- a/src/hydra_zen/structured_configs/_make_custom_builds.py
+++ b/src/hydra_zen/structured_configs/_make_custom_builds.py
@@ -2,13 +2,11 @@
 # SPDX-License-Identifier: MIT
 # pyright: strict
 import inspect
-import warnings
 from functools import wraps
 from typing import Any, Callable, Dict, Mapping, Optional, Union, cast, overload
 
 from typing_extensions import Final, Literal
 
-from hydra_zen.errors import HydraZenDeprecationWarning
 from hydra_zen.typing import ZenWrappers
 from hydra_zen.typing._builds_overloads import FullBuilds, PBuilds, StdBuilds
 from hydra_zen.typing._implementations import ZenConvert
@@ -249,16 +247,6 @@ def make_custom_builds_fn(
 
     # let `builds` validate the new defaults!
     builds(builds, **_new_defaults)
-
-    if _new_defaults["builds_bases"]:
-        warnings.warn(
-            HydraZenDeprecationWarning(
-                "Specifying `make_custom_builds_fn(builds_bases=<...>)` is deprecated "
-                "as of hydra-zen 0.7.0. It will be an error in hydra-zen 0.9.0. "
-                "\n`builds_bases` must be specified via `builds` manually."
-            ),
-            stacklevel=2,
-        )
 
     @wraps(builds)
     def wrapped(*args: Any, **kwargs: Any):

--- a/src/hydra_zen/structured_configs/_make_custom_builds.py
+++ b/src/hydra_zen/structured_configs/_make_custom_builds.py
@@ -4,25 +4,14 @@
 import inspect
 import warnings
 from functools import wraps
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Mapping,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    cast,
-    overload,
-)
+from typing import Any, Callable, Dict, Mapping, Optional, Union, cast, overload
 
 from typing_extensions import Final, Literal
 
 from hydra_zen.errors import HydraZenDeprecationWarning
 from hydra_zen.typing import ZenWrappers
 from hydra_zen.typing._builds_overloads import FullBuilds, PBuilds, StdBuilds
-from hydra_zen.typing._implementations import DataClass_, ZenConvert
+from hydra_zen.typing._implementations import ZenConvert
 
 from ._implementations import builds
 
@@ -38,7 +27,7 @@ __BUILDS_DEFAULTS: Final[Dict[str, Any]] = {
 del _builds_sig
 
 
-# partial=False, pop-sig=True; no parents
+# partial=False, pop-sig=True
 @overload
 def make_custom_builds_fn(
     *,
@@ -49,7 +38,6 @@ def make_custom_builds_fn(
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
-    builds_bases: Tuple[()] = ...,
     zen_convert: Optional[ZenConvert] = ...,
 ) -> FullBuilds:  # pragma: no cover
     ...
@@ -66,13 +54,12 @@ def make_custom_builds_fn(
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
-    builds_bases: Tuple[Type[DataClass_], ...] = ...,
     zen_convert: Optional[ZenConvert] = ...,
 ) -> PBuilds:  # pragma: no cover
     ...
 
 
-# partial=False, pop-sig=False, no parents
+# partial=False, pop-sig=False
 @overload
 def make_custom_builds_fn(
     *,
@@ -83,13 +70,12 @@ def make_custom_builds_fn(
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
-    builds_bases: Tuple[()] = ...,
     zen_convert: Optional[ZenConvert] = ...,
 ) -> StdBuilds:  # pragma: no cover
     ...
 
 
-# partial=False, pop-sig=bool, no parents
+# partial=False, pop-sig=bool
 @overload
 def make_custom_builds_fn(
     *,
@@ -100,26 +86,8 @@ def make_custom_builds_fn(
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
-    builds_bases: Tuple[()] = ...,
     zen_convert: Optional[ZenConvert] = ...,
 ) -> Union[FullBuilds, StdBuilds]:  # pragma: no cover
-    ...
-
-
-# partial=False, pop-sig=bool, with parents
-@overload
-def make_custom_builds_fn(
-    *,
-    zen_partial: Literal[False, None] = ...,
-    populate_full_signature: bool = ...,
-    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
-    zen_meta: Optional[Mapping[str, Any]] = ...,
-    hydra_recursive: Optional[bool] = ...,
-    hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
-    frozen: bool = ...,
-    builds_bases: Tuple[Type[DataClass_], ...],
-    zen_convert: Optional[ZenConvert] = ...,
-) -> StdBuilds:  # pragma: no cover
     ...
 
 
@@ -134,13 +102,12 @@ def make_custom_builds_fn(
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
-    builds_bases: Tuple[Type[DataClass_], ...] = ...,
     zen_convert: Optional[ZenConvert] = ...,
 ) -> Union[PBuilds, StdBuilds]:  # pragma: no cover
     ...
 
 
-# partial=bool, pop-sig=bool, with parents
+# partial=bool, pop-sig=bool
 @overload
 def make_custom_builds_fn(
     *,
@@ -151,24 +118,6 @@ def make_custom_builds_fn(
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
     frozen: bool = ...,
-    builds_bases: Tuple[Type[DataClass_], ...],
-    zen_convert: Optional[ZenConvert] = ...,
-) -> Union[PBuilds, StdBuilds]:  # pragma: no cover
-    ...
-
-
-# partial=bool, pop-sig=bool, no parents
-@overload
-def make_custom_builds_fn(
-    *,
-    zen_partial: Union[bool, None],
-    populate_full_signature: bool,
-    zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
-    zen_meta: Optional[Mapping[str, Any]] = ...,
-    hydra_recursive: Optional[bool] = ...,
-    hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
-    frozen: bool = ...,
-    builds_bases: Tuple[()] = ...,
     zen_convert: Optional[ZenConvert] = ...,
 ) -> Union[FullBuilds, PBuilds, StdBuilds]:  # pragma: no cover
     ...
@@ -183,7 +132,6 @@ def make_custom_builds_fn(
     hydra_recursive: Optional[bool] = None,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = None,
     frozen: bool = False,
-    builds_bases: Tuple[Type[DataClass_], ...] = (),
     zen_convert: Optional[ZenConvert] = None,
 ) -> Union[FullBuilds, PBuilds, StdBuilds]:
     """Returns the `builds` function, but with customized default values.
@@ -288,7 +236,7 @@ def make_custom_builds_fn(
     <Validation error: "c" is not "a" or "b">
     """
 
-    excluded_fields = {"dataclass_name", "hydra_defaults"}
+    excluded_fields = {"dataclass_name", "hydra_defaults", "builds_bases"}
     LOCALS = locals()
 
     # Ensures that new defaults added to `builds` must be reflected

--- a/src/hydra_zen/structured_configs/_make_custom_builds.py
+++ b/src/hydra_zen/structured_configs/_make_custom_builds.py
@@ -171,9 +171,6 @@ def make_custom_builds_fn(
     frozen : bool, optional (default=False)
         Specifies a new the default value for ``builds(..., frozen=<..>)``
 
-    builds_bases : Tuple[DataClass, ...]
-        Specifies a new the default value for ``builds(..., builds_bases=<..>)``
-
     Returns
     -------
     custom_builds
@@ -234,7 +231,7 @@ def make_custom_builds_fn(
     <Validation error: "c" is not "a" or "b">
     """
 
-    excluded_fields = {"dataclass_name", "hydra_defaults", "builds_bases"}
+    excluded_fields = frozenset({"dataclass_name", "hydra_defaults", "builds_bases"})
     LOCALS = locals()
 
     # Ensures that new defaults added to `builds` must be reflected

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -694,20 +694,6 @@ def check_make_custom_builds_no_args():
         expected_text="Type[Builds[(x: int, y: str, z: bool = False) -> Literal[1]]]",
     )
 
-    Parent = make_config(x=1)
-
-    # specifying parent should produce default `builds`
-    builds2 = make_custom_builds_fn(
-        populate_full_signature=True, builds_bases=(Parent,)
-    )
-
-    Conf2 = builds2(f)
-
-    reveal_type(
-        Conf2,
-        expected_text="Type[Builds[(x: int, y: str, z: bool = False) -> Literal[1]]]",
-    )
-
 
 def check_make_custom_builds_pop_sig():
     def f(x: int, y: str, z: bool = False):
@@ -745,19 +731,6 @@ def check_make_custom_builds_partial():
 
     reveal_type(
         Conf2,
-        expected_text="Type[ZenPartialBuilds[(x: int, y: str, z: bool = False) -> int]] | Type[HydraPartialBuilds[(x: int, y: str, z: bool = False) -> int]]",
-    )
-
-    Parent = make_config(x=1)
-
-    partial_builds3 = make_custom_builds_fn(
-        zen_partial=True, builds_bases=(Parent,), populate_full_signature=True
-    )
-
-    Conf3 = partial_builds3(f)
-
-    reveal_type(
-        Conf3,
         expected_text="Type[ZenPartialBuilds[(x: int, y: str, z: bool = False) -> int]] | Type[HydraPartialBuilds[(x: int, y: str, z: bool = False) -> int]]",
     )
 
@@ -941,18 +914,6 @@ def check_partial_narrowing_full(
 
 
 def check_make_custom_builds_overloads(boolean: bool, optional_boolean: Optional[bool]):
-    Parent = builds(int)
-
-    # Returns `StdBuilds`
-    reveal_type(
-        make_custom_builds_fn(populate_full_signature=boolean, builds_bases=(Parent,)),
-        expected_text="StdBuilds",
-    )
-
-    reveal_type(
-        make_custom_builds_fn(builds_bases=(Parent,)),
-        expected_text="StdBuilds",
-    )
 
     # partial = False, pop-sig = False
     reveal_type(make_custom_builds_fn(zen_partial=False), expected_text="StdBuilds")
@@ -973,13 +934,6 @@ def check_make_custom_builds_overloads(boolean: bool, optional_boolean: Optional
         expected_text="PBuilds",
     )
 
-    reveal_type(
-        make_custom_builds_fn(
-            zen_partial=True, populate_full_signature=False, builds_bases=(Parent,)
-        ),
-        expected_text="PBuilds",
-    )
-
     # Returns `PBuilds | StdBuilds``
     reveal_type(
         make_custom_builds_fn(zen_partial=False, populate_full_signature=boolean),
@@ -995,28 +949,6 @@ def check_make_custom_builds_overloads(boolean: bool, optional_boolean: Optional
         make_custom_builds_fn(
             populate_full_signature=False, zen_partial=optional_boolean
         ),
-        expected_text="PBuilds | StdBuilds",
-    )
-    reveal_type(
-        make_custom_builds_fn(
-            populate_full_signature=True,
-            zen_partial=optional_boolean,
-            builds_bases=(Parent,),
-        ),
-        expected_text="PBuilds | StdBuilds",
-    )
-
-    reveal_type(
-        make_custom_builds_fn(
-            populate_full_signature=boolean,
-            zen_partial=optional_boolean,
-            builds_bases=(Parent,),
-        ),
-        expected_text="PBuilds | StdBuilds",
-    )
-
-    reveal_type(
-        make_custom_builds_fn(zen_partial=optional_boolean, builds_bases=(Parent,)),
         expected_text="PBuilds | StdBuilds",
     )
 


### PR DESCRIPTION
Fulfills deprecation set in 0.7.0: https://github.com/mit-ll-responsible-ai/hydra-zen/pull/263