### PR TITLE
Update test link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ VSCode's Pylance extension is built off of pyright, and thus is recommended. If 
 
 ## Adding New Features to the Public API
 
-All functions/classes that are part of the public API must have a docstring that adheres to the [numpy docstring style](https://numpydoc.readthedocs.io/en/latest/format.html), and the docstring must include and `Examples` section. The function's docstring must be scanned by pyright, by adding the function to [this test](https://github.com/mit-ll-responsible-ai/hydra-zen/blob/main/tests/test_docstrings.py).
+All functions/classes that are part of the public API must have a docstring that adheres to the [numpy docstring style](https://numpydoc.readthedocs.io/en/latest/format.html), and the docstring must include and `Examples` section. The function's docstring must be scanned by pyright, by adding the function to [this test](https://github.com/mit-ll-responsible-ai/hydra-zen/blob/main/tests/test_documented_examples.py).
 
 All publicly-facing interfaces must be type-annotated and scan "clean" using the pyright type checker.
 


### PR DESCRIPTION
It looks like the name of the docstrings test (the one where one should place the examples) has changed its name.