### PR TITLE
Change `pyright_analyze` to scan multiple files in parallel

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -82,7 +82,7 @@ all parts of this library code and generate a CLI that reflects the resulting hi
 
    from hydra_zen import just, store
 
-   from baby_torch import DataLoader, Model, relu, sigmoid  # pyright: ignore
+   from baby_torch import DataLoader, Model, relu, sigmoid
    
    # Automatically generate and store configs for `Model`
    model_store = store(group="model")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,7 +201,7 @@ deps = {[testenv]deps}
        scikit-learn
        matplotlib
        --requirement deps/requirements-pyright.txt
-commands = pytest tests/test_docs_typecheck.py -vv {posargs: -n auto --maxprocesses=4}
+commands = pytest tests/test_docs_typecheck.py
 
 
 [testenv:third-party]

--- a/tests/pyright_utils.py
+++ b/tests/pyright_utils.py
@@ -10,9 +10,10 @@ import subprocess
 import tempfile
 import textwrap
 import time
+from collections import Counter, defaultdict
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, DefaultDict, Dict, List, Optional, Union
 
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -216,18 +217,20 @@ def rst_to_code(src: str) -> str:
 
 
 def pyright_analyze(
-    code_or_path: Any,
+    *code_objs_and_or_paths: Any,
     pyright_config: Optional[Dict[str, Any]] = None,
-    *,
     scan_docstring: bool = False,
     path_to_pyright: Union[Path, None] = PYRIGHT_PATH,
     preamble: str = "",
     python_version: Optional[str] = None,
     report_unnecessary_type_ignore_comment: Optional[bool] = None,
     type_checking_mode: Optional[Literal["basic", "strict"]] = None,
-) -> PyrightOutput:
+) -> List[PyrightOutput]:
     r"""
-    Scan a Python object, docstring, or file with pyright.
+    Scan one or more Python objects, docstrings, or files with pyright.
+
+    Note that it is much faster to call this function once for N objects than N
+    times - once for each object.
 
     The following file formats are supported: `.py`, `.rst`, and `.ipynb`
 
@@ -240,20 +243,18 @@ def pyright_analyze(
 
     Parameters
     ----------
-    code_or_path : SourceObjectType | Path
+    *code_objs_and_or_paths : SourceObjectType | Path
         A function, module-object, class, or method to scan. Or, a path to a file
         to scan. Supported file formats are `.py`, `.rst`, and `.ipynb`.
 
-        Specifying a directory is permitted, but only `.py` files in that directory
-        will be scanned. All files will be copied to a temporary directory before being
-        scanned.
+        Specifying a directory is not permitted.
 
     pyright_config : None | dict[str, Any]
         A JSON configuration for pyright's settings [2]_.
 
     scan_docstring : bool, optional (default=False), keyword-only
-        If `True` pyright will scan the docstring examples of the specified code object,
-        rather than the code object itself.
+        If `True` pyright will scan the docstring examples of any specified code
+        objects, rather than the code object itself.
 
         Example code blocks are expected to have the doctest format [3]_.
 
@@ -279,8 +280,8 @@ def pyright_analyze(
 
     Returns
     -------
-    Dict[str, Any]
-        The JSON-decoded results of the scan [3]_.
+    List[Dict[str, Any]]  (In one-to-one correspondence with `code_objs_and_or_paths`)
+        A JSON-decoded result of the scan for each of the inputs [3]_.
             - version: str
             - time: str
             - generalDiagnostics: List[DiagnosticDict] (one entry per error/warning)
@@ -415,75 +416,119 @@ def pyright_analyze(
     if type_checking_mode is not None:
         pyright_config["typeCheckingMode"] = type_checking_mode
 
-    if scan_docstring and (
-        isinstance(code_or_path, (Path, str))
-        or getattr(code_or_path, "__doc__") is None
-    ):
-        raise ValueError(
-            "`scan_docstring=True` can only be specified when `code_or_path` is an "
-            "object with a `__doc__` attribute that returns a string."
-        )
-
-    if isinstance(code_or_path, str):
-        code_or_path = Path(code_or_path)
-
-    if isinstance(code_or_path, Path):
-        code_or_path = code_or_path.resolve()
-        if not code_or_path.exists():
-            raise FileNotFoundError(
-                f"Specified path {code_or_path} does not exist. Cannot be scanned by pyright."
-            )
-        if code_or_path.suffix == ".rst":
-            source = rst_to_code(code_or_path.read_text("utf-8"))
-        elif code_or_path.suffix == ".ipynb":
-            source = notebook_to_py_text(code_or_path)
-        elif code_or_path.is_file() and code_or_path.suffix != ".py":
+    sources: List[Optional[str]] = []
+    for code_or_path in code_objs_and_or_paths:
+        if scan_docstring and (
+            isinstance(code_or_path, (Path, str))
+            or getattr(code_or_path, "__doc__") is None
+        ):
             raise ValueError(
-                f"{code_or_path}: File type {code_or_path.suffix} not supported by "
-                "`pyright_analyze`."
+                "`scan_docstring=True` can only be specified when `code_or_path` is an "
+                "object with a `__doc__` attribute that returns a string."
             )
+
+        if isinstance(code_or_path, str):
+            code_or_path = Path(code_or_path)
+
+        if isinstance(code_or_path, Path):
+            code_or_path = code_or_path.resolve()
+            if code_or_path.is_dir():
+                raise ValueError(
+                    f"Paths must specify individual files, not directories. Got: {str(code_or_path)}"
+                )
+            if not code_or_path.exists():
+                raise FileNotFoundError(
+                    f"Specified path {code_or_path} does not exist. Cannot be scanned by pyright."
+                )
+            if code_or_path.suffix == ".rst":
+                source = rst_to_code(code_or_path.read_text("utf-8"))
+            elif code_or_path.suffix == ".ipynb":
+                source = notebook_to_py_text(code_or_path)
+            elif code_or_path.is_file() and code_or_path.suffix != ".py":
+                raise ValueError(
+                    f"{code_or_path}: File type {code_or_path.suffix} not supported by "
+                    "`pyright_analyze`."
+                )
+            else:
+                source = None
         else:
-            source = None
-    else:
-        if preamble and not preamble.endswith("\n"):
-            preamble = preamble + "\n"
-        if not scan_docstring:
-            source = preamble + textwrap.dedent((inspect.getsource(code_or_path)))
-        else:
-            docstring = inspect.getdoc(code_or_path)
-            assert docstring is not None
-            source = preamble + get_docstring_examples(docstring)
+            if preamble and not preamble.endswith("\n"):
+                preamble = preamble + "\n"
+            if not scan_docstring:
+                source = preamble + textwrap.dedent((inspect.getsource(code_or_path)))
+            else:
+                docstring = inspect.getdoc(code_or_path)
+                assert docstring is not None
+                source = preamble + get_docstring_examples(docstring)
+        sources.append(source)
 
     with chdir():
         cwd = Path.cwd()
-        if source is not None:
-            file_ = cwd / "source.py"
-            file_.write_text(source, encoding="utf-8")
-        else:
-            file_ = Path(code_or_path).absolute()
-            if file_ != cwd:
-                cp = shutil.copytree if file_.is_dir() else shutil.copy
-                file_ = cp(file_, cwd / file_.name)
 
-        run_dir = file_.parent if file_.is_file() else file_
-        config_path = run_dir / "pyrightconfig.json"
+        for n, (source, code_or_path) in enumerate(
+            zip(sources, code_objs_and_or_paths)
+        ):
+            target_dir = cwd / str(n)
+            target_dir.mkdir()
+
+            if source is not None:
+                file_ = target_dir / f"{getattr(code_or_path, '__name__', 'source')}.py"
+                file_.write_text(source, encoding="utf-8")
+            else:
+                file_ = Path(code_or_path).absolute()
+                if file_ != cwd:
+                    file_ = shutil.copy(file_, target_dir / file_.name)
+
+        config_path = cwd / "pyrightconfig.json"
 
         if pyright_config:
             config_path.write_text(json.dumps(pyright_config))
 
         proc = subprocess.run(
-            [str(path_to_pyright.absolute()), str(file_.absolute()), "--outputjson"],
-            cwd=run_dir,
+            [str(path_to_pyright.absolute()), str(cwd.absolute()), "--outputjson"],
+            cwd=cwd,
             encoding="utf-8",
             text=True,
             capture_output=True,
         )
         try:
             time.sleep(0.1)  # maybe fixes JSONDecoder errors
-            return json.loads(proc.stdout)
+            scan: PyrightOutput = json.loads(proc.stdout)
         except Exception as e:  # pragma: no cover
             print(proc.stdout)
             raise e
+
+    out = scan["generalDiagnostics"]
+
+    diagnostics_by_file: DefaultDict[int, List[Diagnostic]] = defaultdict(list)
+
+    for item in out:
+        file_path = Path(item["file"])
+        file_index = int(file_path.parent.name)
+        diagnostic = item.copy()
+        diagnostic["file"] = file_path.name
+        diagnostics_by_file[file_index].append(diagnostic)
+
+    results: List[PyrightOutput] = []
+
+    for n in range(len(code_objs_and_or_paths)):
+        severities = Counter(d["severity"] for d in diagnostics_by_file[n])
+        summary = Summary(
+            filesAnalyzed=1,
+            errorCount=severities["error"],
+            warningCount=severities["warning"],
+            informationCount=severities["information"],
+            timeInSec=scan["summary"]["timeInSec"],
+        )
+        results.append(
+            PyrightOutput(
+                version=scan["version"],
+                time=scan["time"],
+                generalDiagnostics=diagnostics_by_file[n],
+                summary=summary,
+            )
+        )
+    return results
 
 
 def list_error_messages(results: PyrightOutput) -> List[str]:

--- a/tests/test_docs_typecheck.py
+++ b/tests/test_docs_typecheck.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
-import json
 from pathlib import Path
+from typing import Any, Dict
 
 import pytest
 
@@ -24,7 +24,12 @@ from hydra_zen import (
     zen,
 )
 from hydra_zen.typing import DataclassOptions, ZenConvert
-from tests.pyright_utils import PYRIGHT_PATH, list_error_messages, pyright_analyze
+from tests.pyright_utils import (
+    PYRIGHT_PATH,
+    PyrightOutput,
+    list_error_messages,
+    pyright_analyze,
+)
 
 preamble = """from hydra_zen import (
     ZenField,
@@ -46,6 +51,44 @@ preamble = """from hydra_zen import (
 )
 from hydra_zen.typing import ZenConvert, DataclassOptions
 """
+
+# We use this to cache pyright scan results
+# so that we can report their results via parameterized tests
+PYRIGHT_SCAN_RESULTS: Dict[Any, PyrightOutput] = {}
+
+
+FUNCS_TO_SCAN = [
+    ZenField,
+    ZenStore,
+    builds,
+    get_target,
+    hydrated_dataclass,
+    instantiate,
+    is_partial_builds,
+    just,
+    # launch,  # TODO: add after https://github.com/mit-ll-responsible-ai/hydra-zen/pull/313 is merged
+    load_from_yaml,
+    make_config,
+    make_custom_builds_fn,
+    save_as_yaml,
+    to_yaml,
+    uses_zen_processing,
+    zen,
+    ZenConvert,
+    DataclassOptions,
+]
+
+if PYRIGHT_PATH is not None:
+    for obj, scan in zip(
+        FUNCS_TO_SCAN,
+        pyright_analyze(
+            *FUNCS_TO_SCAN,
+            scan_docstring=True,
+            report_unnecessary_type_ignore_comment=True,
+            preamble=preamble,
+        ),
+    ):
+        PYRIGHT_SCAN_RESULTS[obj] = scan
 
 
 @pytest.mark.skipif(PYRIGHT_PATH is None, reason="pyright is not installed")
@@ -73,22 +116,12 @@ from hydra_zen.typing import ZenConvert, DataclassOptions
     ],
 )
 def test_docstrings_scan_clean_via_pyright(func):
-    try:
-        results = pyright_analyze(
-            func,
-            scan_docstring=True,
-            report_unnecessary_type_ignore_comment=True,
-            preamble=preamble,
-        )
-    except json.JSONDecodeError:
-        pytest.skip("Weird JSON decode error")
-
+    results = PYRIGHT_SCAN_RESULTS[func]
     assert results["summary"]["errorCount"] == 0, list_error_messages(results)
 
 
 docs_src = Path(hydra_zen.__file__).parents[2] / "docs" / "source"
 
-files = list(docs_src.glob("*.rst"))
 
 files = [
     pytest.param(f, {}, id=str(f.absolute()))
@@ -111,6 +144,21 @@ files += [
     for f in list(docs_src.glob("explanation/*.rst"))
 ]
 
+if PYRIGHT_PATH is not None:
+    raw_files = [f.values[0] for f in files]
+    pyright_config = {k: v for d in [f.values[1] for f in files] for k, v in d.items()}
+
+    for obj, scan in zip(
+        raw_files,
+        pyright_analyze(
+            *raw_files,
+            report_unnecessary_type_ignore_comment=True,
+            preamble=preamble,
+            pyright_config=pyright_config,
+        ),
+    ):
+        PYRIGHT_SCAN_RESULTS[obj] = scan
+
 
 @pytest.mark.skipif(PYRIGHT_PATH is None, reason="pyright is not installed")
 @pytest.mark.skipif(not files, reason="docs not found")
@@ -119,16 +167,7 @@ files += [
     files,
 )
 def test_rst_docs_scan_clean_via_pyright(func, pyright_config):
-    try:
-        results = pyright_analyze(
-            func,
-            report_unnecessary_type_ignore_comment=True,
-            preamble=preamble,
-            pyright_config=pyright_config,
-            python_version="3.10",
-        )
-    except json.JSONDecodeError:
-        pytest.skip("Weird JSON decode error")
+    results = PYRIGHT_SCAN_RESULTS[func]
     errors = [
         e
         for e in list_error_messages(results)


### PR DESCRIPTION
Instead of:

```python
scan_results = [pyright_analyze(obj) for obj in stuff]
```

Do:

```python
scan_results = pyright_analyze(*stuff)
```

and it'll be *way* faster. Only pay for pyright startup once and pyright knows how to parallelize.

Our pytest run on pyright docs-scan goes from 81s to 20s!