### PR TITLE
`just` no longer produces frozen dataclass instances

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -13,18 +13,22 @@ chronological order. All previous releases should still be available on pip.
 ---------------------
 0.11.0rc - 2023-04-09
 ---------------------
-This release drops support for hydra-core 1.1 and for omegaconf 2.1; this enables hydra-zen to remove a lot of complex compatibility logic and to improve the behavior
-of :func:`~hydra_zen.zen`.
+
+.. note:: This is documentation for an unreleased version of hydra-zen. You can try out this pre-release version using `pip install --pre hydra-zen`
+
+This release drops support for hydra-core 1.1 and for omegaconf 2.1; this enabled the 
+removal of a lot of complex compatibility logic from hydra-zen's source code, and to 
+improve the behavior of :func:`~hydra_zen.zen`.
 
 Bug Fixes
 ---------
-- :pull:`355` configs produced by `~hydra_zen.just` can now 
+- Configs produced by `~hydra_zen.just` will no longer cause a `ReadonlyConfigError` during Hydra's config-composition process. See :pull:`459`
 
 Compatibility-Breaking Changes
 ------------------------------
 - The auto-instantiation behavior of :class:`~hydra_zen.wrapper.Zen` and :func:`~hydra_zen.zen` have been updated so that nested dataclasses (nested within lists, dicts, and other dataclasses) will no longer be returned as omegaconf configs (see :pull:`448`).
 - hydra-core 1.2.0 and omegaconf 2.2.1 are now the minimum supported versions.
-- :func:`~hydra_zen.just` not longer returns a frozen dataclass.
+- :func:`~hydra_zen.just` not longer returns a frozen dataclass (see :pull:`459`).
 
 --------------------------
 Documentation - 2023-03-11

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -8,15 +8,6 @@ Changelog
 This is a record of all past hydra-zen releases and what went into them, in reverse 
 chronological order. All previous releases should still be available on pip.
 
---------------------------
-Documentation - 2023-03-11
---------------------------
-
-The following parts of the documentation underwent significant revisions:
-
-- `The landing page <https://github.com/mit-ll-responsible-ai/hydra-zen>`_ now has a "hydra-zen at at glance" subsection.
-- The docs for `~hydra_zen.ZenStore` were revamped.
-
 .. _v0.11.0:
 
 ---------------------
@@ -25,11 +16,24 @@ The following parts of the documentation underwent significant revisions:
 This release drops support for hydra-core 1.1 and for omegaconf 2.1; this enables hydra-zen to remove a lot of complex compatibility logic and to improve the behavior
 of :func:`~hydra_zen.zen`.
 
+Bug Fixes
+---------
+- :pull:`355` configs produced by `~hydra_zen.just` can now 
 
 Compatibility-Breaking Changes
 ------------------------------
 - The auto-instantiation behavior of :class:`~hydra_zen.wrapper.Zen` and :func:`~hydra_zen.zen` have been updated so that nested dataclasses (nested within lists, dicts, and other dataclasses) will no longer be returned as omegaconf configs (see :pull:`448`).
 - hydra-core 1.2.0 and omegaconf 2.2.1 are now the minimum supported versions.
+- :func:`~hydra_zen.just` not longer returns a frozen dataclass.
+
+--------------------------
+Documentation - 2023-03-11
+--------------------------
+
+The following parts of the documentation underwent significant revisions:
+
+- `The landing page <https://github.com/mit-ll-responsible-ai/hydra-zen>`_ now has a "hydra-zen at at glance" subsection.
+- The docs for `~hydra_zen.ZenStore` were revamped.
 
 
 .. _v0.10.0:

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -485,7 +485,7 @@ def hydrated_dataclass(
     return wrapper
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class Just:
     """Just[T] is a config that returns T when instantiated."""
 

--- a/tests/test_launch/test_merge_compat.py
+++ b/tests/test_launch/test_merge_compat.py
@@ -1,0 +1,49 @@
+import pytest
+from omegaconf import DictConfig
+
+from hydra_zen import builds, launch, make_config, store, to_yaml, zen
+
+
+def relu():
+    ...
+
+
+def selu():
+    ...
+
+
+class Model:
+    def __init__(self, activation_fn=relu):
+        ...
+
+
+def app(zen_cfg: DictConfig, model: Model) -> None:
+    print(to_yaml(zen_cfg, resolve=True))
+
+
+store(Model, group="model")
+
+
+@pytest.mark.usefixtures("cleandir")
+def test_merge_prevented_by_frozen_regression():
+    # https://github.com/mit-ll-responsible-ai/hydra-zen/issues/449
+    Config = builds(
+        app,
+        populate_full_signature=True,
+        hydra_defaults=[
+            "_self_",
+            {"model": "Model"},
+            {"experiment": "selu"},
+        ],
+    )
+
+    experiment_store = store(group="experiment", package="_global_")
+    experiment_store(
+        make_config(
+            hydra_defaults=["_self_"], model=dict(activation_fn=selu), bases=(Config,)
+        ),
+        name="selu",
+    )
+
+    store.add_to_hydra_store()
+    launch(Config, zen(app), version_base="1.2")

--- a/tests/test_launch/test_merge_compat.py
+++ b/tests/test_launch/test_merge_compat.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 Massachusetts Institute of Technology
+# SPDX-License-Identifier: MIT
+
 import pytest
 from omegaconf import DictConfig
 

--- a/tests/test_launch/test_merge_compat.py
+++ b/tests/test_launch/test_merge_compat.py
@@ -4,7 +4,7 @@
 import pytest
 from omegaconf import DictConfig
 
-from hydra_zen import builds, launch, make_config, store, to_yaml, zen
+from hydra_zen import ZenStore, builds, launch, make_config, to_yaml, zen
 
 
 def relu():
@@ -24,12 +24,12 @@ def app(zen_cfg: DictConfig, model: Model) -> None:
     print(to_yaml(zen_cfg, resolve=True))
 
 
-store(Model, group="model")
-
-
 @pytest.mark.usefixtures("cleandir")
+@pytest.mark.usefixtures("clean_store")
 def test_merge_prevented_by_frozen_regression():
     # https://github.com/mit-ll-responsible-ai/hydra-zen/issues/449
+
+    store = ZenStore()
     Config = builds(
         app,
         populate_full_signature=True,
@@ -47,6 +47,6 @@ def test_merge_prevented_by_frozen_regression():
         ),
         name="selu",
     )
-
+    store(Model, group="model")
     store.add_to_hydra_store()
     launch(Config, zen(app), version_base="1.2")


### PR DESCRIPTION
Closes #449 I.e. configs produced by `just` can now be merged into configs by Hydra.


This is a backwards-compatibility breaking change, but it should be of negligible negative impact. 