### PR TITLE
Add pickle compatibility for classes decorated by `@hydrated_dataclass`

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -68,6 +68,12 @@ New Features
 - Adds the :func:`~hydra_zen.zen` decorator (see :pull:`310`)
 - Adds the :func:`~hydra_zen.wrapper.Zen` decorator-class (see :pull:`310`)
 
+
+Improvements
+------------
+- :func:`~hydra_zen.hydrated_dataclass` will now produce a pickle-compatible dataclass type.
+
+
 .. _v0.8.0:
 
 ------------------

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -359,7 +359,7 @@ def hydrated_dataclass(
         else:
             kwargs: Dict[str, Any] = {}
 
-        return builds(
+        out = builds(
             target,
             *pos_args,
             **kwargs,
@@ -374,6 +374,8 @@ def hydrated_dataclass(
             frozen=frozen,
             zen_convert=zen_convert,
         )
+        out.__module__ = decorated_obj.__module__
+        return out
 
     return wrapper
 

--- a/tests/test_roundtrips.py
+++ b/tests/test_roundtrips.py
@@ -4,6 +4,7 @@ import datetime
 import math
 import operator
 import os
+import pickle
 import random
 import re
 import statistics
@@ -17,7 +18,7 @@ import pytest
 from hypothesis import given
 from omegaconf import OmegaConf
 
-from hydra_zen import builds, get_target, instantiate, just, to_yaml
+from hydra_zen import builds, get_target, hydrated_dataclass, instantiate, just, to_yaml
 from hydra_zen.structured_configs._type_guards import is_builds
 from tests import is_same, valid_hydra_literals
 
@@ -201,3 +202,18 @@ def test_get_target_with_non_string_target():
 def test_recursive_just():
     x = {"a": [3 - 4j, 1 + 2j]}
     assert instantiate(just(x)) == x
+
+
+def fn_target(x: int, y: int):
+    return x + y
+
+
+@hydrated_dataclass(int)
+class HydratedExample:
+    x: int
+    y: int = 3
+
+
+def test_hydrated_dataclass_pickles():
+    assert pickle.loads(pickle.dumps(HydratedExample)) is HydratedExample
+    assert pickle.loads(pickle.dumps(HydratedExample(x=2))) == HydratedExample(x=2)


### PR DESCRIPTION
Partially addresses support for pickling raised in #333 

Given:

```python
# contents of mylib/foo.py
from hydra_zen import hydrated_dataclass

@hydrated_dataclass(target=int)
class A:
    ...
```

**Before**:

```python
>>> A
types.A
>>> import pickle
>>> pickle.loads(pickle.dumps(A)) is A
---------------------------------------------------------------------------
PicklingError: Can't pickle <class 'types.A'>: attribute lookup A on types failed
```

**After**:
```python
>>> A
mylib.foo.A
>>> import pickle
>>> pickle.loads(pickle.dumps(A)) is A  
False
```