### PR TITLE
Add support for numpy 1.25.0

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -53,6 +53,7 @@ Improvements
 - :func:`~hydra_zen.builds` now has a transitive property that enables iterative build patterns. See :pull:`455`
 - :func:`~hydra_zen.zen`'s instantiation phase has been improved so that dataclass objects and stdlib containers are returned instead of omegaconf objects. See :pull:`448`. 
 - :func:`~hydra_zen.zen` can now be passed `resolve_pre_call=False` to defer the resolution of interpolated fields until after `pre_call` functions are called. See :pull:`460`.
+- Added support for NumPy 1.25.0
 
 Bug Fixes
 ---------

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -535,6 +535,10 @@ def _check_instance(*target_types: str, value: "Any", module: str):  # pragma: n
         return any(value is t for t in types)
 
 
+_is_numpy_array_func_dispatcher = functools.partial(
+    _check_instance, "_ArrayFunctionDispatcher", module="numpy.core._multiarray_umath"
+)
+
 _is_jax_compiled_func = functools.partial(
     _check_instance, "CompiledFunction", "PjitFunction", module="jaxlib.xla_extension"
 )
@@ -648,6 +652,7 @@ def sanitized_default_value(
             or inspect.ismethod(value)
             or isinstance(value, _BUILTIN_TYPES)
             or _is_ufunc(value)
+            or _is_numpy_array_func_dispatcher(value=value)
             or _is_jax_compiled_func(value=value)
         )
     ):


### PR DESCRIPTION
NumPy 1.25.0 changed some of its function dispatching logic in a way that prevented hydra-zen's config-creation functions from identifying some otherwise-supported Python functions. Affected functions included `numpy.reshape` and `numpy.linalg.norm`