### PR TITLE
Update `builds` signature inspection for python 3.11.4 change

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -51,7 +51,7 @@ hydra-zen now uses the `trusted publishers <https://blog.pypi.org/posts/2023-04-
 Improvements
 ------------
 - :func:`~hydra_zen.builds` now has a transitive property that enables iterative build patterns. See :pull:`455`
-- :func:`~hydra_zen.zen`'s instantiation phase has been improved so that dataclass objects and stdlib containers are returned instead of omegaconf objects. See :pull:`#448`. 
+- :func:`~hydra_zen.zen`'s instantiation phase has been improved so that dataclass objects and stdlib containers are returned instead of omegaconf objects. See :pull:`448`. 
 - :func:`~hydra_zen.zen` can now be passed `resolve_pre_call=False` to defer the resolution of interpolated fields until after `pre_call` functions are called. See :pull:`460`.
 
 Bug Fixes
@@ -68,6 +68,7 @@ Most of these changes will not have any impact on users, based on download stati
 - :func:`~hydra_zen.just` not longer returns a frozen dataclass (see :pull:`459`).
 - Users that relied on patterns like `builds(builds(...))` will find that :pull:`455` has changed their behaviors. This new behavior can be disabled via `builds(..., zen_convert={'flat_target': False})`
 - :func:`~hydra_zen.zen`'s instantiation behavior was changed by :pull:`448`. See that PR for instructions on restoring the old behavior.
+- The signature-inspection logic of :func:`~hydra_zen.builds` has been modified to adopt and backport a fix made to :py:func:`inspect.signature` in Python 3.11.4. See :pull:`497`.
 
 --------------------------
 Documentation - 2023-03-11

--- a/tests/test_signature_parsing.py
+++ b/tests/test_signature_parsing.py
@@ -510,32 +510,32 @@ def test_populate_annotated_enum_regression():
 class A:
     # Manually verified using `inspect.signature` after
     # the fix of https://bugs.python.org/issue40897
-    py_310_sig = (("a", int),)
+    expected_sig = (("a", int),)
 
     def __new__(cls, a: int):
         return object.__new__(cls)
 
 
 class B(A):
-    py_310_sig = (("b", float),)
+    expected_sig = (("b", float),)
 
     def __init__(self, b: float):
         pass
 
 
 class C(A):
-    py_310_sig = (("c", str),)
+    expected_sig = (("c", str),)
 
     def __new__(cls, c: str):
         return object.__new__(cls)
 
 
 class D(A):
-    py_310_sig = (("a", int),)
+    expected_sig = (("a", int),)
 
 
 class E(B):
-    py_310_sig = (("a", int),)
+    expected_sig = (("b", float),)
 
 
 @pytest.mark.parametrize("Obj", [A, B, C, D, E])
@@ -548,7 +548,7 @@ def test_parse_sig_with_new_vs_init(Obj):
         (p.name, p.annotation) for p in inspect.signature(Conf).parameters.values()
     )
 
-    assert sig_via_builds == Obj.py_310_sig
+    assert sig_via_builds == Obj.expected_sig
 
 
 def test_Counter():


### PR DESCRIPTION
https://github.com/python/cpython/issues/105080 updates the behavior of `inspect.signature` to walk through a class' mro in search of its signature, rather than just defer to the most recent definition of `__new__`.

This PR updates the signature inspection logic of `builds` to match this new behavior of `inspect.signature` across all versions of Python. I.e. this effectively serves as a backport.

Here is an example that exhibits this change in behavior:

```python
class A:
    def __new__(cls, a: int):
        return object.__new__(cls)

class B(A):
    def __init__(self, b: float):  ...

class C(B):
    ...
```

Before:

The signature of `A.__new__` was preferred over that of `B.__init__` even though the latter is closer to `C` in the inheritance hierarchy.

```python
>>> import inspect
>>> from hydra_zen import inspect
>>> inspect.signature(builds(c, populate_full_signature=True))
<Signature (a: int) -> None>
```

After:

C's signature is that of `B.__init__`

```python
>>> import inspect
>>> from hydra_zen import inspect
>>> inspect.signature(builds(c, populate_full_signature=True))
<Signature (b: float) -> None>
```