### PR TITLE
Adds `hydra_zen.store`

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -53,6 +53,17 @@ Creating Configs
    hydrated_dataclass
 
 
+Storing Configs
+***************
+.. currentmodule:: hydra_zen
+
+.. autosummary::
+   :toctree: generated/
+
+   ZenStore
+   wrapper.default_to_config
+
+
 Instantiating and Resolving Configs
 ***********************************
 

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -11,7 +11,7 @@ chronological order. All previous releases should still be available on pip.
 .. _v0.9.0:
 
 ---------------------
-0.9.0rc3 - 2022-11-17
+0.9.0rc4 - 2022-11-21
 ---------------------
 
 .. note:: This is documentation for an unreleased version of hydra-zen. You can try out this pre-release version using `pip install --pre hydra-zen`

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -51,14 +51,15 @@ with a Hydra-agnostic task function that has an explicit signature:
 
    from hydra_zen import zen
    
-   @zen
    def trainer_task_fn(model, data, partial_optim, trainer, num_epochs: int):
-      # All config-field extraction & instantiation is automated/mediated by zen
       optim = partial_optim(model.parameters())
       trainer(model, optim, data).fit(num_epochs)
    
    if __name__ == "__main__":
-      trainer_task_fn.hydra_main(config_name="my_app", config_path=None)
+      # All config-field extraction & instantiation is automated/mediated by zen.
+      # I.e. `zen` will extract & instantiate model, data, etc. from the input
+      # config and pass it to `trainer_task_fn`
+      zen(trainer_task_fn).hydra_main(config_name="my_app", config_path=None)
 
 
 There are plenty more bells and whistles to :func:`~hydra_zen.zen`, refer to :pull:`310` and its reference documentation for more details.

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -19,9 +19,9 @@ chronological order. All previous releases should still be available on pip.
 
 Release Highlights
 ------------------
-This release adds the :func:`~hydra_zen.zen` decorator, which enables users to use Hydra-agnostic task functions for their Hydra app; the decorator will automatically extract, resolve, and instantiate fields from an input config based on the function's signature. 
+This release introduces :func:`~hydra_zen.zen` and :class:`~hydra_zen.ZenStore`, which enable hydra-zen users to eliminate Hydra-specific boilerplate code from their projects, and to utilize new patterns and best practices for working with config stores.
 
-This encourages users to eliminate Hydra-specific boilerplate code from their projects and to instead opt for task functions with explicit signatures, including functions from third parties.
+The :func:`~hydra_zen.zen` decorator enables of use Hydra-agnostic task functions in Hydra apps; the decorator will automatically extract, resolve, and instantiate fields from an input config based on the function's signature. This encourages users to eliminate Hydra-specific boilerplate code from their projects and to instead opt for task functions with explicit signatures, which can include functions from third parties.
 
 E.g., :func:`~hydra_zen.zen` enables us to replace the following Hydra-specific task function:
 
@@ -63,10 +63,55 @@ with a Hydra-agnostic task function that has an explicit signature:
 
 There are plenty more bells and whistles to :func:`~hydra_zen.zen`, refer to :pull:`310` and its reference documentation for more details.
 
+:class:`~hydra_zen.ZenStore` is an abstraction over Hydra's config store.
+It enables users to maintain multiple, isolated store instances before populating Hydra's global config store.
+It also protects users from accidentally overwriting  entries in Hydra's global store
+
+This enables objects to be stored using a decorator pattern, e.g.
+
+.. code-block:: python
+   :caption: Using `hydra_zen.store` as a decorator to auto-configure and store objects.
+
+   from dataclasses import dataclass
+   from hydra_zen import store
+
+   profile_store = store(group="profile")
+
+   # Adds two store entries under the "profile" group of the store
+   # with configured defaults for `has_root`
+   @profile_store(name="admin", has_root=True)
+   @profile_store(name="basic", has_root=False)
+   @dataclass
+   class Profile:
+       username: str
+       schema: str
+       has_root: bool
+
+:class:`~hydra_zen.ZenStore` also possesses auto-config capabilities: it will automatically apply :func:`~hyda_zen.builds` and :func:`~hyda_zen.just` in intuitive ways on inputs to generate the stored configs.
+
+.. code-block:: python
+   :caption: Using `hydra_zen.store` auto-generate and store configs
+
+   from hydra_zen import ZenStore
+   from torch.optim import Adam, AdamW, RMSprop
+
+   torch_store = ZenStore("torch_store")
+
+   # Specify defaults for storing entries (group=optim)
+   # and for generating configs (_partial_=True and lr=1e-3)
+   torch_store = torch_store(group="optim", zen_partial=True, lr=0.001)
+
+   # Automatically applies `builds(<obj>, zen_partial=True, lr=0.001)` 
+   # to create and then store configs under the "optim" group
+   torch_store(Adam, name="adam", amsgrad=True)
+   torch_store(AdamW, name="adamw", betas=(0.1, 0.999))
+   torch_store(RMSprop, name="rmsprop")
+
 New Features
 ------------
 - Adds the :func:`~hydra_zen.zen` decorator (see :pull:`310`)
 - Adds the :func:`~hydra_zen.wrapper.Zen` decorator-class (see :pull:`310`)
+- Adds the :class:`~hydra_zen.ZenStore` decorator (see :pull:`331`)
 
 
 Improvements

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,13 +77,13 @@ intersphinx_mapping = {
 #   alias ->  (base-URL, prefix)
 _repo = "https://github.com/mit-ll-responsible-ai/hydra-zen/"
 extlinks = {
-    "commit": (_repo + "commit/%s", "commit "),
-    "gh-file": (_repo + "blob/master/%s", ""),
-    "gh-link": (_repo + "%s", ""),
-    "issue": (_repo + "issues/%s", "issue #"),
-    "pull": (_repo + "pull/%s", "pull request #"),
-    "plymi": ("https://www.pythonlikeyoumeanit.com/%s", ""),
-    "hydra": ("https://hydra.cc/docs/%s", ""),
+    "commit": (_repo + "commit/%s", "commit %s"),
+    "gh-file": (_repo + "blob/master/%s", "%s"),
+    "gh-link": (_repo + "%s", "%s"),
+    "issue": (_repo + "issues/%s", "issue #%s"),
+    "pull": (_repo + "pull/%s", "pull request #%s"),
+    "plymi": ("https://www.pythonlikeyoumeanit.com/%s", "%s"),
+    "hydra": ("https://hydra.cc/docs/%s", "%s"),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/generated/hydra_zen.ZenField.rst
+++ b/docs/source/generated/hydra_zen.ZenField.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.ZenField
+hydra\_zen.ZenField
 ===================
 
 .. currentmodule:: hydra_zen

--- a/docs/source/generated/hydra_zen.builds.rst
+++ b/docs/source/generated/hydra_zen.builds.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.builds
+hydra\_zen.builds
 =================
 
 .. currentmodule:: hydra_zen

--- a/docs/source/generated/hydra_zen.get_target.rst
+++ b/docs/source/generated/hydra_zen.get_target.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.get\_target
+hydra\_zen.get\_target
 ======================
 
 .. currentmodule:: hydra_zen

--- a/docs/source/generated/hydra_zen.hydrated_dataclass.rst
+++ b/docs/source/generated/hydra_zen.hydrated_dataclass.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.hydrated\_dataclass
+hydra\_zen.hydrated\_dataclass
 ==============================
 
 .. currentmodule:: hydra_zen

--- a/docs/source/generated/hydra_zen.instantiate.rst
+++ b/docs/source/generated/hydra_zen.instantiate.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.instantiate
+hydra\_zen.instantiate
 ======================
 
 .. currentmodule:: hydra_zen

--- a/docs/source/generated/hydra_zen.is_partial_builds.rst
+++ b/docs/source/generated/hydra_zen.is_partial_builds.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.is\_partial\_builds
+hydra\_zen.is\_partial\_builds
 ==============================
 
 .. currentmodule:: hydra_zen

--- a/docs/source/generated/hydra_zen.just.rst
+++ b/docs/source/generated/hydra_zen.just.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.just
+hydra\_zen.just
 ===============
 
 .. currentmodule:: hydra_zen

--- a/docs/source/generated/hydra_zen.launch.rst
+++ b/docs/source/generated/hydra_zen.launch.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.launch
+hydra\_zen.launch
 =================
 
 .. currentmodule:: hydra_zen

--- a/docs/source/generated/hydra_zen.load_from_yaml.rst
+++ b/docs/source/generated/hydra_zen.load_from_yaml.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.load\_from\_yaml
+hydra\_zen.load\_from\_yaml
 ===========================
 
 .. currentmodule:: hydra_zen

--- a/docs/source/generated/hydra_zen.make_config.rst
+++ b/docs/source/generated/hydra_zen.make_config.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.make\_config
+hydra\_zen.make\_config
 =======================
 
 .. currentmodule:: hydra_zen

--- a/docs/source/generated/hydra_zen.make_custom_builds_fn.rst
+++ b/docs/source/generated/hydra_zen.make_custom_builds_fn.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.make\_custom\_builds\_fn
+hydra\_zen.make\_custom\_builds\_fn
 ===================================
 
 .. currentmodule:: hydra_zen

--- a/docs/source/generated/hydra_zen.save_as_yaml.rst
+++ b/docs/source/generated/hydra_zen.save_as_yaml.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.save\_as\_yaml
+hydra\_zen.save\_as\_yaml
 =========================
 
 .. currentmodule:: hydra_zen

--- a/docs/source/generated/hydra_zen.third_party.beartype.validates_with_beartype.rst
+++ b/docs/source/generated/hydra_zen.third_party.beartype.validates_with_beartype.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.third\_party.beartype.validates\_with\_beartype
+hydra\_zen.third\_party.beartype.validates\_with\_beartype
 ==========================================================
 
 .. currentmodule:: hydra_zen.third_party.beartype

--- a/docs/source/generated/hydra_zen.third_party.pydantic.validates_with_pydantic.rst
+++ b/docs/source/generated/hydra_zen.third_party.pydantic.validates_with_pydantic.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.third\_party.pydantic.validates\_with\_pydantic
+hydra\_zen.third\_party.pydantic.validates\_with\_pydantic
 ==========================================================
 
 .. currentmodule:: hydra_zen.third_party.pydantic

--- a/docs/source/generated/hydra_zen.to_yaml.rst
+++ b/docs/source/generated/hydra_zen.to_yaml.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.to\_yaml
+hydra\_zen.to\_yaml
 ===================
 
 .. currentmodule:: hydra_zen

--- a/docs/source/generated/hydra_zen.typing.ZenConvert.rst
+++ b/docs/source/generated/hydra_zen.typing.ZenConvert.rst
@@ -1,4 +1,4 @@
-﻿Each of hydra-zen's :ref:`config-creation functions <create-config>` has a `zen_config` 
+Each of hydra-zen's :ref:`config-creation functions <create-config>` has a `zen_config` 
 parameter, which can be passed a dictionary to modify the function's value and type conversion behaviors. `hydra_zen.typing.ZenConfig` is a :py:class:`typing.TypedDict` 
 that can be used as a convenience function to view and override these options.
 

--- a/docs/source/generated/hydra_zen.uses_zen_processing.rst
+++ b/docs/source/generated/hydra_zen.uses_zen_processing.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.uses\_zen\_processing
+hydra\_zen.uses\_zen\_processing
 ================================
 
 .. currentmodule:: hydra_zen

--- a/docs/source/generated/hydra_zen.wrapper.Zen.rst
+++ b/docs/source/generated/hydra_zen.wrapper.Zen.rst
@@ -1,4 +1,4 @@
-﻿hydra\_zen.wrapper.Zen
+hydra\_zen.wrapper.Zen
 ======================
 
 .. currentmodule:: hydra_zen.wrapper

--- a/docs/source/generated/hydra_zen.zen.rst
+++ b/docs/source/generated/hydra_zen.zen.rst
@@ -1,5 +1,5 @@
-﻿hydra\_zen.zen
-===============
+hydra\_zen.zen
+==============
 
 .. currentmodule:: hydra_zen
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ combine_as_imports = true
 omit = ["src/hydra_zen/_version.py"]
 
 
+[tool.pytest.ini_options]
+xfail_strict=true
+
 
 [tool.pyright]
 include = ["src"]

--- a/src/hydra_zen/__init__.py
+++ b/src/hydra_zen/__init__.py
@@ -21,7 +21,7 @@ from .structured_configs import (
 )
 from .structured_configs._implementations import get_target
 from .structured_configs._type_guards import is_partial_builds, uses_zen_processing
-from .wrapper import store, zen
+from .wrapper import ZenStore, store, zen
 
 __all__ = [
     "builds",
@@ -42,6 +42,7 @@ __all__ = [
     "uses_zen_processing",
     "zen",
     "store",
+    "ZenStore",
 ]
 
 if not TYPE_CHECKING:

--- a/src/hydra_zen/__init__.py
+++ b/src/hydra_zen/__init__.py
@@ -21,7 +21,7 @@ from .structured_configs import (
 )
 from .structured_configs._implementations import get_target
 from .structured_configs._type_guards import is_partial_builds, uses_zen_processing
-from .wrapper import zen
+from .wrapper import store, zen
 
 __all__ = [
     "builds",
@@ -41,6 +41,7 @@ __all__ = [
     "is_partial_builds",
     "uses_zen_processing",
     "zen",
+    "store",
 ]
 
 if not TYPE_CHECKING:

--- a/src/hydra_zen/typing/__init__.py
+++ b/src/hydra_zen/typing/__init__.py
@@ -8,6 +8,7 @@ from ._implementations import (
     Just,
     Partial,
     PartialBuilds,
+    StoreEntry,
     SupportedPrimitive,
     ZenConvert,
     ZenPartialBuilds,
@@ -25,4 +26,5 @@ __all__ = [
     "ZenPartialBuilds",
     "HydraPartialBuilds",
     "ZenConvert",
+    "StoreEntry",
 ]

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -266,6 +266,7 @@ NodeName: TypeAlias = str
 Node: TypeAlias = Any
 
 
+# TODO: make immutable
 class StoreEntry(TypedDict):
     name: NodeName
     group: GroupName

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -261,6 +261,18 @@ class AllConvert(TypedDict, total=True):
 # used for runtime type-checking
 convert_types: Final = {"dataclass": bool}
 
+GroupName: TypeAlias = Optional[str]
+NodeName: TypeAlias = str
+Node: TypeAlias = Any
+
+
+class StoreEntry(TypedDict):
+    name: NodeName
+    group: GroupName
+    package: Optional[str]
+    provider: Optional[str]
+    node: Node
+
 
 class ZenConvert(TypedDict, total=False):
     """A TypedDict that provides a type-checked interface for specifying zen-convert

--- a/src/hydra_zen/wrapper/__init__.py
+++ b/src/hydra_zen/wrapper/__init__.py
@@ -3,6 +3,6 @@
 
 # pyright: strict
 
-from ._implementations import Zen, store, zen
+from ._implementations import Zen, ZenStore, store, zen
 
-__all__ = ["zen", "Zen", "store"]
+__all__ = ["zen", "Zen", "store", "ZenStore"]

--- a/src/hydra_zen/wrapper/__init__.py
+++ b/src/hydra_zen/wrapper/__init__.py
@@ -3,6 +3,6 @@
 
 # pyright: strict
 
-from ._implementations import Zen, zen
+from ._implementations import Zen, store, zen
 
-__all__ = ["zen", "Zen"]
+__all__ = ["zen", "Zen", "store"]

--- a/src/hydra_zen/wrapper/__init__.py
+++ b/src/hydra_zen/wrapper/__init__.py
@@ -3,6 +3,6 @@
 
 # pyright: strict
 
-from ._implementations import Zen, ZenStore, store, zen
+from ._implementations import Zen, ZenStore, default_to_config, store, zen
 
-__all__ = ["zen", "Zen", "store", "ZenStore"]
+__all__ = ["zen", "Zen", "store", "ZenStore", "default_to_config"]

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -661,7 +661,8 @@ def default_to_config(
         else:
             if kw:
                 raise ValueError(
-                    "store(<dataclass-instance>, [...]) does not support specifying keyword arguments"
+                    "store(<dataclass-instance>, [...]) does not support specifying "
+                    "keyword arguments"
                 )
             return target
     elif isinstance(target, (dict, list)):
@@ -691,40 +692,40 @@ class HydraStoreFn(Protocol):
         group: Optional[str] = None,
         package: Optional[str] = None,
         provider: Optional[str] = None,
-    ):
+    ):  # pragma: no cover
         ...
 
 
-class StoreFn(Protocol):
-    @overload
-    def __call__(
-        self,
-        __f: F,
-        *,
-        name: Union[str, Callable[[Any, Any], str]] = ...,
-        group: Optional[Union[str, Callable[[Any, Any], str]]] = ...,
-        package: Optional[Union[str, Callable[[Any, Any], str]]] = ...,
-        provider: Optional[str] = ...,
-        to_config: Callable[[F], Any] = ...,
-        store_fn: HydraStoreFn = ...,
-        **to_config_kw: Any,
-    ) -> F:
-        ...
+# class StoreFn(Protocol):
+#     @overload
+#     def __call__(
+#         self,
+#         __f: F,
+#         *,
+#         name: Union[str, Callable[[Any, Any], str]] = ...,
+#         group: Optional[Union[str, Callable[[Any, Any], str]]] = ...,
+#         package: Optional[Union[str, Callable[[Any, Any], str]]] = ...,
+#         provider: Optional[str] = ...,
+#         to_config: Callable[[F], Any] = ...,
+#         store_fn: HydraStoreFn = ...,
+#         **to_config_kw: Any,
+#     ) -> F:
+#         ...
 
-    @overload
-    def __call__(
-        self,
-        __f: Literal[None] = None,
-        *,
-        name: Union[str, Callable[[Any, Any], str]] = ...,
-        group: Optional[Union[str, Callable[[Any, Any], str]]] = ...,
-        package: Optional[Union[str, Callable[[Any, Any], str]]] = ...,
-        provider: Optional[str] = ...,
-        to_config: Callable[[Any], Any] = ...,
-        store_fn: HydraStoreFn = ...,
-        **to_config_kw: Any,
-    ) -> "StoreFn":
-        ...
+#     @overload
+#     def __call__(
+#         self,
+#         __f: Literal[None] = None,
+#         *,
+#         name: Union[str, Callable[[Any, Any], str]] = ...,
+#         group: Optional[Union[str, Callable[[Any, Any], str]]] = ...,
+#         package: Optional[Union[str, Callable[[Any, Any], str]]] = ...,
+#         provider: Optional[str] = ...,
+#         to_config: Callable[[Any], Any] = ...,
+#         store_fn: HydraStoreFn = ...,
+#         **to_config_kw: Any,
+#     ) -> "StoreFn":
+#         ...
 
 
 # @overload

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -786,8 +786,8 @@ class ZenStore:
     {'lr': 0.01, 'momentum': 0.9}
 
     By default, the stored config(s) will be "enqueued" for addition to Hydra's config
-    store, and `add_to_hydra_store` must be called to add the store's enqueued configs
-    to Hydra's central store (modify this behavior via `store = ZenStore(deferred_hydra_store=True)`)
+    store, and `.add_to_hydra_store()` must be called to add the enqueued configs
+    to Hydra's central store (modify this behavior via `ZenStore(deferred_hydra_store=True)`).
 
     >>> store.has_enqueued()
     True
@@ -796,9 +796,9 @@ class ZenStore:
     False
 
     Overwriting an entry will result in an error; this behavior can be modified via
-    `store = ZenStore(overwrite_ok=True)`.
+    `ZenStore(overwrite_ok=True)`.
 
-    >>> store({}, name="sgd", group="optim")  # same name & group as above
+    >>> store({}, name="sgd", group="optim")  # same name and group as above
     ValueError: (name=sgd group=optim): Hydra config store entry already exists. Specify `overwrite_ok=True` to enable replacing config store entries
 
     Creating a distinct store.
@@ -863,7 +863,8 @@ class ZenStore:
 
     Note that, by default, the application of `to_config` via the store is deferred
     until the config is actually accessed (by the user or when added to Hydra's store).
-    This minimizes the runtime overhead associated with decorating functions this way.
+    This minimizes the runtime overhead associated with decorating functions this way
+    in use cases where the stored configs are not utilitized.
     """
 
     __slots__ = (

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -866,7 +866,6 @@ def _resolve_node(entry: _Entry) -> _Entry:
     return entry
 
 
-# TODO: Test that statefulness doesnt get mutated
 # TODO: Type annotations / overrides
 class ZenStore:
     __slots__ = (

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -739,6 +739,31 @@ def _resolve_node(entry: StoreEntry) -> StoreEntry:
 
 
 class ZenStore:
+    """An abstraction over Hydra's config store, which enables users to maintain
+    multiple, isolated store instances before populating Hydra's global config store.
+
+    `ZenStore` is also designed to consolidate the config-creation and storage process;
+    it can be used to decorate config-targets and dataclasses, enabling "inline" config
+    creation and storage patterns.
+
+    This is a "self-partialing" object, meaning a store instance can overwrite its own
+    default values. Please consult the examples for more details.
+
+    `hydra_zen.store` is available as a pre-instantiated, globally-available store:
+
+    .. code-block:: python
+
+       store = ZenStore(
+           name="store",
+           deferred_to_config=True,
+           deferred_hydra_store=True,
+       )
+
+    Examples
+    --------
+
+    """
+
     __slots__ = (
         "name",
         "_internal_repo",
@@ -779,10 +804,12 @@ class ZenStore:
         self._overwrite_ok = overwrite_ok
 
     def __repr__(self) -> str:
+        # TODO: nicer repr?
         groups_contents: DefaultDict[Optional[str], List[str]] = defaultdict(list)
         for grp, name in self._internal_repo:
             groups_contents[grp].append(name)
-        return f"({self.name}){dict(groups_contents)}"
+
+        return f"{self.name}\n{repr(dict(groups_contents))}"
 
     # TODO: support *to_config_pos_args
     @overload
@@ -1014,5 +1041,7 @@ class ZenStore:
 
 
 store: ZenStore = ZenStore(
-    name="store", deferred_to_config=True, deferred_hydra_store=True
+    name="store",
+    deferred_to_config=True,
+    deferred_hydra_store=True,
 )

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -769,7 +769,7 @@ class ZenStore:
         provider: Optional[str] = ...,
         to_config: Callable[[F], Any] = default_to_config,
         **to_config_kw: Any,
-    ) -> F:
+    ) -> F:  # pragma: no cover
         ...
 
     # TODO: ZenStore -> Self when mypy adds support for Self
@@ -785,7 +785,7 @@ class ZenStore:
         provider: Optional[str] = ...,
         to_config: Callable[[Any], Any] = ...,
         **to_config_kw: Any,
-    ) -> "ZenStore":
+    ) -> "ZenStore":  # pragma: no cover
         ...
 
     def __call__(self, __f: Optional[F] = None, **kw: Any) -> Union[F, "ZenStore"]:

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -868,8 +868,15 @@ class ZenStore:
             return __f
 
     @property
-    def groups(self) -> List[Optional[str]]:
-        return sorted(set(group for group, _ in self._internal_repo))  # type: ignore
+    def groups(self) -> Sequence[Optional[str]]:
+        set_: Set[Optional[str]] = set(group for group, _ in self._internal_repo)
+        if None in set_:
+            set_.remove(None)
+            no_none = cast(Set[str], set_)
+            return [None] + sorted(no_none)
+        else:
+            no_none = cast(Set[str], set_)
+            return sorted(no_none)
 
     @overload
     def __getitem__(self, key: Tuple[Optional[str], str]) -> Any:
@@ -889,7 +896,8 @@ class ZenStore:
             return {
                 (group, name): _resolve_node(entry)["node"]
                 for (group, name), entry in self._internal_repo.items()
-                if group == key or (key_not_none and group.startswith(key + "/"))  # type: ignore
+                if group == key
+                or (key_not_none and group is not None and group.startswith(key + "/"))
             }
         return _resolve_node(self._internal_repo[key])["node"]
 

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -454,7 +454,7 @@ def zen(
 
     Notes
     -----
-    ConfigLike is DataClass | list[Any] | dict[str, Any] | DictConfig | ListConfig
+    ConfigLike is DataClass | dict[str, Any] | DictConfig
 
     The fields extracted from the input config are determined by the signature of the
     decorated function. There is an exception: including a parameter named "zen_cfg"
@@ -529,6 +529,19 @@ def zen(
     >>> zen(f, unpack_kwargs=True)(cfg)
     (1, {'b': 22})
 
+
+    **Passing Through The Config**
+
+    Some task functions require complete access to the full config to gain access to
+    sub-configs. One can specify the field named `zen_config` in their task function's
+    signature to signal `zen` that it should pass the full config to that parameter .
+
+    >>> @zen
+    ... def f(x: int, zen_cfg):
+    ...     return x, zen_cfg
+    >>> f(dict(x=1, y="${x}"))
+    (1, {'x': 1, 'y': 1})
+    
     **Including a pre-call function**
 
     Given that a zen-wrapped function will automatically extract and instantiate config
@@ -604,18 +617,6 @@ def zen(
     >>> zen_f.validate({"x": 1, "seed": 10})  # OK
     >>> zen_f.validate({"x": 1})  # Missing seed as required by pre-call
     HydraZenValidationError: `cfg` is missing the following fields: seed
-
-    **Passing Through The Config**
-
-    Some task functions require complete access to the full config to gain access to
-    sub-configs. One can specify the field named `zen_config` in their task function's
-    signature to signal `zen` that it should pass the full config to that parameter .
-
-    >>> @zen
-    ... def f(x: int, zen_cfg):
-    ...     return x, zen_cfg
-    >>> f(dict(x=1, y="${x}"))
-    (1, {'x': 1, 'y': 1})
     """
     if __func is not None:
         return ZenWrapper(

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -29,7 +29,6 @@ from typing import (
 
 import hydra
 from hydra.core.config_store import ConfigStore
-from hydra.main import _UNSPECIFIED_  # type: ignore
 from hydra.utils import instantiate
 from omegaconf import DictConfig, ListConfig, OmegaConf
 from typing_extensions import Final, Literal, ParamSpec, TypeAlias, TypedDict, TypeGuard
@@ -53,6 +52,8 @@ F = TypeVar("F")
 GroupName: TypeAlias = Optional[str]
 NodeName: TypeAlias = str
 Config: TypeAlias = Any
+
+_UNSPECIFIED_: Any = object()
 
 if HYDRA_SUPPORTS_LIST_INSTANTIATION:
     _SUPPORTED_INSTANTIATION_TYPES: Tuple[Any, ...] = (dict, DictConfig, list, ListConfig)  # type: ignore
@@ -349,7 +350,7 @@ class Zen(Generic[P, R]):
         version_base: Optional[str] = _UNSPECIFIED_,
     ) -> Callable[[Any], Any]:
         """
-        Returns a Hydra-CLI compatible version of the wrapped function: `hydra.main(zen(func))`
+        Generates a Hydra-CLI for the wrapped function. Equivalent to `hydra.main(zen(func), [...])()`
 
         Parameters
         ----------
@@ -374,8 +375,12 @@ class Zen(Generic[P, R]):
             Equivalent to `hydra.main(zen(func), [...])()`
         """
 
-        kw = dict(config_path=config_path, config_name=config_name)
-        if SUPPORTS_VERSION_BASE:
+        kw = dict(config_name=config_name)
+
+        if config_path is not _UNSPECIFIED_:
+            kw["config_path"] = config_path
+
+        if SUPPORTS_VERSION_BASE and version_base is not _UNSPECIFIED_:
             kw["version_base"] = version_base
 
         return hydra.main(**kw)(self)()

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -392,7 +392,9 @@ class Zen(Generic[P, R]):
         if config_path is not _UNSPECIFIED_:
             kw["config_path"] = config_path
 
-        if SUPPORTS_VERSION_BASE and version_base is not _UNSPECIFIED_:
+        if (
+            SUPPORTS_VERSION_BASE and version_base is not _UNSPECIFIED_
+        ):  # pragma: no cover
             kw["version_base"] = version_base
 
         return hydra.main(**kw)(self)()

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -27,7 +27,7 @@ from hydra.core.config_store import ConfigStore
 from hydra.main import _UNSPECIFIED_  # type: ignore
 from hydra.utils import instantiate
 from omegaconf import DictConfig, ListConfig, OmegaConf
-from typing_extensions import Literal, ParamSpec, Protocol, Self, TypeAlias, TypeGuard
+from typing_extensions import Literal, ParamSpec, Protocol, TypeAlias, TypeGuard
 
 from hydra_zen import instantiate, make_custom_builds_fn
 from hydra_zen.errors import HydraZenValidationError
@@ -669,7 +669,7 @@ class StoreFn(Protocol):
 
     @overload
     def __call__(
-        self: Self,
+        self,
         __f: Literal[None] = None,
         *,
         name: Union[str, Callable[[Any], str]] = ...,

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -35,7 +35,6 @@ from typing_extensions import (
     Literal,
     ParamSpec,
     Protocol,
-    Self,
     TypeAlias,
     TypedDict,
     TypeGuard,
@@ -811,9 +810,7 @@ class ZenStore:
     ) -> "ZenStore":
         ...
 
-    def __call__(
-        self: Self, __f: Optional[F] = None, **kw: Any
-    ) -> Union[F, "ZenStore"]:
+    def __call__(self, __f: Optional[F] = None, **kw: Any) -> Union[F, "ZenStore"]:
         if __f is None:
             _s = type(self)(
                 self.name,

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -879,11 +879,13 @@ class ZenStore:
             return sorted(no_none)
 
     @overload
-    def __getitem__(self, key: Tuple[Optional[str], str]) -> Any:
+    def __getitem__(self, key: Tuple[Optional[str], str]) -> Any:  # pragma: no cover
         ...
 
     @overload
-    def __getitem__(self, key: Optional[str]) -> Dict[Tuple[Optional[str], str], Any]:
+    def __getitem__(
+        self, key: Optional[str]
+    ) -> Dict[Tuple[Optional[str], str], Any]:  # pragma: no cover
         ...
 
     def __getitem__(self, key: Union[Optional[str], Tuple[Optional[str], str]]) -> Any:
@@ -897,7 +899,7 @@ class ZenStore:
                 (group, name): _resolve_node(entry)["node"]
                 for (group, name), entry in self._internal_repo.items()
                 if group == key
-                or (key_not_none and group is not None and group.startswith(key + "/"))
+                or (key_not_none and group is not None and group.startswith(key + "/"))  # type: ignore
             }
         return _resolve_node(self._internal_repo[key])["node"]
 

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -914,9 +914,11 @@ class ZenStore:
             return any(k[0] is None for k in self._internal_repo)
 
         if isinstance(key, str):
+            key_w_end: str = key + "/"
             return any(
-                key == group or group is not None and group.startswith(key + "/")
+                key == group or group.startswith(key_w_end)
                 for group, _ in self._internal_repo
+                if group is not None
             )
         return key in self._internal_repo
 

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -759,7 +759,7 @@ class ZenStore:
         self._deferred_store = deferred_hydra_store
         self._overwrite_ok = overwrite_ok
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         groups_contents: DefaultDict[Optional[str], List[str]] = defaultdict(list)
         for grp, name in self._internal_repo:
             groups_contents[grp].append(name)

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -30,15 +30,7 @@ from hydra.core.config_store import ConfigStore
 from hydra.main import _UNSPECIFIED_  # type: ignore
 from hydra.utils import instantiate
 from omegaconf import DictConfig, ListConfig, OmegaConf
-from typing_extensions import (
-    Final,
-    Literal,
-    ParamSpec,
-    Protocol,
-    TypeAlias,
-    TypedDict,
-    TypeGuard,
-)
+from typing_extensions import Final, Literal, ParamSpec, TypeAlias, TypedDict, TypeGuard
 
 from hydra_zen import instantiate, just, make_custom_builds_fn
 from hydra_zen.errors import HydraZenValidationError
@@ -687,18 +679,6 @@ def get_name(target: Any) -> str:
     return name
 
 
-class HydraStoreFn(Protocol):
-    def __call__(
-        self,
-        name: str,
-        node: Any,
-        group: Optional[str] = None,
-        package: Optional[str] = None,
-        provider: Optional[str] = None,
-    ):  # pragma: no cover
-        ...
-
-
 class _Entry(TypedDict):
     name: str
     group: Optional[str]
@@ -730,8 +710,8 @@ _DEFAULT_KEYS: Final[FrozenSet[str]] = frozenset(_Defaults.__required_keys__ - {
 
 
 def _resolve_node(entry: _Entry) -> _Entry:
-    """Given an entry, updates the entry so that its node
-    is not deferred, and returns the entry"""
+    """Given an entry, updates the entry so that its node is not deferred, and returns
+    the entry. This function is a passthrough for an entry whose node is not deferred"""
     item = entry["node"]
     if not isinstance(item, type) and callable(item):
         entry["node"] = item()
@@ -770,7 +750,7 @@ class ZenStore:
                 f"deferred_hydra_store must be a bool, got {deferred_hydra_store}"
             )
 
-        self.name = "store" if name is None else name
+        self.name: str = "store" if name is None else name
         self._internal_repo: Dict[Tuple[str, Optional[str]], _Entry] = {}
         self._queue: Deque[_Entry] = deque([])
         self._defaults = defaults.copy()
@@ -788,7 +768,6 @@ class ZenStore:
         package: Optional[Union[str, Callable[[Any], str]]] = ...,
         provider: Optional[str] = ...,
         to_config: Callable[[F], Any] = default_to_config,
-        store_fn: HydraStoreFn = ...,
         **to_config_kw: Any,
     ) -> F:
         ...
@@ -805,7 +784,6 @@ class ZenStore:
         package: Optional[Union[str, Callable[[Any], str]]] = ...,
         provider: Optional[str] = ...,
         to_config: Callable[[Any], Any] = ...,
-        store_fn: HydraStoreFn = ...,
         **to_config_kw: Any,
     ) -> "ZenStore":
         ...
@@ -887,7 +865,7 @@ class ZenStore:
             key = (key, None)
         return _resolve_node(self._internal_repo[key])["node"]
 
-    def add_to_hydra_store(self, overwrite_ok: Optional[bool] = None):
+    def add_to_hydra_store(self, overwrite_ok: Optional[bool] = None) -> None:
 
         while self._queue:
             entry = _resolve_node(self._queue.popleft())
@@ -919,4 +897,4 @@ class ZenStore:
         return name + ".yaml" in repo
 
 
-store = ZenStore(deferred_to_config=True)
+store: ZenStore = ZenStore(deferred_to_config=True)

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -850,7 +850,7 @@ class ZenStore:
     ... def func(a: int, b: int):
     ...     return a - b
 
-    >>> func(10, 3)
+    >>> func(10, 3)  # the decorated function is left unchanged
     7
     >>> pp(hz_store[None, "func1"])
     _target_: __main__.func

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -887,6 +887,19 @@ class ZenStore:
         deferred_hydra_store: bool = True,
         overwrite_ok: bool = False,
     ) -> None:
+        if not isinstance(deferred_to_config, bool):  # type: ignore
+            raise TypeError(
+                f"deferred_to_config must be a bool, got {deferred_to_config}"
+            )
+
+        if not isinstance(overwrite_ok, bool):  # type: ignore
+            raise TypeError(f"overwrite_ok must be a bool, got {overwrite_ok}")
+
+        if not isinstance(deferred_hydra_store, bool):  # type: ignore
+            raise TypeError(
+                f"deferred_hydra_store must be a bool, got {deferred_hydra_store}"
+            )
+
         self.name = "store" if name is None else name
         self._internal_repo: Dict[Tuple[str, Optional[str]], _Entry] = {}
         self._queue: Deque[_Entry] = deque([])

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -60,7 +60,7 @@ from hydra_zen.typing import (
 from hydra_zen.typing._builds_overloads import FullBuilds, PBuilds, StdBuilds
 from hydra_zen.typing._implementations import DataClass_, HydraPartialBuilds
 from hydra_zen.wrapper import Zen
-from hydra_zen.wrapper._implementations import _Entry
+from hydra_zen.wrapper._implementations import StoreEntry
 
 T = TypeVar("T")
 
@@ -1234,6 +1234,6 @@ def check_store():
     store(name=1)  # type: ignore
     store(group=1)  # type: ignore
 
-    assert_type(list(store), List[_Entry])
+    assert_type(list(store), List[StoreEntry])
     assert_type("group" in store, bool)
     assert_type(("group", "name") in store, bool)

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
-# These tests help to ensure that our typed interfaces have the desired behvarior, when
+# These tests help to ensure that our typed interfaces have the desired behavior, when
 # being processed by static type-checkers. Specifically we test using pyright.
 #
 # We perform contrapositive testing using lines with the pattern:
@@ -18,7 +18,18 @@ from dataclasses import dataclass
 from enum import Enum
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, List, Mapping, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from omegaconf import MISSING, DictConfig, ListConfig
 from typing_extensions import Literal, assert_type
@@ -47,7 +58,7 @@ from hydra_zen.typing import (
 )
 from hydra_zen.typing._builds_overloads import FullBuilds, PBuilds, StdBuilds
 from hydra_zen.typing._implementations import DataClass_, HydraPartialBuilds
-from hydra_zen.wrapper import Zen
+from hydra_zen.wrapper import Zen, ZenStore
 
 T = TypeVar("T")
 
@@ -1196,3 +1207,21 @@ def check_store():
 
     store(A)
     store(A(1))
+
+    class SubStore(ZenStore):
+        ...
+
+    substore = SubStore()
+    substore1 = substore(a=1)
+    x = substore1(dict(a=1))
+
+    # TODO: Enable when mypy supports Self
+    # assert_type(substore1, SubStore)
+
+    assert_type(x, Dict[str, int])
+
+    # check __getitem__
+    assert_type(store["name"], Any)
+    store["name", None]
+    store["name", "group"]
+    store["name", "group", "bad"]  # type: ignore

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -1232,3 +1232,7 @@ def check_store():
     store({}, group=1)  # type: ignore
     store(name=1)  # type: ignore
     store(group=1)  # type: ignore
+
+    assert_type(list(store), List[Tuple[Optional[str], str]])
+    assert_type("group" in store, bool)
+    assert_type(("group", "name") in store, bool)

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -60,6 +60,7 @@ from hydra_zen.typing import (
 from hydra_zen.typing._builds_overloads import FullBuilds, PBuilds, StdBuilds
 from hydra_zen.typing._implementations import DataClass_, HydraPartialBuilds
 from hydra_zen.wrapper import Zen
+from hydra_zen.wrapper._implementations import _Entry
 
 T = TypeVar("T")
 
@@ -1233,6 +1234,6 @@ def check_store():
     store(name=1)  # type: ignore
     store(group=1)  # type: ignore
 
-    assert_type(list(store), List[Tuple[Optional[str], str]])
+    assert_type(list(store), List[_Entry])
     assert_type("group" in store, bool)
     assert_type(("group", "name") in store, bool)

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -32,6 +32,7 @@ from hydra_zen import (
     make_config,
     make_custom_builds_fn,
     mutable_value,
+    store,
     zen,
 )
 from hydra_zen.structured_configs._value_conversion import ConfigComplex, ConfigPath
@@ -1132,4 +1133,42 @@ def check_zen():
 
     @zen(exclude=1)  # type: ignore
     def p3():
+        ...
+
+
+def check_store():
+    @store
+    def f(x: int, y: int) -> str:
+        ...
+
+    @store(name="hi")
+    def f2(x: int, y: int) -> str:
+        ...
+
+    reveal_type(f, expected_text="(x: int, y: int) -> str")
+    reveal_type(f2, expected_text="(x: int, y: int) -> str")
+
+    reveal_type(store(f), expected_text="(x: int, y: int) -> str")
+    reveal_type(store(f, name="bye"), expected_text="(x: int, y: int) -> str")
+    reveal_type(store(name="bye")(f), expected_text="(x: int, y: int) -> str")
+
+    apple_store = store(group="apple")
+
+    @apple_store
+    def a1(x: int) -> bool:
+        ...
+
+    @apple_store(name="hello")
+    def a2(x: int) -> bool:
+        ...
+
+    reveal_type(a1, expected_text="(x: int) -> bool")
+    reveal_type(a2, expected_text="(x: int) -> bool")
+
+    reveal_type(apple_store(a1), expected_text="(x: int) -> bool")
+    reveal_type(apple_store(a1, name="bye"), expected_text="(x: int) -> bool")
+    reveal_type(apple_store(name="bye")(a1), expected_text="(x: int) -> bool")
+
+    @store(f)  # type: ignore
+    def bad(x: int, y: int) -> str:
         ...

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -1225,3 +1225,9 @@ def check_store():
     assert_type(store[None, "name"], Any)
     assert_type(store["group", "name"], Any)
     store["name", "group", "bad"]  # type: ignore
+
+    # check __call__overrides
+    store({}, name=1)  # type: ignore
+    store({}, group=1)  # type: ignore
+    store(name=1)  # type: ignore
+    store(group=1)  # type: ignore

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -36,6 +36,7 @@ from typing_extensions import Literal, assert_type
 
 from hydra_zen import (
     ZenField,
+    ZenStore,
     builds,
     get_target,
     instantiate,
@@ -58,7 +59,7 @@ from hydra_zen.typing import (
 )
 from hydra_zen.typing._builds_overloads import FullBuilds, PBuilds, StdBuilds
 from hydra_zen.typing._implementations import DataClass_, HydraPartialBuilds
-from hydra_zen.wrapper import Zen, ZenStore
+from hydra_zen.wrapper import Zen
 
 T = TypeVar("T")
 

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -1172,3 +1172,27 @@ def check_store():
     @store(f)  # type: ignore
     def bad(x: int, y: int) -> str:
         ...
+
+    # checking that store type-checks against to_config
+    store(1)  # type: ignore
+    store(1, to_config=just)
+
+    store()(1, to_config=builds)  # type: ignore
+    store()(1, to_config=just)
+    store()()(1, to_config=builds)  # type: ignore
+
+    @store
+    @dataclass
+    class A:
+        x: int
+
+    @store(name="hi")
+    @dataclass
+    class B:
+        y: str
+
+    assert_type(A(1).x, int)
+    assert_type(B("a").y, str)
+
+    store(A)
+    store(A(1))

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -1221,7 +1221,7 @@ def check_store():
     assert_type(x, Dict[str, int])
 
     # check __getitem__
-    assert_type(store["name"], Any)
-    store["name", None]
-    store["name", "group"]
+    assert_type(store["group"], Dict[Tuple[Optional[str], str], Any])
+    assert_type(store[None, "name"], Any)
+    assert_type(store["group", "name"], Any)
     store["name", "group", "bad"]  # type: ignore

--- a/tests/annotations/mypy_checks.py
+++ b/tests/annotations/mypy_checks.py
@@ -3,7 +3,7 @@
 
 from typing_extensions import assert_type
 
-from hydra_zen import builds, instantiate, make_custom_builds_fn, store
+from hydra_zen import builds, instantiate, just, make_custom_builds_fn, store
 
 
 def check_builds() -> None:
@@ -84,6 +84,14 @@ def check_store() -> None:
     @store(f)  # type: ignore [arg-type, call-arg]
     def bad(x: int, y: int) -> str:
         ...
+
+    # checking that store type-checks against to_config
+    # mypy isn't as good as pyright here
+
+    # store(1)  # false negative
+    # store()(1, to_config=builds)  # false negative
+    store(1, to_config=just)
+    store()(1, to_config=just)
 
 
 # def check_just() -> None:

--- a/tests/annotations/mypy_checks.py
+++ b/tests/annotations/mypy_checks.py
@@ -4,6 +4,7 @@
 from typing_extensions import assert_type
 
 from hydra_zen import builds, instantiate, just, make_custom_builds_fn, store
+from hydra_zen.wrapper import ZenStore
 
 
 def check_builds() -> None:
@@ -55,14 +56,15 @@ def check_store() -> None:
     def f2(x: int, y: int) -> str:
         ...
 
-    reveal_type(f)
-    reveal_type(f2)
+    # reveal_type(f)
+    # reveal_type(f2)
 
-    reveal_type(store(f))
-    reveal_type(store(f, name="bye"))
-    reveal_type(store(name="bye")(f))
+    # reveal_type(store(f))
+    # reveal_type(store(f, name="bye"))
+    # reveal_type(store(name="bye")(f))
 
     apple_store = store(group="apple")
+    assert_type(apple_store, ZenStore)
 
     @apple_store
     def a1(x: int) -> bool:
@@ -72,14 +74,15 @@ def check_store() -> None:
     def a2(x: int) -> bool:
         ...
 
-    reveal_type(a1)
-    reveal_type(a2)
+    assert_type(a2(1), bool)
+    assert_type(store()(a1)(1), bool)
+    assert_type(store()(a1)("a"), bool)  # type: ignore [arg-type]
     apple_store(name="bye")
     apple_store(name=22)  # type: ignore [call-overload]
 
-    reveal_type(apple_store(a1))
-    reveal_type(apple_store(a1, name="bye"))
-    reveal_type(apple_store(name="bye")(a1))
+    # reveal_type(apple_store(a1))
+    # reveal_type(apple_store(a1, name="bye"))
+    # reveal_type(apple_store(name="bye")(a1))
 
     @store(f)  # type: ignore [arg-type, call-arg]
     def bad(x: int, y: int) -> str:

--- a/tests/annotations/mypy_checks.py
+++ b/tests/annotations/mypy_checks.py
@@ -3,7 +3,7 @@
 
 from typing_extensions import assert_type
 
-from hydra_zen import builds, instantiate, make_custom_builds_fn
+from hydra_zen import builds, instantiate, make_custom_builds_fn, store
 
 
 def check_builds() -> None:
@@ -44,6 +44,46 @@ def check_make_custom_builds() -> None:
     assert_type(instantiate(partial_builds(f))(), str)
 
     full_builds(f)(y=2)  # type: ignore [call-arg]
+
+
+def check_store() -> None:
+    @store
+    def f(x: int, y: int) -> str:
+        ...
+
+    @store(name="hi")
+    def f2(x: int, y: int) -> str:
+        ...
+
+    reveal_type(f)
+    reveal_type(f2)
+
+    reveal_type(store(f))
+    reveal_type(store(f, name="bye"))
+    reveal_type(store(name="bye")(f))
+
+    apple_store = store(group="apple")
+
+    @apple_store
+    def a1(x: int) -> bool:
+        ...
+
+    @apple_store(name="hello")
+    def a2(x: int) -> bool:
+        ...
+
+    reveal_type(a1)
+    reveal_type(a2)
+    apple_store(name="bye")
+    apple_store(name=22)  # type: ignore [call-overload]
+
+    reveal_type(apple_store(a1))
+    reveal_type(apple_store(a1, name="bye"))
+    reveal_type(apple_store(name="bye")(a1))
+
+    @store(f)  # type: ignore [arg-type, call-arg]
+    def bad(x: int, y: int) -> str:
+        ...
 
 
 # def check_just() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import pytest
 from hydra.core.config_store import ConfigStore
 from omegaconf import DictConfig, ListConfig
 
+from hydra_zen import store
 from hydra_zen._compatibility import HYDRA_VERSION
 
 _store = ConfigStore.instance()
@@ -64,11 +65,15 @@ def cleandir() -> Iterable[str]:
 
 
 @pytest.fixture()
-def configstore_repo() -> Iterable[dict]:
+def clean_store() -> Iterable[dict]:
     """Provides access to configstore repo and restores state after test"""
     prev_state = deepcopy(_store.repo)
+    zen_prev_state = (store._internal_repo.copy(), store._queue.copy())
     yield _store.repo
     _store.repo = prev_state
+    int_repo, queue = zen_prev_state
+    store._internal_repo = int_repo
+    store._queue = queue
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,21 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
-
 import logging
 import os
 import sys
 import tempfile
+from copy import deepcopy
 from typing import Dict, Iterable, Optional
 
 import hypothesis.strategies as st
 import pkg_resources
 import pytest
+from hydra.core.config_store import ConfigStore
 from omegaconf import DictConfig, ListConfig
 
 from hydra_zen._compatibility import HYDRA_VERSION
+
+_store = ConfigStore.instance()
 
 # Skip collection of tests that don't work on the current version of Python.
 collect_ignore_glob = []
@@ -58,6 +61,14 @@ def cleandir() -> Iterable[str]:
         yield tmpdirname  # yields control to the test to be run
         os.chdir(old_dir)
         logging.shutdown()
+
+
+@pytest.fixture()
+def configstore_repo() -> Iterable[dict]:
+    """Provides access to configstore repo and restores state after test"""
+    prev_state = deepcopy(_store.repo)
+    yield _store.repo
+    _store.repo = prev_state
 
 
 @pytest.fixture()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2022 Massachusetts Institute of Technology
+# SPDX-License-Identifier: MIT
+
+
+from typing import Any, Callable
+
+import pytest
+from hydra.core.config_store import ConfigStore
+
+from hydra_zen import instantiate, store
+
+cs = ConfigStore().instance()
+
+
+def func(a: int, b: int):
+    assert isinstance(a, int)
+    assert isinstance(b, int)
+    return (a, b)
+
+
+def instantiate_from_repo(name: str, **kw):
+    """Fetches config-node from repo by name and instantiates it
+    with provided kwargs"""
+    return instantiate(cs.repo[f"{name}.yaml"].node, **kw)
+
+
+@pytest.mark.parametrize(
+    "apply_store",
+    [
+        pytest.param(lambda: store(func, a=1, b=2), id="inline"),
+        pytest.param(lambda: store(a=1, b=2)(func), id="decorated"),
+        pytest.param(lambda: store()(func, a=1, b=2), id="partiald_inline"),
+        pytest.param(lambda: store()(a=1, b=2)(func), id="partiald_decorated"),
+        pytest.param(lambda: store(a=-22)(a=1, b=-22)(func, b=2), id="kw_overrides"),
+        pytest.param(
+            lambda: store(name="BAD")(func),
+            id="ensure_can_fail1",
+            marks=pytest.mark.xfail,
+        ),
+        pytest.param(
+            lambda: store(a=22, b=10)(func),
+            id="ensure_can_fail2",
+            marks=pytest.mark.xfail,
+        ),
+    ],
+)
+@pytest.mark.usefixtures("configstore_repo")
+def test_basic_store_patterns(apply_store: Callable[[], Any]):
+    out = apply_store()
+    assert out is func
+    assert instantiate_from_repo("func") == (1, 2)
+
+
+@pytest.mark.parametrize(
+    "apply_store",
+    [
+        pytest.param(lambda: store(func, name="dunk", a=1, b=2), id="inline"),
+        pytest.param(lambda: store(name="dunk")(func), id="decorated"),
+        pytest.param(lambda: store(name="O1")(func, name="dunk"), id="partiald_inline"),
+        pytest.param(
+            lambda: store(name="O1")(name="dunk")(func), id="partiald_decorated"
+        ),
+        pytest.param(
+            lambda: store(name="O1")(name="O2")(func, name="dunk"), id="kw_overrides"
+        ),
+        pytest.param(
+            lambda: store(name="BAD")(func),
+            id="ensure_can_fail",
+            marks=pytest.mark.xfail,
+        ),
+    ],
+)
+@pytest.mark.usefixtures("configstore_repo")
+def test_name_overrides(apply_store: Callable[[], Any]):
+    out = apply_store()
+    assert out is func
+    assert instantiate_from_repo("dunk", a=1, b=2) == (1, 2)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -206,37 +206,32 @@ def test_to_config_overrides(apply_store: Callable[[], Any]):
     assert instantiate_from_repo(name="func") == dict(a=1, b=2, target=func)
 
 
-class CustomStore:
-    def store(
-        self,
-        name: str,
-        node: Any,
-        group: Optional[str] = None,
-        package: Optional[str] = None,
-        provider: Optional[str] = None,
-    ):
-        assert False
-
-
-override_store = CustomStore()
+def override_store(
+    name: str,
+    node: Any,
+    group: Optional[str] = None,
+    package: Optional[str] = None,
+    provider: Optional[str] = None,
+):
+    assert False
 
 
 @pytest.mark.parametrize(
     "apply_store",
     [
-        pytest.param(lambda: store(func, store_instance=override_store), id="inline"),
+        pytest.param(lambda: store(func, store_fn=override_store), id="inline"),
         pytest.param(
-            lambda: store(store_instance=override_store)(func),
+            lambda: store(store_fn=override_store)(func),
             id="decorated",
         ),
         pytest.param(
-            lambda: store()(store_instance=override_store)(func),
+            lambda: store()(store_fn=override_store)(func),
             id="partiald_decorated",
         ),
     ],
 )
 @pytest.mark.usefixtures("configstore_repo")
-def test_store_instance_overrides(apply_store: Callable[[], Any]):
+def test_store_fn_overrides(apply_store: Callable[[], Any]):
     with pytest.raises(AssertionError):
         apply_store()
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -299,9 +299,9 @@ def test_store_nested_groups(include_none: bool):
 
     if include_none:
         assert local_store.groups == [None, "A", "A/B", "A/B/C"]
+        assert len(local_store[None]) == 1
     else:
         assert local_store.groups == ["A", "A/B", "A/B/C"]
-    assert len(local_store[None]) == 1
     assert len(local_store["A"]) == 4
     assert len(local_store["A/B"]) == 2
     assert len(local_store["A/B/C"]) == 1

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -642,6 +642,7 @@ def test_bool(entries, store: ZenStore, sub_store: bool):
         assert bool(entries) is bool(store)
 
 
+@settings(max_examples=20)
 @given(...)
 def test_repr(store: ZenStore):
     assert isinstance(repr(store), str)
@@ -672,6 +673,7 @@ def test_store_protects_overwriting_entries_in_hydra_store(store: ZenStore):
         store.add_to_hydra_store(overwrite_ok=True)
 
 
+@settings(max_examples=20)
 @given(...)
 def test_getitem(store: ZenStore):
     assume(store)
@@ -681,6 +683,7 @@ def test_getitem(store: ZenStore):
             assert len(store[entry["group"]]) > 0
 
 
+@settings(max_examples=20)
 @given(...)
 def test_eq(store1: ZenStore, store2: ZenStore):
     with clean_store():

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -45,7 +45,7 @@ def instantiate_from_repo(name: str, **kw):
     ],
 )
 @pytest.mark.usefixtures("configstore_repo")
-def test_basic_store_patterns(apply_store: Callable[[], Any]):
+def test_kw_overrides(apply_store: Callable[[], Any]):
     out = apply_store()
     assert out is func
     assert instantiate_from_repo("func") == (1, 2)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -264,10 +264,14 @@ def test_store_nested_groups():
     # Tests that nested groups are stored in Hydra store as-expected
     # and that ZenStore's __getitem__ has parity with the store
     local_store = ZenStore(deferred_hydra_store=False)
+    local_store({"a": 0}, name="a")
     local_store({"a": 1}, group="A", name="a")
     local_store({"a": 2}, group="A", name="b")
     local_store({"a": 3}, group="A/B", name="ab")
     local_store({"a": 4}, group="A/B/C", name="abc")
+
+    assert instantiate_from_repo(name="a") == instantiate(local_store[None, "a"])
+    assert instantiate_from_repo(name="a") == {"a": 0}
 
     assert instantiate_from_repo(name="a", group="A") == instantiate(
         local_store["A", "a"]
@@ -290,7 +294,8 @@ def test_store_nested_groups():
     )
     assert instantiate_from_repo(name="abc", group="A/B/C") == {"a": 4}
 
-    assert local_store.groups == ["A", "A/B", "A/B/C"]
+    assert local_store.groups == [None, "A", "A/B", "A/B/C"]
+    assert len(local_store[None]) == 1
     assert len(local_store["A"]) == 4
     assert len(local_store["A/B"]) == 2
     assert len(local_store["A/B/C"]) == 1

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -219,26 +219,6 @@ def override_store(
 @pytest.mark.parametrize(
     "apply_store",
     [
-        pytest.param(lambda: store(func, store_fn=override_store), id="inline"),
-        pytest.param(
-            lambda: store(store_fn=override_store)(func),
-            id="decorated",
-        ),
-        pytest.param(
-            lambda: store()(store_fn=override_store)(func),
-            id="partiald_decorated",
-        ),
-    ],
-)
-@pytest.mark.usefixtures("configstore_repo")
-def test_store_fn_overrides(apply_store: Callable[[], Any]):
-    with pytest.raises(AssertionError):
-        apply_store()
-
-
-@pytest.mark.parametrize(
-    "apply_store",
-    [
         pytest.param(lambda: store(func, provider="dunk", a=1, b=2), id="inline"),
         pytest.param(lambda: store(provider="dunk")(func), id="decorated"),
         pytest.param(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -432,3 +432,11 @@ def test_default_to_config_validates_dataclass_instance_with_kw():
 
     with pytest.raises(ValueError):
         store["dc"]
+
+
+@pytest.mark.parametrize(
+    "param_name", ["deferred_to_config", "deferred_hydra_store", "overwrite_ok"]
+)
+def test_validate_init(param_name):
+    with pytest.raises(TypeError, match=f"{param_name} must be a bool"):
+        ZenStore(**{param_name: "bad"})

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -266,10 +266,20 @@ def test_store_nested_groups(include_none: bool):
     local_store = ZenStore(deferred_hydra_store=False)
     if include_none:
         local_store({"a": 0}, name="a")
+
+    assert isinstance(repr(local_store), str)
+
     local_store({"a": 1}, group="A", name="a")
+    assert isinstance(repr(local_store), str)
+
     local_store({"a": 2}, group="A", name="b")
+    assert isinstance(repr(local_store), str)
+
     local_store({"a": 3}, group="A/B", name="ab")
+    assert isinstance(repr(local_store), str)
+
     local_store({"a": 4}, group="A/B/C", name="abc")
+    assert isinstance(repr(local_store), str)
 
     if include_none:
         assert instantiate_from_repo(name="a") == instantiate(local_store[None, "a"])

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,8 +1,7 @@
 # Copyright (c) 2022 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 
-
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import pytest
 from hydra.core.config_store import ConfigStore
@@ -18,10 +17,17 @@ def func(a: int, b: int):
     return (a, b)
 
 
-def instantiate_from_repo(name: str, **kw):
+def instantiate_from_repo(
+    name: str, group: Optional[str] = None, package: Optional[str] = None, **kw
+):
     """Fetches config-node from repo by name and instantiates it
     with provided kwargs"""
-    return instantiate(cs.repo[f"{name}.yaml"].node, **kw)
+    if group is not None:
+        item = cs.repo[group][f"{name}.yaml"]
+    else:
+        item = cs.repo[f"{name}.yaml"]
+    assert item.package == package
+    return instantiate(item.node, **kw)
 
 
 @pytest.mark.parametrize(
@@ -75,3 +81,67 @@ def test_name_overrides(apply_store: Callable[[], Any]):
     out = apply_store()
     assert out is func
     assert instantiate_from_repo("dunk", a=1, b=2) == (1, 2)
+
+
+@pytest.mark.parametrize(
+    "apply_store",
+    [
+        pytest.param(lambda: store(func, group="dunk", a=1, b=2), id="inline"),
+        pytest.param(lambda: store(group="dunk")(func), id="decorated"),
+        pytest.param(
+            lambda: store(group="O1")(func, group="dunk"), id="partiald_inline"
+        ),
+        pytest.param(
+            lambda: store(group="O1")(group="dunk")(func), id="partiald_decorated"
+        ),
+        pytest.param(
+            lambda: store(group="O1")(group="O2")(func, group="dunk"), id="kw_overrides"
+        ),
+        pytest.param(
+            lambda: store(group="BAD")(func),
+            id="ensure_can_fail",
+            marks=pytest.mark.xfail,
+        ),
+    ],
+)
+@pytest.mark.usefixtures("configstore_repo")
+def test_group_overrides(apply_store: Callable[[], Any]):
+    out = apply_store()
+    assert out is func
+    assert instantiate_from_repo(name="func", group="dunk", a=1, b=2) == (1, 2)
+
+
+@pytest.mark.parametrize(
+    "apply_store",
+    [
+        pytest.param(lambda: store(func, package="dunk", a=1, b=2), id="inline"),
+        pytest.param(lambda: store(package="dunk")(func), id="decorated"),
+        pytest.param(
+            lambda: store(package="O1")(func, package="dunk"), id="partiald_inline"
+        ),
+        pytest.param(
+            lambda: store(package="O1")(package="dunk")(func), id="partiald_decorated"
+        ),
+        pytest.param(
+            lambda: store(package="O1")(package="O2")(func, package="dunk"),
+            id="kw_overrides",
+        ),
+        pytest.param(
+            lambda: store(package="BAD")(func),
+            id="ensure_can_fail",
+            marks=pytest.mark.xfail,
+        ),
+    ],
+)
+@pytest.mark.usefixtures("configstore_repo")
+def test_package_overrides(apply_store: Callable[[], Any]):
+    out = apply_store()
+    assert out is func
+    assert instantiate_from_repo(name="func", package="dunk", a=1, b=2) == (1, 2)
+
+
+@pytest.mark.parametrize("bad_val", [1, True, ("a",)])
+@pytest.mark.parametrize("field_name", ["name", "group", "package"])
+def test_store_param_validation(bad_val, field_name: str):
+    with pytest.raises(TypeError, match=rf"`{field_name}` must be"):
+        store(func, **{field_name: bad_val})

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -378,6 +378,7 @@ def test_stores_have_independent_mutable_state(store1: ZenStore, store2: ZenStor
         if isinstance(x, Hashable):
             continue
         assert x is not getattr(store2, attr)
+        assert x is not getattr(store, attr)  # check default store
 
 
 @pytest.mark.parametrize("name", "ab")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -584,6 +584,7 @@ def test_contains_manual():
     assert_not_contains((None, "apple"))
     assert_not_contains(1)
     assert_not_contains((1, 2))
+    assert_not_contains(("a", "apple", "grape"))
 
 
 @given(...)
@@ -597,7 +598,11 @@ def test_contains_consistent_with_getitem(store: ZenStore):
         assert group in store
         assert (group, name) in store
         assert name not in store
+        assert not store[name]
+
         assert (name, group) not in store  # type: ignore
+        with pytest.raises(KeyError):
+            store[name, group]  # type: ignore
 
         if group is None:
             continue

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -693,3 +693,31 @@ def test_eq(store1: ZenStore, store2: ZenStore):
         store2.add_to_hydra_store()
         assert store1 != store2
         assert store1 == store1(param="blah")
+
+
+@settings(max_examples=20)
+@given(...)
+def test_get_entry(store: ZenStore):
+    assume(store)
+    entry, *_ = store
+    entry_ = store.get_entry(entry["group"], name=entry["name"])
+    assert entry == entry_
+
+
+@settings(max_examples=20)
+@given(store=...)
+@pytest.mark.parametrize(
+    "getter",
+    [
+        lambda store, *_: next(iter(store)),
+        lambda store, group, name: store.get_entry(group, name),
+    ],
+)
+def test_entry_access_cannot_mutate_store(store: ZenStore, getter):
+    assume(store)
+    entries = tuple(d.copy() for d in store)
+
+    entry = getter(store, entries[0]["group"], entries[0]["name"])
+    entry["name"] = 2222
+    new_entries = tuple(d.copy() for d in store)
+    assert all(e in new_entries for e in entries)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -10,9 +10,8 @@ from hydra.core.config_store import ConfigStore
 from hypothesis import given
 from omegaconf import DictConfig, ListConfig
 
-from hydra_zen import builds, instantiate, just, make_config, store
+from hydra_zen import ZenStore, builds, instantiate, just, make_config, store
 from hydra_zen._compatibility import HYDRA_SUPPORTS_LIST_INSTANTIATION
-from hydra_zen.wrapper._implementations import ZenStore
 
 cs = ConfigStore().instance()
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -413,7 +413,14 @@ def test_deferred_to_config(name, group):
     s = ZenStore(deferred_to_config=False)
     s = s(to_config=never_call)
     with pytest.raises(AssertionError):
-        s(1, name=name, group=group)
+        s(dict(a=1), name=name, group=group)
+
+
+def test_self_partialing_preserves_subclass():
+    s1 = NoHydra()
+    s2 = s1()
+    assert s1 is not s2
+    assert isinstance(s2, NoHydra)
 
 
 @pytest.mark.parametrize("name", "ab")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -554,14 +554,7 @@ def test_iter():
     _store = ZenStore()
     _store({"": 2}, name="grape")
     _store({"": 1}, group="a/b", name="apple")
-    assert list(_store) == [(None, "grape"), ("a/b", "apple")]
-
-
-def test_items():
-    _store = ZenStore()
-    _store({"": 2}, name="grape")
-    _store({"": 1}, group="a/b", name="apple")
-    assert list([(k, v["node"]) for k, v in _store.items()]) == [
-        ((None, "grape"), {"": 2}),
-        (("a/b", "apple"), {"": 1}),
+    assert list((v["group"], v["name"], v["node"]) for v in _store) == [
+        (None, "grape", {"": 2}),
+        ("a/b", "apple", {"": 1}),
     ]


### PR DESCRIPTION
`hydra_zen.ZenStore` is an abstraction over Hydra's config store that streamlines the process of generating a config and then storing it in Hydra's config store. It enables users to isolate stores from Hydra's global config store and from one another, so that many stores can be maintained within a project without "clobbering" one another.

It is designed to be highly customizable while having defaults that seldom need to be tinkered with. It also has some nice ergonomics (see the self-partialing feature 😄 ).

## Basic Usage

This code:

```python
from hydra_zen import builds
from hydra.core.config_store import ConfigStore

def repeat(x: int, y: str):
    return x * y

cs = ConfigStore.instance()
cs.store(name=repeat.__name__, node=builds(func, populate_full_signature=True))
```

is equivalent to:

```python
from hydra_zen import store

@store
def repeat(x: int, y: str):
    return x * y

store.add_to_hydra_store()  # (default) have to explicitly opt-in to populating Hydra's global store
```

and this:

```python
cs.store(name="repeat1", node=builds(repeat, x=1, populate_full_signature=True))
cs.store(name="repeat2", node=builds(repeat, x=2, populate_full_signature=True))
```

can be rewritten as:

```python
@store(name="repeat2", x=2)
@store(name="repeat1", x=1)
def repeat(x: int, y: str):
    return x * y
```

or

```python
store(repeat, name="repeat1", x=1)
store(repeat, name="repeat2", x=2)
```

## Basic Implementation Details

There is a lot more here than meets the eye. It is useful to take a peek at the implementation, which, at its core, is quite simple. Here is a stripped-down implementation:

```python
def store(       
    f: Optional[F] = None,
    *,
    name: str | Callable[[Any, Any], str] = lambda f, _: f.__name__,
    group: None | str | Callable[[Any, Any], str] = None,
    package: None | str | Callable[[Any, Any], str] = None,
    provider: Optional[str] = None,
    to_config: Callable[[F], Any] = lambda x, **kw: builds(x, **kw, populate_full_signature=True),
    store_fn: HydraStoreFn = ConfigStore.instance().store,
    **to_config_kw: Any) -> F:
    
    # this excludes some fancy decorator & self-partialing stuff, as well as annotation overrides

    cfg = to_config(f, **to_config_kw)

    _name = name(f, cfg) if callable(name) else name
    _group = group(f, cfg) if callable(group) else group
    _pkg = package(f, cfg) if callable(package) else package
    store_fn(
            name=_name,
            node=cfg,
            group=_group,
            package=_pkg,
            provider=provider,
        )
    return f
```

Note that nearly every aspect of `store`, including how it generates configs, can be customized. Furthermore, the `name`, `group`, and `package` fields can be specified as callables, which can be used to, for instance, auto-generate the node's name based on details like its module's path.

## Bells & Whistles

### `store` is both a function and a decorator

As shown above `store` can be used as a function or a decorator

```python
# as a decorator
@store(group="math")
def add(x, y): 
    return x + y

# as a function
def add(x, y): 
    return x + y

store(add, group="math")
```

### `store` is a passthrough
That is, `store(f) is f`, and extra keywords passed to `store` are passed to the config-creation function. This means that you can stack `@store` decorators to store different configs for the same target

```python
@store(name="grid_trainer", device="gpu")  # user has to specify `num_epoch` on launch
@store(name="test_trainer", num_epoch=1, device="cpu")  # all defaults provided here
def trainer(num_epochs, device):
    ...
```

this also streamlines things like creating partial configs

```python
from torch.optim import Adam

store(Adam, name="adam", zen_partial=True)  # `zen_partial=True` is passed to `builds` 
```

### `store` is self-partialing

This is really cool.. you can overwrite the default arguments of `store` without using `functools.partial`

```python
math_store = store(group="math")

@math_store(name="add_it")  # equivalent to  @store(name="add_it", group="math")
def add(x, y): return x + y
```

You can specify new defaults endlessly

```python
new_store = store(name="a")(group="b")(package="c")

new_store(func)  # equivalent to store(func, name="a", group="b", package="c")
```

This makes it easy to customize the behavior of `store` while preserving its signature and type annotations. You can seriously override everything [^2] 

### Specialized support for dataclasses

The default `to_config` function will create configs that are proper subclasses of a target dataclass. Consider:

```python
from dataclasses import dataclass

from hydra.core.config_store import ConfigStore
from omegaconf import OmegaConf

from hydra_zen import store


@store(name="a2", x=2)
@store(name="a1", x=1)
@store(name="a")
@dataclass
class A:
    x: int
```

```python
>>> config = OmegaConf.to_object(ConfigStore.instance().repo["a1.yaml"].node)
>>> issubclass(type(config), A)
True
```

Thus for each application of `store`, `builds` produces a new dataclass-type, which is a subtype of `A`.


[^2]: A library author might be interested in patterns similar to the following:

    ```python
    from collections import defaultdict

    from hydra_zen import store as orig_store, builds, get_target
    from hydra.core.config_store import ConfigStore

    from my_lib import Dense, Conv2d, Cifar10, MNIST

    config_repo = defaultdict(dict)  # makes for easy-access to the generated configs

    def override_store(
        name: str,
        node: Any,
        group: Optional[str] = None,
        package: Optional[str] = None,
        provider: Optional[str] = None,
    ):
        ConfigStore.instance().store(name, node, group, package, provider)
        target = get_target(node) 
        config_repo[target][(name, node, group, package, provider)] = node
        return None

    store = orig_store(provider="my_lib", store_fn=override_store)

    model_store = store(group="model")
    model_store(Dense)
    model_store(Conv2d)

    data_store = store(group="data")
    data_store(Cifar10)
    data_store(MNIST)
    ```

### Responsive type annotations

pyright impresses once again (unfortunately, mypy can't catch the following true positive -- I will open an issue)

```python
from hydra_zen import store,  just

# type checker: error  (you can't pass a dict as a target to `builds`)
# runtime: error
store({"a": 1}, name="some_dict", to_config=builds)  

# type checker: OK
# runtime: OK
store({"a": 1}, name="some_dict", to_config=just)  
```


## Feedback

### Does `@store` encourage an anti-pattern?
Although I like the `@store` syntax, I am not crazy about having library authors decorate functions throughout their library -- it leads to a "non-locality", where those functions will only be added to the store if they are accessed. E.g. if I have

```python
# contents of my_lib/math.py
@store
def add(x, y): ...
```

The config for `add` only becomes available in Hydra's config store if `my_lib.math` gets imported somewhere along the way. This feels like an anti-pattern as it leads to spooky action-at-a-distance behavior for unwitting users who may wonder why `add` is suddenly in their config store[^1]. 

I realize that library authors could just as easily write:

```python
# contents of my_lib/math.py
def add(x, y): ...

store(add)
```

but this feels like more of a deliberate design decision, whereas the availability of the decorator syntax feels like it is practically begging for this pattern.

Is there a way to discourage or even prevent this? I have considered having some sort of intermediary function, `add_configs_to_store`, that users have to explicitly call to actually update Hydra's config store. 

I am also concerned with configs silently getting overwritten by configs of the same name.

This is just a preliminary idea, and I'd love to hear other ideas for encouraging best practices with Hydra's config store.

[^1]: That being said, it is *quite* nice to be able to do:

    ```python
    from hydra_zen import store, zen

    @store(name="task2", x=1, y=2)
    @store(name="task1", x=1, y=2)
    def task_fn(x, y):
        # stuff

    if __name__ == "__main__":
        zen(task_fn).hydra_main(config_path=None, config_name="task1")
    ```

 