### PR TITLE
v0.10.2: Fix pyright's failure to handle  `make_custom_builds_fn`

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -9,7 +9,16 @@ This is a record of all past hydra-zen releases and what went into them, in reve
 chronological order. All previous releases should still be available on pip.
 
 
-.. _v0.10.0:
+.. _v0.10.2:
+
+-------------------
+0.10.2 - 2023-07-04
+-------------------
+
+This patch circumvents an upstream bug in pyright, which was causing pyright 1.1.305+ to report the return type of :func:`hydra_zen.make_custom_builds_fn` as "Unknown".
+
+
+.. _v0.10.1:
 
 -------------------
 0.10.1 - 2023-05-23

--- a/src/hydra_zen/structured_configs/_make_custom_builds.py
+++ b/src/hydra_zen/structured_configs/_make_custom_builds.py
@@ -4,7 +4,17 @@
 import inspect
 import warnings
 from functools import wraps
-from typing import Any, Callable, Dict, Mapping, Optional, Union, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Mapping,
+    Optional,
+    Union,
+    cast,
+    overload,
+)
 
 from typing_extensions import Final, Literal
 
@@ -268,8 +278,9 @@ def make_custom_builds_fn(
 
     _frozen = _new_defaults.pop("frozen")
 
-    # let `builds` validate the new defaults!
-    builds(builds, **_new_defaults)
+    if not TYPE_CHECKING:  # pragma: no branch
+        # let `builds` validate the new defaults!
+        builds(builds, **_new_defaults)
 
     _zen_dataclass: Optional[DataclassOptions] = _new_defaults.pop("zen_dataclass")
     if _zen_dataclass is None:


### PR DESCRIPTION
A patch for v0.10:  This patch circumvents an upstream bug in pyright, which was causing pyright 1.1.305+ to report the return type of :func:`hydra_zen.make_custom_builds_fn` as "Unknown".