### PR TITLE
Fix typing errors

### DIFF
--- a/src/hydra_zen/structured_configs/_type_guards.py
+++ b/src/hydra_zen/structured_configs/_type_guards.py
@@ -77,7 +77,7 @@ def is_builds(x: Any) -> TypeGuard[Builds[Any]]:
 def is_just(x: Any) -> TypeGuard[Just[Any]]:
     if is_builds(x) and hasattr(x, JUST_FIELD_NAME):
         attr = _get_target(x)
-        if attr == _get_target(Just) or attr is get_obj:  # type: ignore
+        if attr == _get_target(Just) or attr is get_obj:
             return True
         else:
             # ensures we convert this branch in tests

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -152,6 +152,7 @@ class BuildsWithSig(Builds[T], Protocol[T, P]):
 @runtime_checkable
 class Just(Builds[T], Protocol[T]):
     path: str  # interpolated string for importing obj
+    _target_: ClassVar[str] = "hydra_zen.funcs.get_obj"
 
 
 class ZenPartialMixin(Protocol[T]):
@@ -165,7 +166,7 @@ class HydraPartialMixin(Protocol[T]):
 
 @runtime_checkable
 class ZenPartialBuilds(Builds[T], ZenPartialMixin[T], Protocol[T]):
-    ...
+    _target_: ClassVar[str] = "hydra_zen.funcs.zen_processing"
 
 
 @runtime_checkable

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -152,7 +152,6 @@ class BuildsWithSig(Builds[T], Protocol[T, P]):
 @runtime_checkable
 class Just(Builds[T], Protocol[T]):
     path: str  # interpolated string for importing obj
-    _target_: ClassVar[Literal["hydra_zen.funcs.get_obj"]] = "hydra_zen.funcs.get_obj"
 
 
 class ZenPartialMixin(Protocol[T]):
@@ -166,9 +165,7 @@ class HydraPartialMixin(Protocol[T]):
 
 @runtime_checkable
 class ZenPartialBuilds(Builds[T], ZenPartialMixin[T], Protocol[T]):
-    _target_: ClassVar[
-        Literal["hydra_zen.funcs.zen_processing"]
-    ] = "hydra_zen.funcs.zen_processing"
+    ...
 
 
 @runtime_checkable

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -520,12 +520,8 @@ def check_protocols():
 
     PBuilds = f()
 
-    reveal_type(
-        PBuilds._target_, expected_text="Literal['hydra_zen.funcs.zen_processing']"
-    )
-    reveal_type(
-        PBuilds()._target_, expected_text="Literal['hydra_zen.funcs.zen_processing']"
-    )
+    reveal_type(PBuilds._target_, expected_text="str")
+    reveal_type(PBuilds()._target_, expected_text="str")
 
     reveal_type(PBuilds._zen_target, expected_text="str")
     reveal_type(PBuilds()._zen_target, expected_text="str")
@@ -538,7 +534,7 @@ def check_protocols():
     reveal_type(HPBuilds()._partial_, expected_text="Literal[True]")
 
     just_ = just(int)
-    reveal_type(just_._target_, expected_text="Literal['hydra_zen.funcs.get_obj']")
+    reveal_type(just_._target_, expected_text="str")
 
 
 def check_populate_full_sig():
@@ -802,12 +798,12 @@ def check_overloads_arent_too_restrictive():
         zen_meta: Optional[Mapping[str, SupportedPrimitive]],
         populate_full_signature: bool,
         hydra_recursive: Optional[bool],
+        fbuilds: FullBuilds,
+        pbuilds: PBuilds,
         hydra_convert: Optional[Literal["none", "partial", "all"]],
         frozen: bool,
         builds_bases: Tuple[Type[DataClass_], ...],
         dataclass_name: Optional[str],
-        fbuilds: FullBuilds = ...,
-        pbuilds: PBuilds = ...,
         **kwargs_for_target: Any,
     ):
         def func(x: int) -> str:


### PR DESCRIPTION
Compatible with pyright 1.1.331. There are still pyright errors, but these are false positives.