### PR TITLE
Use Self annotation in store self-partialing

### DIFF
--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -210,7 +210,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install mypy==0.982
+        pip install mypy
         pip install -e .
     - name: Run mypy on test script
       run: mypy --warn-unused-ignores tests/annotations/mypy_checks.py

--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -213,4 +213,4 @@ jobs:
         pip install mypy
         pip install -e .
     - name: Run mypy on test script
-      run: mypy --warn-unused-ignores tests/annotations/mypy_checks.py
+      run: mypy tests/annotations/mypy_checks.py

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -21,6 +21,8 @@ Improvements
 ------------
 - :func:`hydra_zen.launch` now supports dictionary overrides. See :pull:`313`.
 - :class:`hydra_zen.ZenStore` now provides specialized support for storing instances/subclasses of `HydraConf`. See :issue:`395`.
+- Adds auto-config support for jax 0.4.0. See :pull:`414`.
+- Improved the type annotations of :class:`~hydra_zen.wrappers.ZenStore`. See :pull:`409`.
 
 
 --------------------------

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -39,6 +39,7 @@ from typing_extensions import (
     Literal,
     ParamSpec,
     Protocol,
+    Self,
     TypeAlias,
     TypedDict,
     TypeGuard,
@@ -171,7 +172,8 @@ class Zen(Generic[P, R]):
             )
         except (ValueError, TypeError):
             raise HydraZenValidationError(
-                "hydra_zen.zen can only wrap callables that possess inspectable signatures."
+                "hydra_zen.zen can only wrap callables that possess inspectable "
+                "signatures."
             )
 
         if not isinstance(unpack_kwargs, bool):  # type: ignore
@@ -1235,7 +1237,7 @@ class ZenStore:
     #       https://github.com/python/mypy/pull/11666
     @overload
     def __call__(
-        self,
+        self: Self,
         __target: Literal[None] = None,
         *,
         name: Union[NodeName, Callable[[Any], NodeName]] = ...,
@@ -1244,7 +1246,7 @@ class ZenStore:
         provider: Optional[str] = ...,
         to_config: Callable[[Any], Node] = ...,
         **to_config_kw: Any,
-    ) -> "ZenStore":
+    ) -> Self:
         ...
 
     def __call__(self, __target: Optional[F] = None, **kw: Any) -> Union[F, "ZenStore"]:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 # mypy: disable-error-code=misc
+# mypy: disable-error-code=import
 
 import functools
 from typing import Any

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2023 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
+# mypy: disable-error-code=misc
 
 import functools
 from typing import Any

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -1231,8 +1231,7 @@ def check_store():
     substore1 = substore(a=1)
     x = substore1(dict(a=1))
 
-    # TODO: Enable when mypy supports Self
-    # assert_type(substore1, SubStore)
+    assert_type(substore1, SubStore)
 
     assert_type(x, Dict[str, int])
 

--- a/tests/annotations/mypy_checks.py
+++ b/tests/annotations/mypy_checks.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2023 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
+# mypy: disable-error-code=empty-body
 
 from typing_extensions import assert_type
 
@@ -95,6 +96,15 @@ def check_store() -> None:
     # store()(1, to_config=builds)  # false negative
     store(1, to_config=just)
     store()(1, to_config=just)
+
+
+def custom_store() -> None:
+    class MyStore(ZenStore):
+        ...
+
+    mstore = MyStore()
+    ss = mstore(name="foo")
+    assert_type(ss, MyStore)
 
 
 # def check_just() -> None:


### PR DESCRIPTION
A subclassed `ZenStore` will now return the correct type -- the subclass -- when self-partialing. This works for both pyright and mypy.

E.g.

```python
from hydra_zen.wrapper import ZenStore

class MyStore(ZenStore):
    ...

store = MyStore()
optim_store = store(group="optim")

# Before: type checker sees `ZenStore`
# After: type checker sees `MyStore`
reveal_type(optim_store)
```