### PR TITLE
Separate out pyright docs scan job

### DIFF
--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -78,6 +78,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox
+    - name: Cache tox environments
+      id: cache-third-party
+      uses: actions/cache@v3
+      with:
+        path: .tox
+        key: tox-pyright-docs-${{ hashFiles('setup.cfg') }}-${{ hashFiles('setup.py') }}-${{ hashFiles('tests/conftest.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
     - name: Scan docs with pyright
       run: tox -e pyright-scan-docs
 

--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -65,6 +65,21 @@ jobs:
         pip install tox
     - name: Measure coverage
       run: tox -e coverage
+  
+  pyright-scan-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: Scan docs with pyright
+      run: tox -e pyright-scan-docs
 
   test-third-party:
     runs-on: ubuntu-latest

--- a/docs/source/how_to/pytorch_lightning.rst
+++ b/docs/source/how_to/pytorch_lightning.rst
@@ -60,7 +60,7 @@ following code. Here, we define our single-layer neural network and the `lightni
    def single_layer_nn(num_neurons: int) -> nn.Module:
        """y = sum(V sigmoid(X W + b))"""
        return nn.Sequential(
-           nn.Linear(1, num_neurons),
+           nn.Linear(1,1,1,1,1,1,"apple"),  # TODO: FIX ME
            nn.Sigmoid(),
            nn.Linear(num_neurons, 1, bias=False),
        )

--- a/docs/source/how_to/pytorch_lightning.rst
+++ b/docs/source/how_to/pytorch_lightning.rst
@@ -60,7 +60,7 @@ following code. Here, we define our single-layer neural network and the `lightni
    def single_layer_nn(num_neurons: int) -> nn.Module:
        """y = sum(V sigmoid(X W + b))"""
        return nn.Sequential(
-           nn.Linear(1,1,1,1,1,1,"apple"),  # TODO: FIX ME
+           nn.Linear(1, num_neurons),
            nn.Sigmoid(),
            nn.Linear(num_neurons, 1, bias=False),
        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ combine_as_imports = true
 
 [tool.coverage.run]
 branch = true
+omit = [
+  "tests/test_docs_typecheck.py",
+]
 
 [tool.coverage.report]
 omit = ["src/hydra_zen/_version.py"]
@@ -180,8 +183,19 @@ deps = {[testenv]deps}
        pydantic
        beartype
        cloudpickle
-       pyright
 commands = pytest --cov-report term-missing --cov-config=pyproject.toml --cov-fail-under=100 --cov=hydra_zen -n auto tests
+
+
+[testenv:pyright-scan-docs]
+setenv = NUMBA_DISABLE_JIT=1
+usedevelop = true
+basepython = python3.8
+deps = {[testenv]deps}
+       numpy
+       pydantic
+       beartype
+       pyright
+commands = pytest -n auto tests/test_docs_typecheck.py
 
 
 [testenv:third-party]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,7 @@ deps = {[testenv]deps}
        pydantic
        beartype
        pyright
-commands = pytest -n auto tests/test_docs_typecheck.py
+commands = pytest -n auto tests/test_docs_typecheck.py -vv
 
 
 [testenv:third-party]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,13 @@ commands = pytest --cov-report term-missing --cov-config=pyproject.toml --cov-fa
 usedevelop = true
 basepython = python3.9
 deps = {[testenv]deps}
+       torch
+       pytorch-lightning
+       numpy
+       jaxlib
+       jax
+       pydantic
+       beartype
        pyright
 commands = pytest -n auto tests/test_docs_typecheck.py -vv
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,7 @@ commands = pytest --cov-report term-missing --cov-config=pyproject.toml --cov-fa
 
 [testenv:pyright-scan-docs]
 usedevelop = true
-basepython = python3.8
+basepython = python3.9
 deps = {[testenv]deps}
        numpy
        pydantic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,6 @@ commands = pytest --cov-report term-missing --cov-config=pyproject.toml --cov-fa
 
 
 [testenv:pyright-scan-docs]
-setenv = NUMBA_DISABLE_JIT=1
 usedevelop = true
 basepython = python3.8
 deps = {[testenv]deps}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,9 +190,6 @@ commands = pytest --cov-report term-missing --cov-config=pyproject.toml --cov-fa
 usedevelop = true
 basepython = python3.9
 deps = {[testenv]deps}
-       numpy
-       pydantic
-       beartype
        pyright
 commands = pytest -n auto tests/test_docs_typecheck.py -vv
 

--- a/tests/test_docs_typecheck.py
+++ b/tests/test_docs_typecheck.py
@@ -48,7 +48,6 @@ from hydra_zen.typing import ZenConvert
 
 
 @pytest.mark.skipif(PYRIGHT_PATH is None, reason="pyright is not installed")
-@pytest.mark.no_cover
 @pytest.mark.parametrize(
     "func",
     [
@@ -109,7 +108,6 @@ files += [
 
 @pytest.mark.skipif(PYRIGHT_PATH is None, reason="pyright is not installed")
 @pytest.mark.skipif(not files, reason="docs not found")
-@pytest.mark.no_cover
 @pytest.mark.parametrize(
     "func, pyright_config",
     files,


### PR DESCRIPTION
Ensure pyright docs scan has 3rd party libraries installed so that pyright can validate against their interfaces as well