### PR TITLE
Add type conversion support for `InitVar`

### DIFF
--- a/src/hydra_zen/structured_configs/_utils.py
+++ b/src/hydra_zen/structured_configs/_utils.py
@@ -3,7 +3,7 @@
 import inspect
 import sys
 import warnings
-from dataclasses import MISSING, field as _field, is_dataclass
+from dataclasses import MISSING, InitVar, field as _field, is_dataclass
 from enum import Enum
 from keyword import iskeyword
 from pathlib import Path
@@ -455,6 +455,13 @@ def sanitized_type(
         # these aren't hashable -- can't check for membership in set
         return Any
 
+    if isinstance(type_, InitVar):
+        return sanitized_type(
+            type_.type,
+            primitive_only=primitive_only,
+            wrap_optional=wrap_optional,
+            nested=nested,
+        )
     if (
         type_ is Any
         or type_ in _supported_types

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -273,7 +273,7 @@ vDict = Dict[Any, Any] if sys.version_info < (3, 8) else Dict
         ),
         (Tuple[Tuple[int, ...], ...], Tuple[Any, ...]),
         (Optional[Tuple[Tuple[int, ...], ...]], Optional[Tuple[Any, ...]]),
-        (InitVar[List[frozenset]], List[Any] if sys.version_info < (3, 8) else Any),
+        (InitVar[List[frozenset]], Any if sys.version_info < (3, 8) else List[Any]),
     ],
 )
 def test_sanitized_type_expected_behavior(in_type, expected_type):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ import enum
 import random
 import string
 import sys
-from dataclasses import dataclass, field as dataclass_field, make_dataclass
+from dataclasses import InitVar, dataclass, field as dataclass_field, make_dataclass
 from inspect import signature
 from pathlib import Path, PosixPath, WindowsPath
 from typing import (
@@ -273,6 +273,7 @@ vDict = Dict[Any, Any] if sys.version_info < (3, 8) else Dict
         ),
         (Tuple[Tuple[int, ...], ...], Tuple[Any, ...]),
         (Optional[Tuple[Tuple[int, ...], ...]], Optional[Tuple[Any, ...]]),
+        (InitVar[List[frozenset]], List[Any]),
     ],
 )
 def test_sanitized_type_expected_behavior(in_type, expected_type):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -273,7 +273,7 @@ vDict = Dict[Any, Any] if sys.version_info < (3, 8) else Dict
         ),
         (Tuple[Tuple[int, ...], ...], Tuple[Any, ...]),
         (Optional[Tuple[Tuple[int, ...], ...]], Optional[Tuple[Any, ...]]),
-        (InitVar[List[frozenset]], List[Any]),
+        (InitVar[List[frozenset]], List[Any] if sys.version_info < (3, 8) else Any),
     ],
 )
 def test_sanitized_type_expected_behavior(in_type, expected_type):


### PR DESCRIPTION
Given:

```python
from dataclasses import dataclass, InitVar
from inspect import signature

from hydra_zen import builds

@dataclass
class A:
    x: InitVar[int]

Conf = builds(A, populate_full_signature=True)
```

Before:

```python
>>> signature(Conf)
<Signature (x: Any) -> None>
```

After:

```python
>>> signature(Conf)
<Signature (x: int) -> None>
```
