### PR TITLE
Improve `Partial` protocol

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -126,6 +126,7 @@ Improvements
 Compatibility-Breaking Changes
 ------------------------------
 - Previously, any class decorated by :func:`~hydra_zen.hydrated_dataclass` would have a `__module__` attribute set to `typing`. Now the class's `__module__` will reflect the module where its static definition resides. This enables pickle-compatibility  (:pull:`338`). This is unlikely to cause any issues for users.
+- Improved the `hydra_zen.typing.Partial` protocol to match against the output of `functools.partial` more reliably in the eyes of pyright (:pull:`354`).
 
 .. _v0.8.0:
 

--- a/src/hydra_zen/structured_configs/_just.py
+++ b/src/hydra_zen/structured_configs/_just.py
@@ -15,6 +15,7 @@ from ._utils import merge_settings
 from ._value_conversion import ConfigComplex
 
 # pyright: strict
+T = TypeVar("T")
 TD = TypeVar("TD", bound=DataClass_)
 TC = TypeVar("TC", bound=Callable[..., Any])
 TP = TypeVar("TP", bound=_HydraPrimitive)
@@ -50,23 +51,23 @@ def just(
 
 @overload
 def just(
-    obj: TB,
-    *,
-    zen_convert: Optional[ZenConvert] = ...,
-    hydra_recursive: Optional[bool] = ...,
-    hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
-) -> Builds[Type[TB]]:
-    ...
-
-
-@overload
-def just(
     obj: TC,
     *,
     zen_convert: Optional[ZenConvert] = ...,
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
 ) -> Type[Just[TC]]:
+    ...
+
+
+@overload
+def just(
+    obj: TB,
+    *,
+    zen_convert: Optional[ZenConvert] = ...,
+    hydra_recursive: Optional[bool] = ...,
+    hydra_convert: Optional[Literal["none", "partial", "all"]] = ...,
+) -> Builds[Type[TB]]:
     ...
 
 

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -89,6 +89,8 @@ else:
 
 @runtime_checkable
 class Partial(Protocol[T2]):
+    __call__: Callable[..., T2]
+
     @property
     def func(self) -> Callable[..., T2]:
         ...
@@ -104,9 +106,6 @@ class Partial(Protocol[T2]):
     def __new__(
         cls: Type[Self], __func: Callable[..., T2], *args: Any, **kwargs: Any
     ) -> Self:
-        ...
-
-    def __call__(self, *args: Any, **kwargs: Any) -> T2:
         ...
 
     if sys.version_info >= (3, 9):  # pragma: no cover

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -482,11 +482,12 @@ def check_partial_protocol_harder():
     def f() -> int:
         ...
 
-    def g(x: str) -> int:
+    def g(x: str) -> bool:
         ...
 
     x: Partial[int] = partial(f)
-    y: Partial[int] = partial(g)
+    y: Partial[bool] = partial(g, x="a")
+    z: Partial[str] = partial(g, x="a")  # type: ignore
 
 
 def check_partiald_target():

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -478,6 +478,17 @@ def check_partial_protocol():
     assert x
 
 
+def check_partial_protocol_harder():
+    def f() -> int:
+        ...
+
+    def g(x: str) -> int:
+        ...
+
+    x: Partial[int] = partial(f)
+    y: Partial[int] = partial(g)
+
+
 def check_partiald_target():
     reveal_type(builds(partial(int)), expected_text="Type[Builds[partial[int]]]")
     reveal_type(


### PR DESCRIPTION
Our pyright tests for Partial weren't tight enough to catch some issues with the current protocol.

The following failed to type check prior to 7d93063:

```python
def f() -> int:
    ...

def g(x: str) -> bool:
    ...

x: Partial[int] = partial(f)
y: Partial[bool] = partial(g, x="a")
```