### PR TITLE
Add `zen_exclude` option to `builds` and `make_custom_builds_fn`

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -64,7 +64,8 @@ For more details and examples, see :pull:`553`.
 
 Improvements
 ------------
-- :func:`~hydra_zen.builds` and :func:`~hydra_zen.make_custom_builds_fn` accept a `zen_exclude` field for excluding parameters from auto-population, either by name or by pattern. See :pull:`558`.
+- :func:`~hydra_zen.BuildsFn` was introduced to permit customizable auto-config and type-refinement support in config-creation functions. See :pull:`553`.
+- :func:`~hydra_zen.builds` and :func:`~hydra_zen.make_custom_builds_fn` now accept a `zen_exclude` field for excluding parameters from auto-population, either by name or by pattern. See :pull:`558`.
 
 
 .. _v0.11.0:

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -11,7 +11,7 @@ chronological order. All previous releases should still be available on pip.
 .. _v0.12.0:
 
 ----------------------
-0.12.0rc1 - 2023-10-23
+0.12.0rc2 - 2023-11-23
 ----------------------
 
 
@@ -61,6 +61,11 @@ Here is a stripped-down example.
 
 
 For more details and examples, see :pull:`553`.
+
+Improvements
+------------
+- :func:`~hydra_zen.builds` and :func:`~hydra_zen.make_custom_builds_fn` accept a `zen_exclude` field for excluding parameters from auto-population, either by name or by pattern. See :pull:`558`.
+
 
 .. _v0.11.0:
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -4,7 +4,8 @@ import functools
 import inspect
 import sys
 import warnings
-from collections import Collection, Counter, deque
+from collections import Counter, deque
+from collections.abc import Collection
 from dataclasses import (  # use this for runtime checks
     MISSING,
     Field as _Field,

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1473,7 +1473,7 @@ class BuildsFn(Generic[T]):
         Type[PartialBuilds[Importable]],
         Type[BuildsWithSig[Type[R], P]],
     ]:
-        """builds(hydra_target, /, *pos_args, zen_partial=None, zen_wrappers=(), zen_meta=None, populate_full_signature=False, hydra_recursive=None, hydra_convert=None, hydra_defaults=None, frozen=False, dataclass_name=None, builds_bases=(), **kwargs_for_target)
+        """builds(hydra_target, /, *pos_args, zen_partial=None, zen_wrappers=(), zen_meta=None, populate_full_signature=False, zen_exclude=(), hydra_recursive=None, hydra_convert=None, hydra_defaults=None, frozen=False, dataclass_name=None, builds_bases=(), **kwargs_for_target)
 
         `builds(target, *args, **kw)` returns a Hydra-compatible config that, when
         instantiated, returns `target(*args, **kw)`.

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1475,454 +1475,477 @@ class BuildsFn(Generic[T]):
     ]:
         """builds(hydra_target, /, *pos_args, zen_partial=None, zen_wrappers=(), zen_meta=None, populate_full_signature=False, hydra_recursive=None, hydra_convert=None, hydra_defaults=None, frozen=False, dataclass_name=None, builds_bases=(), **kwargs_for_target)
 
-        `builds(target, *args, **kw)` returns a Hydra-compatible config that, when
-        instantiated, returns `target(*args, **kw)`.
+         `builds(target, *args, **kw)` returns a Hydra-compatible config that, when
+         instantiated, returns `target(*args, **kw)`.
+
+         I.e., `instantiate(builds(target, *args, **kw)) == target(*args, **kw)`
 
-        I.e., `instantiate(builds(target, *args, **kw)) == target(*args, **kw)`
+         Consult the Notes section for more details, and the Examples section to see
+         the various features of `builds` in action.
 
-        Consult the Notes section for more details, and the Examples section to see
-        the various features of `builds` in action.
+         Parameters
+         ----------
+         hydra_target : T (Callable)
+             The target object to be configured. This is a required, **positional-only**
+             argument.
+
+         *pos_args : SupportedPrimitive
+             Positional arguments passed as ``<hydra_target>(*pos_args, ...)`` upon
+             instantiation.
+
+             Arguments specified positionally are not included in the config's signature
+             and are stored as a tuple bound to in the ``_args_`` field.
 
-        Parameters
-        ----------
-        hydra_target : T (Callable)
-            The target object to be configured. This is a required, **positional-only**
-            argument.
+         **kwargs_for_target : SupportedPrimitive
+             The keyword arguments passed as ``<hydra_target>(..., **kwargs_for_target)``
+             upon instantiation.
 
-        *pos_args : SupportedPrimitive
-            Positional arguments passed as ``<hydra_target>(*pos_args, ...)`` upon
-            instantiation.
-
-            Arguments specified positionally are not included in the config's signature
-            and are stored as a tuple bound to in the ``_args_`` field.
+             The arguments specified here determine the signature of the resulting
+             config, unless ``populate_full_signature=True`` is specified (see below).
 
-        **kwargs_for_target : SupportedPrimitive
-            The keyword arguments passed as ``<hydra_target>(..., **kwargs_for_target)``
-            upon instantiation.
+             Named parameters of the forms that have the prefixes ``hydra_``, ``zen_`` or
+             ``_zen_`` are reserved to ensure future-compatibility, and thus cannot be
+             specified by the user.
+
+         zen_partial : Optional[bool]
+             If ``True``, then the resulting config will instantiate as
+             ``functools.partial(<hydra_target>, *pos_args, **kwargs_for_target)``. Thus
+             this enables the partial-configuration of objects.
 
-            The arguments specified here determine the signature of the resulting
-            config, unless ``populate_full_signature=True`` is specified (see below).
+             Specifying ``zen_partial=True`` and ``populate_full_signature=True`` together
+             will populate the config's signature only with parameters that: are explicitly
+             specified by the user, or that have default values specified in the target's
+             signature. I.e. it is presumed that un-specified parameters that have no
+             default values are to be excluded from the config.
+
+         zen_wrappers : None | Callable | Builds | InterpStr | Sequence[None | Callable | Builds | InterpStr]
+             One or more wrappers, which will wrap ``hydra_target`` prior to instantiation.
+             E.g. specifying the wrappers ``[f1, f2, f3]`` will instantiate as::
+
+                 f3(f2(f1(<hydra_target>)))(*args, **kwargs)
+
+             Wrappers can also be specified as interpolated strings [2]_ or targeted
+             configs.
+
+         zen_meta : Optional[Mapping[str, SupportedPrimitive]]
+             Specifies field-names and corresponding values that will be included in the
+             resulting config, but that will *not* be used to instantiate
+             ``<hydra_target>``. These are called "meta" fields.
 
-            Named parameters of the forms that have the prefixes ``hydra_``, ``zen_`` or
-            ``_zen_`` are reserved to ensure future-compatibility, and thus cannot be
-            specified by the user.
+         populate_full_signature : bool, optional (default=False)
+             If ``True``, then the resulting config's signature and fields will be
+             populated according to the signature of ``<hydra_target>``; values also
+             specified in ``**kwargs_for_target`` take precedent.
+
+             This option is not available for objects with inaccessible signatures, such
+             as NumPy's various ufuncs.
+
+         zen_exclude : Collection[str] | Callable[[str], bool], optional (default=[])
+             Specifies parameter names, or a function for checking names, to exclude
+             those parameters from the config-creation process.
+
+         Note that inherited fields cannot be excluded.
+         zen_convert : Optional[ZenConvert]
+             A dictionary that modifies hydra-zen's value and type conversion behavior.
+             Consists of the following optional key-value pairs (:ref:`zen-convert`):
+
+             - `dataclass` : `bool` (default=True):
+                 If `True` any dataclass type/instance without a
+                 `_target_` field is automatically converted to a targeted config
+                 that will instantiate to that type/instance. Otherwise the dataclass
+                 type/instance will be passed through as-is.
+
+             - `flat_target`: `bool` (default=True)
+                 If `True` (default), `builds(builds(f))` is equivalent to `builds(f)`. I.e. the second `builds` call will use the `_target_` field of its input, if it exists.
+
+         builds_bases : Tuple[Type[DataClass], ...]
+             Specifies a tuple of parent classes that the resulting config inherits from.
+
+         hydra_recursive : Optional[bool], optional (default=True)
+             If ``True``, then Hydra will recursively instantiate all other
+             hydra-config objects nested within this config [3]_.
+
+             If ``None``, the ``_recursive_`` attribute is not set on the resulting config.
+
+         hydra_convert : Optional[Literal["none", "partial", "all", "object"]], optional (default="none")
+             Determines how Hydra handles the non-primitive, omegaconf-specific objects passed to
+             ``<hydra_target>`` [4]_.
+
+             - ``"none"``: No conversion occurs; omegaconf containers are passed through (Default)
+             - ``"partial"``: ``DictConfig`` and ``ListConfig`` objects converted to ``dict`` and
+             ``list``, respectively. Structured configs and their fields are passed without conversion.
+             - ``"all"``: All passed objects are converted to dicts, lists, and primitives, without
+             a trace of OmegaConf containers.
+             - ``"object"``: Passed objects are converted to dict and list. Structured Configs are converted to instances of the backing dataclass / attr class.
+
+             If ``None``, the ``_convert_`` attribute is not set on the resulting config.
+
+         hydra_defaults : None | list[str | dict[str, str | list[str] | None ]], optional (default = None)
+             A list in an input config that instructs Hydra how to build the output config
+             [6]_ [7]_. Each input config can have a Defaults List as a top level element. The
+             Defaults List itself is not a part of output config.
+
+         zen_dataclass : Optional[DataclassOptions]
+             A dictionary that can specify any option that is supported by
+             :py:func:`dataclasses.make_dataclass` other than `fields`.
+             The default value for `unsafe_hash` is `True`.
+
+             Additionally, the `module` field can be specified to enable pickle
+             compatibility. See `hydra_zen.typing.DataclassOptions` for details.
+
+         frozen : bool, optional (default=False)
+             .. deprecated:: 0.9.0
+                 `frozen` will be removed in hydra-zen 0.10.0. It is replaced by
+                 `zen_dataclass={'frozen': <bool>}`.
+
+             If ``True``, the resulting config will create frozen (i.e. immutable) instances.
+             I.e. setting/deleting an attribute of an instance will raise
+             :py:class:`dataclasses.FrozenInstanceError` at runtime.
+
+         dataclass_name : Optional[str]
+             .. deprecated:: 0.9.0
+                 `dataclass_name` will be removed in hydra-zen 0.10.0. It is replaced by
+                 `zen_dataclass={'cls_name': <str>}`.
+
+             If specified, determines the name of the returned class object.
+
+         Returns
+         -------
+         Config : Type[Builds[Type[T]]] | Type[PartialBuilds[Type[T]]]
+             A dynamically-generated structured config (i.e. a dataclass type) that
+             describes how to build ``hydra_target``.
+
+         Raises
+         ------
+         hydra_zen.errors.HydraZenUnsupportedPrimitiveError
+             The provided configured value cannot be serialized by Hydra, nor does
+             hydra-zen provide specialized support for it. See :ref:`valid-types` for
+             more details.
+
+         Notes
+         -----
+         The following pseudo code conveys the core functionality of `builds`:
+
+         .. code-block:: python
+
+             from dataclasses import make_dataclass
+
+             def builds(self,target, populate_full_signature=False, **kw):
+                 # Dynamically defines a Hydra-compatible dataclass type.
+                 # Akin to doing:
+                 #
+                 # @dataclass
+                 # class Builds_thing:
+                 #     _target_: str = get_import_path(target)
+                 #     # etc.
+
+                 _target_ = get_import_path(target)
+
+                 if populate_full_signature:
+                     sig = get_signature(target)
+                     kw = {**sig, **kw}  # merge w/ preference for kw
+
+                 type_annots = [get_hints(target)[k] for k in kw]
+
+                 fields = [("_target_", str, _target_)]
+                 fields += [
+                     (
+                         field_name,
+                         hydra_compat_type_annot(hint),
+                         hydra_compat_val(v),
+                     )
+                     for hint, (field_name, v) in zip(type_annots, kw.items())
+                 ]
+
+                 Config = make_dataclass(f"Builds_{target}", fields)
+                 return Config
+
+         The resulting "config" is a dynamically-generated dataclass type [5]_ with
+         Hydra-specific attributes attached to it [1]_. It possesses a `_target_`
+         attribute that indicates the import path to the configured target as a string.
+
+         Using any of the ``zen_xx`` features will result in a config that depends
+         explicitly on hydra-zen. I.e. hydra-zen must be installed in order to
+         instantiate the resulting config, including its yaml version.
+
+         For details of the annotation `SupportedPrimitive`, see :ref:`valid-types`.
+
+         Type annotations are inferred from the target's signature and are only
+         retained if they are compatible with Hydra's limited set of supported
+         annotations; otherwise an annotation is automatically 'broadened' until
+         it is made compatible with Hydra.
+
+         `builds` provides runtime validation of user-specified arguments against
+         the target's signature. E.g. specifying mis-named arguments or too many
+         arguments will cause `builds` to raise.
 
-        zen_partial : Optional[bool]
-            If ``True``, then the resulting config will instantiate as
-            ``functools.partial(<hydra_target>, *pos_args, **kwargs_for_target)``. Thus
-            this enables the partial-configuration of objects.
+         References
+         ----------
+         .. [1] https://hydra.cc/docs/tutorials/structured_config/intro/
+         .. [2] https://omegaconf.readthedocs.io/en/2.1_branch/usage.html#variable-interpolation
+         .. [3] https://hydra.cc/docs/advanced/instantiate_objects/overview/#recursive-instantiation
+         .. [4] https://hydra.cc/docs/advanced/instantiate_objects/overview/#parameter-conversion-strategies
+         .. [5] https://docs.python.org/3/library/dataclasses.html
+         .. [6] https://hydra.cc/docs/tutorials/structured_config/defaults/
+         .. [7] https://hydra.cc/docs/advanced/defaults_list/
 
-            Specifying ``zen_partial=True`` and ``populate_full_signature=True`` together
-            will populate the config's signature only with parameters that: are explicitly
-            specified by the user, or that have default values specified in the target's
-            signature. I.e. it is presumed that un-specified parameters that have no
-            default values are to be excluded from the config.
-
-        zen_wrappers : None | Callable | Builds | InterpStr | Sequence[None | Callable | Builds | InterpStr]
-            One or more wrappers, which will wrap ``hydra_target`` prior to instantiation.
-            E.g. specifying the wrappers ``[f1, f2, f3]`` will instantiate as::
-
-                f3(f2(f1(<hydra_target>)))(*args, **kwargs)
+         See Also
+         --------
+         instantiate: Instantiates a configuration created by `builds`, returning the instantiated target.
+         make_custom_builds_fn: Returns a new `builds` function with customized default values.
+         make_config: Creates a general config with customized field names, default values, and annotations.
+         get_target: Returns the target-object from a targeted structured config.
+         just: Produces a config that, when instantiated by Hydra, "just" returns the un-instantiated target-object.
+         to_yaml: Serialize a config as a yaml-formatted string.
 
-            Wrappers can also be specified as interpolated strings [2]_ or targeted
-            configs.
+         Examples
+         --------
+         These examples describe:
 
-        zen_meta : Optional[Mapping[str, SupportedPrimitive]]
-            Specifies field-names and corresponding values that will be included in the
-            resulting config, but that will *not* be used to instantiate
-            ``<hydra_target>``. These are called "meta" fields.
-
-        populate_full_signature : bool, optional (default=False)
-            If ``True``, then the resulting config's signature and fields will be populated
-            according to the signature of ``<hydra_target>``; values also specified in
-            ``**kwargs_for_target`` take precedent.
-
-            This option is not available for objects with inaccessible signatures, such as
-            NumPy's various ufuncs.
+         - Basic usage
+         - Creating a partial config
+         - Auto-populating parameters
+         - Composing configs via inheritance
+         - Runtime validation performed by builds
+         - Using meta-fields
+         - Using zen-wrappers
+         - Creating a pickle-compatible config
+         - Creating a frozen config
+         - Support for partial'd targets
 
-        zen_convert : Optional[ZenConvert]
-            A dictionary that modifies hydra-zen's value and type conversion behavior.
-            Consists of the following optional key-value pairs (:ref:`zen-convert`):
+         A helpful utility for printing examples
 
-            - `dataclass` : `bool` (default=True):
-                If `True` any dataclass type/instance without a
-                `_target_` field is automatically converted to a targeted config
-                that will instantiate to that type/instance. Otherwise the dataclass
-                type/instance will be passed through as-is.
-
-            - `flat_target`: `bool` (default=True)
-                If `True` (default), `builds(builds(f))` is equivalent to `builds(f)`. I.e. the second `builds` call will use the `_target_` field of its input, if it exists.
-
-        builds_bases : Tuple[Type[DataClass], ...]
-            Specifies a tuple of parent classes that the resulting config inherits from.
-
-        hydra_recursive : Optional[bool], optional (default=True)
-            If ``True``, then Hydra will recursively instantiate all other
-            hydra-config objects nested within this config [3]_.
-
-            If ``None``, the ``_recursive_`` attribute is not set on the resulting config.
-
-        hydra_convert : Optional[Literal["none", "partial", "all", "object"]], optional (default="none")
-            Determines how Hydra handles the non-primitive, omegaconf-specific objects passed to
-            ``<hydra_target>`` [4]_.
-
-            - ``"none"``: No conversion occurs; omegaconf containers are passed through (Default)
-            - ``"partial"``: ``DictConfig`` and ``ListConfig`` objects converted to ``dict`` and
-            ``list``, respectively. Structured configs and their fields are passed without conversion.
-            - ``"all"``: All passed objects are converted to dicts, lists, and primitives, without
-            a trace of OmegaConf containers.
-            - ``"object"``: Passed objects are converted to dict and list. Structured Configs are converted to instances of the backing dataclass / attr class.
-
-            If ``None``, the ``_convert_`` attribute is not set on the resulting config.
-
-        hydra_defaults : None | list[str | dict[str, str | list[str] | None ]], optional (default = None)
-            A list in an input config that instructs Hydra how to build the output config
-            [6]_ [7]_. Each input config can have a Defaults List as a top level element. The
-            Defaults List itself is not a part of output config.
-
-        zen_dataclass : Optional[DataclassOptions]
-            A dictionary that can specify any option that is supported by
-            :py:func:`dataclasses.make_dataclass` other than `fields`.
-            The default value for `unsafe_hash` is `True`.
-
-            Additionally, the `module` field can be specified to enable pickle
-            compatibility. See `hydra_zen.typing.DataclassOptions` for details.
-
-        frozen : bool, optional (default=False)
-            .. deprecated:: 0.9.0
-                `frozen` will be removed in hydra-zen 0.10.0. It is replaced by
-                `zen_dataclass={'frozen': <bool>}`.
-
-            If ``True``, the resulting config will create frozen (i.e. immutable) instances.
-            I.e. setting/deleting an attribute of an instance will raise
-            :py:class:`dataclasses.FrozenInstanceError` at runtime.
-
-        dataclass_name : Optional[str]
-            .. deprecated:: 0.9.0
-                `dataclass_name` will be removed in hydra-zen 0.10.0. It is replaced by
-                `zen_dataclass={'cls_name': <str>}`.
-
-            If specified, determines the name of the returned class object.
-
-        Returns
-        -------
-        Config : Type[Builds[Type[T]]] | Type[PartialBuilds[Type[T]]]
-            A dynamically-generated structured config (i.e. a dataclass type) that
-            describes how to build ``hydra_target``.
-
-        Raises
-        ------
-        hydra_zen.errors.HydraZenUnsupportedPrimitiveError
-            The provided configured value cannot be serialized by Hydra, nor does hydra-zen
-            provide specialized support for it. See :ref:`valid-types` for more details.
-
-        Notes
-        -----
-        The following pseudo code conveys the core functionality of `builds`:
-
-        .. code-block:: python
-
-            from dataclasses import make_dataclass
-
-            def builds(self,target, populate_full_signature=False, **kw):
-                # Dynamically defines a Hydra-compatible dataclass type.
-                # Akin to doing:
-                #
-                # @dataclass
-                # class Builds_thing:
-                #     _target_: str = get_import_path(target)
-                #     # etc.
-
-                _target_ = get_import_path(target)
-
-                if populate_full_signature:
-                    sig = get_signature(target)
-                    kw = {**sig, **kw}  # merge w/ preference for kw
-
-                type_annots = [get_hints(target)[k] for k in kw]
-
-                fields = [("_target_", str, _target_)]
-                fields += [
-                    (
-                        field_name,
-                        hydra_compat_type_annot(hint),
-                        hydra_compat_val(v),
-                    )
-                    for hint, (field_name, v) in zip(type_annots, kw.items())
-                ]
-
-                Config = make_dataclass(f"Builds_{target}", fields)
-                return Config
-
-        The resulting "config" is a dynamically-generated dataclass type [5]_ with
-        Hydra-specific attributes attached to it [1]_. It possesses a `_target_`
-        attribute that indicates the import path to the configured target as a string.
-
-        Using any of the ``zen_xx`` features will result in a config that depends
-        explicitly on hydra-zen. I.e. hydra-zen must be installed in order to
-        instantiate the resulting config, including its yaml version.
-
-        For details of the annotation `SupportedPrimitive`, see :ref:`valid-types`.
-
-        Type annotations are inferred from the target's signature and are only
-        retained if they are compatible with Hydra's limited set of supported
-        annotations; otherwise an annotation is automatically 'broadened' until
-        it is made compatible with Hydra.
-
-        `builds` provides runtime validation of user-specified arguments against
-        the target's signature. E.g. specifying mis-named arguments or too many
-        arguments will cause `builds` to raise.
-
-        References
-        ----------
-        .. [1] https://hydra.cc/docs/tutorials/structured_config/intro/
-        .. [2] https://omegaconf.readthedocs.io/en/2.1_branch/usage.html#variable-interpolation
-        .. [3] https://hydra.cc/docs/advanced/instantiate_objects/overview/#recursive-instantiation
-        .. [4] https://hydra.cc/docs/advanced/instantiate_objects/overview/#parameter-conversion-strategies
-        .. [5] https://docs.python.org/3/library/dataclasses.html
-        .. [6] https://hydra.cc/docs/tutorials/structured_config/defaults/
-        .. [7] https://hydra.cc/docs/advanced/defaults_list/
+         >>> from hydra_zen import builds, instantiate, to_yaml
+         >>> def pyaml(x):
+         ...     # for pretty printing configs
+         ...     print(to_yaml(x))
 
-        See Also
-        --------
-        instantiate: Instantiates a configuration created by `builds`, returning the instantiated target.
-        make_custom_builds_fn: Returns a new `builds` function with customized default values.
-        make_config: Creates a general config with customized field names, default values, and annotations.
-        get_target: Returns the target-object from a targeted structured config.
-        just: Produces a config that, when instantiated by Hydra, "just" returns the un-instantiated target-object.
-        to_yaml: Serialize a config as a yaml-formatted string.
+         **Basic Usage**
 
-        Examples
-        --------
-        These examples describe:
+         Lets create a basic config that describes how to 'build' a particular dictionary.
 
-        - Basic usage
-        - Creating a partial config
-        - Auto-populating parameters
-        - Composing configs via inheritance
-        - Runtime validation performed by builds
-        - Using meta-fields
-        - Using zen-wrappers
-        - Creating a pickle-compatible config
-        - Creating a frozen config
-        - Support for partial'd targets
+         >>> Conf = builds(dict, a=1, b='x')
 
-        A helpful utility for printing examples
+         The resulting config is a dataclass with the following signature and attributes:
 
-        >>> from hydra_zen import builds, instantiate, to_yaml
-        >>> def pyaml(x):
-        ...     # for pretty printing configs
-        ...     print(to_yaml(x))
+         >>> Conf  # signature: Conf(a: Any = 1, b: Any = 'x')
+         <class 'types.Builds_dict'>
 
-        **Basic Usage**
+         >>> pyaml(Conf)
+         _target_: builtins.dict
+         a: 1
+         b: x
 
-        Lets create a basic config that describes how to 'build' a particular dictionary.
+         The `instantiate` function is used to enact this build – to create the dictionary.
 
-        >>> Conf = builds(dict, a=1, b='x')
+         >>> instantiate(Conf)  # calls: `dict(a=1, b='x')`
+         {'a': 1, 'b': 'x'}
 
-        The resulting config is a dataclass with the following signature and attributes:
+         The default parameters that we provided can be overridden.
 
-        >>> Conf  # signature: Conf(a: Any = 1, b: Any = 'x')
-        <class 'types.Builds_dict'>
+         >>> new_conf = Conf(a=10, b="hi")  # an instance of our dataclass
+         >>> instantiate(new_conf)  # calls: `dict(a=10, b='hi')`
+         {'a': 10, 'b': 'hi'}
 
-        >>> pyaml(Conf)
-        _target_: builtins.dict
-        a: 1
-        b: x
+         Positional arguments are supported.
 
-        The `instantiate` function is used to enact this build – to create the dictionary.
+         >>> Conf = builds(len, [1, 2, 3])
+         >>> Conf._args_  # type: ignore
+         [1, 2, 3]
+         >>> instantiate(Conf)
+         3
 
-        >>> instantiate(Conf)  # calls: `dict(a=1, b='x')`
-        {'a': 1, 'b': 'x'}
+         **Creating a Partial Config**
 
-        The default parameters that we provided can be overridden.
+         `builds` can be used to partially-configure a target. Let's
+         create a config for the following function
 
-        >>> new_conf = Conf(a=10, b="hi")  # an instance of our dataclass
-        >>> instantiate(new_conf)  # calls: `dict(a=10, b='hi')`
-        {'a': 10, 'b': 'hi'}
+         >>> def a_two_tuple(x: int, y: float): return x, y
 
-        Positional arguments are supported.
+         such that we only configure the parameter ``x``.
 
-        >>> Conf = builds(len, [1, 2, 3])
-        >>> Conf._args_  # type: ignore
-        [1, 2, 3]
-        >>> instantiate(Conf)
-        3
+         >>> PartialConf = builds(a_two_tuple, x=1, zen_partial=True)  # configures only `x`
+         >>> pyaml(PartialConf)
+         _target_: __main__.a_two_tuple
+         _partial_: true
+         x: 1
 
-        **Creating a Partial Config**
+         Instantiating this config will return ``functools.partial(a_two_tuple, x=1)``.
 
-        `builds` can be used to partially-configure a target. Let's
-        create a config for the following function
+         >>> partial_func = instantiate(PartialConf)
+         >>> partial_func
+         functools.partial(<function a_two_tuple at 0x00000220A7820EE0>, x=1)
 
-        >>> def a_two_tuple(x: int, y: float): return x, y
+         And thus the remaining parameter can be provided post-instantiation.
 
-        such that we only configure the parameter ``x``.
+         >>> partial_func(y=22.0)  # providing the remaining parameter
+         (1, 22.0)
 
-        >>> PartialConf = builds(a_two_tuple, x=1, zen_partial=True)  # configures only `x`
-        >>> pyaml(PartialConf)
-        _target_: __main__.a_two_tuple
-        _partial_: true
-        x: 1
+         **Auto-populating parameters**
 
-        Instantiating this config will return ``functools.partial(a_two_tuple, x=1)``.
+         The configurable parameters of a target can be auto-populated in our config.
+         Suppose we want to configure the following function.
 
-        >>> partial_func = instantiate(PartialConf)
-        >>> partial_func
-        functools.partial(<function a_two_tuple at 0x00000220A7820EE0>, x=1)
+         >>> def bar(x: bool, y: str = 'foo'): return x, y
 
-        And thus the remaining parameter can be provided post-instantiation.
+         The following config will have a signature that matches ``f``; the
+         annotations and default values of the parameters of ``f`` are explicitly
+         incorporated into the config.
 
-        >>> partial_func(y=22.0)  # providing the remaining parameter
-        (1, 22.0)
+         >>> # signature: `Builds_bar(x: bool, y: str = 'foo')`
+         >>> Conf = builds(bar, populate_full_signature=True)
+         >>> pyaml(Conf)
+         _target_: __main__.bar
+         x: ???
+         'y': foo
 
-        **Auto-populating parameters**
+         `zen_exclude` can be used to either name parameter to be excluded from the
+         auto-population process:
 
-        The configurable parameters of a target can be auto-populated in our config.
-        Suppose we want to configure the following function.
+         >>> Conf2 = builds(bar, populate_full_signature=True, zen_exclude=["y"])
+         >>> pyaml(Conf2)
+         _target_: __main__.bar
+         x: ???
+         'y': foo
 
-        >>> def bar(x: bool, y: str = 'foo'): return x, y
+         or specify a pattern - via a function - for excluding parameters:
 
-        The following config will have a signature that matches ``f``; the
-        annotations and default values of the parameters of ``f`` are explicitly
-        incorporated into the config.
+        >>> Conf3 = builds(bar, populate_full_signature=True, zen_exclude=lambda name: name.startswith("x"))
+         >>> pyaml(Conf3)
+         _target_: __main__.bar
+         'y': foo
 
-        >>> # signature: `Builds_bar(x: bool, y: str = 'foo')`
-        >>> Conf = builds(bar, populate_full_signature=True)
-        >>> pyaml(Conf)
-        _target_: __main__.bar
-        x: ???
-        'y': foo
+         Annotations will be used by Hydra to provide limited runtime type-checking
+         during instantiation. Here, we'll pass a float for ``x``, which expects a
+         boolean value.
 
-        Annotations will be used by Hydra to provide limited runtime type-checking during
-        instantiation. Here, we'll pass a float for ``x``, which expects a boolean value.
+         >>> instantiate(Conf(x=10.0))  # type: ignore
+         ValidationError: Value '10.0' is not a valid bool (type float)
+             full_key: x
+             object_type=Builds_func
 
-        >>> instantiate(Conf(x=10.0))  # type: ignore
-        ValidationError: Value '10.0' is not a valid bool (type float)
-            full_key: x
-            object_type=Builds_func
+         **Composing configs via inheritance**
 
-        **Composing configs via inheritance**
+         Because a config produced via `builds` is simply a class-object, we can
+         compose configs via class inheritance.
 
-        Because a config produced via `builds` is simply a class-object, we can
-        compose configs via class inheritance.
+         >>> ParentConf = builds(dict, a=1, b=2)
+         >>> ChildConf = builds(dict, b=-2, c=-3, builds_bases=(ParentConf,))
+         >>> instantiate(ChildConf)
+         {'a': 1, 'b': -2, 'c': -3}
+         >>> issubclass(ChildConf, ParentConf)
+         True
 
-        >>> ParentConf = builds(dict, a=1, b=2)
-        >>> ChildConf = builds(dict, b=-2, c=-3, builds_bases=(ParentConf,))
-        >>> instantiate(ChildConf)
-        {'a': 1, 'b': -2, 'c': -3}
-        >>> issubclass(ChildConf, ParentConf)
-        True
+         .. _builds-validation:
 
-        .. _builds-validation:
+         **Runtime validation performed by builds**
 
-        **Runtime validation performed by builds**
+         Misspelled parameter names and other invalid configurations for the target’s
+         signature will be caught by `builds` so that such errors are caught prior to
+         instantiation.
 
-        Misspelled parameter names and other invalid configurations for the target’s
-        signature will be caught by `builds` so that such errors are caught prior to
-        instantiation.
+         >>> def func(a_number: int): pass
 
-        >>> def func(a_number: int): pass
+         >>> builds(func, a_nmbr=2)  # misspelled parameter name
+         TypeError: Building: func ..
 
-        >>> builds(func, a_nmbr=2)  # misspelled parameter name
-        TypeError: Building: func ..
+         >>> builds(func, 1, 2)  # too many arguments
+         TypeError: Building: func ..
 
-        >>> builds(func, 1, 2)  # too many arguments
-        TypeError: Building: func ..
+         >>> BaseConf = builds(func, a_number=2)
+         >>> builds(func, 1, builds_bases=(BaseConf,))  # too many args (via inheritance)
+         TypeError: Building: func ..
 
-        >>> BaseConf = builds(func, a_number=2)
-        >>> builds(func, 1, builds_bases=(BaseConf,))  # too many args (via inheritance)
-        TypeError: Building: func ..
+         >>> # value type not supported by Hydra
+         >>> builds(int, (i for i in range(10)))  # type: ignore
+         hydra_zen.errors.HydraZenUnsupportedPrimitiveError: Building: int ..
 
-        >>> # value type not supported by Hydra
-        >>> builds(int, (i for i in range(10)))  # type: ignore
-        hydra_zen.errors.HydraZenUnsupportedPrimitiveError: Building: int ..
 
+         .. _meta-field:
 
-        .. _meta-field:
+         **Using meta-fields**
 
-        **Using meta-fields**
+         Meta-fields are fields that are included in a config but are excluded by the
+         instantiation process. Thus arbitrary metadata can be attached to a config.
 
-        Meta-fields are fields that are included in a config but are excluded by the
-        instantiation process. Thus arbitrary metadata can be attached to a config.
+         Let's create a config whose fields reference a meta-field via
+         relative-interpolation [2]_.
 
-        Let's create a config whose fields reference a meta-field via
-        relative-interpolation [2]_.
+         >>> Conf = builds(dict, a="${.s}", b="${.s}", zen_meta=dict(s=-10))
+         >>> instantiate(Conf)
+         {'a': -10, 'b': -10}
+         >>> instantiate(Conf, s=2)
+         {'a': 2, 'b': 2}
 
-        >>> Conf = builds(dict, a="${.s}", b="${.s}", zen_meta=dict(s=-10))
-        >>> instantiate(Conf)
-        {'a': -10, 'b': -10}
-        >>> instantiate(Conf, s=2)
-        {'a': 2, 'b': 2}
+         .. _zen-wrapper:
 
-        .. _zen-wrapper:
+         **Using zen-wrappers**
 
-        **Using zen-wrappers**
+         Zen-wrappers enables us to make arbitrary changes to ``<hydra_target>``, its inputs,
+         and/or its outputs during the instantiation process.
 
-        Zen-wrappers enables us to make arbitrary changes to ``<hydra_target>``, its inputs,
-        and/or its outputs during the instantiation process.
+         Let's use a wrapper to add a unit-conversion step to a config. We'll modify a
+         config that builds a function, which converts a temperature in Fahrenheit to
+         Celsius, and add a wrapper to it so that it will convert from Fahrenheit to
+         Kelvin instead.
 
-        Let's use a wrapper to add a unit-conversion step to a config. We'll modify a
-        config that builds a function, which converts a temperature in Fahrenheit to
-        Celsius, and add a wrapper to it so that it will convert from Fahrenheit to
-        Kelvin instead.
+         >>> def faren_to_celsius(temp_f):  # our target
+         ...     return ((temp_f - 32) * 5) / 9
 
-        >>> def faren_to_celsius(temp_f):  # our target
-        ...     return ((temp_f - 32) * 5) / 9
+         >>> def change_celcius_to_kelvin(celc_func):  # our wrapper
+         ...     def wraps(*args, **kwargs):
+         ...         return 273.15 + celc_func(*args, **kwargs)
+         ...     return wraps
 
-        >>> def change_celcius_to_kelvin(celc_func):  # our wrapper
-        ...     def wraps(*args, **kwargs):
-        ...         return 273.15 + celc_func(*args, **kwargs)
-        ...     return wraps
+         >>> AsCelcius = builds(faren_to_celsius)
+         >>> AsKelvin = builds(faren_to_celsius, zen_wrappers=change_celcius_to_kelvin)
+         >>> instantiate(AsCelcius, temp_f=32)
+         0.0
+         >>> instantiate(AsKelvin, temp_f=32)
+         273.15
 
-        >>> AsCelcius = builds(faren_to_celsius)
-        >>> AsKelvin = builds(faren_to_celsius, zen_wrappers=change_celcius_to_kelvin)
-        >>> instantiate(AsCelcius, temp_f=32)
-        0.0
-        >>> instantiate(AsKelvin, temp_f=32)
-        273.15
+         **Creating a pickle-compatible config**
 
-        **Creating a pickle-compatible config**
+         The dynamically-generated classes created by `builds` can be made pickle-compatible
+         by specifying the name of the symbol that it is assigned to and the module in which
+         it was defined.
 
-        The dynamically-generated classes created by `builds` can be made pickle-compatible
-        by specifying the name of the symbol that it is assigned to and the module in which
-        it was defined.
+         .. code-block:: python
 
-        .. code-block:: python
+            # contents of mylib/foo.py
+            from pickle import dumps, loads
 
-        # contents of mylib/foo.py
-        from pickle import dumps, loads
+            DictConf = builds(dict,
+                                zen_dataclass={'module': 'mylib.foo',
+                                                'cls_name': 'DictConf'})
 
-        DictConf = builds(dict,
-                            zen_dataclass={'module': 'mylib.foo',
-                                            'cls_name': 'DictConf'})
+            assert DictConf is loads(dumps(DictConf))
 
-        assert DictConf is loads(dumps(DictConf))
 
+         **Creating a frozen config**
 
-        **Creating a frozen config**
+         Let's create a config object whose instances will by "frozen" (i.e., immutable).
 
-        Let's create a config object whose instances will by "frozen" (i.e., immutable).
+         >>> RouterConfig = builds(dict, ip_address=None, zen_dataclass={'frozen': True})
+         >>> my_router = RouterConfig(ip_address="192.168.56.1")  # an immutable instance
 
-        >>> RouterConfig = builds(dict, ip_address=None, zen_dataclass={'frozen': True})
-        >>> my_router = RouterConfig(ip_address="192.168.56.1")  # an immutable instance
+         Attempting to overwrite the attributes of ``my_router`` will raise.
 
-        Attempting to overwrite the attributes of ``my_router`` will raise.
+         >>> my_router.ip_address = "148.109.37.2"
+         FrozenInstanceError: cannot assign to field 'ip_address'
 
-        >>> my_router.ip_address = "148.109.37.2"
-        FrozenInstanceError: cannot assign to field 'ip_address'
+         **Support for partial'd targets**
 
-        **Support for partial'd targets**
+         Specifying ``builds(functools.partial(<target>, ...), ...)`` is supported; `builds`
+         will automatically "unpack" a partial'd object that is passed as its target.
 
-        Specifying ``builds(functools.partial(<target>, ...), ...)`` is supported; `builds`
-        will automatically "unpack" a partial'd object that is passed as its target.
-
-        >>> import functools
-        >>> partiald_dict = functools.partial(dict, a=1, b=2)
-        >>> Conf = builds(partiald_dict)  # signature: (a = 1, b = 2)
-        >>> instantiate(Conf)  # equivalent to calling: `partiald_dict()`
-        {'a': 1, 'b': 2}
-        >>> instantiate(Conf(a=-4))  # equivalent to calling: `partiald_dict(a=-4)`
-        {'a': -4, 'b': 2}
+         >>> import functools
+         >>> partiald_dict = functools.partial(dict, a=1, b=2)
+         >>> Conf = builds(partiald_dict)  # signature: (a = 1, b = 2)
+         >>> instantiate(Conf)  # equivalent to calling: `partiald_dict()`
+         {'a': 1, 'b': 2}
+         >>> instantiate(Conf(a=-4))  # equivalent to calling: `partiald_dict(a=-4)`
+         {'a': -4, 'b': 2}
         """
 
         zen_convert_settings = _utils.merge_settings(

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1475,477 +1475,477 @@ class BuildsFn(Generic[T]):
     ]:
         """builds(hydra_target, /, *pos_args, zen_partial=None, zen_wrappers=(), zen_meta=None, populate_full_signature=False, hydra_recursive=None, hydra_convert=None, hydra_defaults=None, frozen=False, dataclass_name=None, builds_bases=(), **kwargs_for_target)
 
-         `builds(target, *args, **kw)` returns a Hydra-compatible config that, when
-         instantiated, returns `target(*args, **kw)`.
-
-         I.e., `instantiate(builds(target, *args, **kw)) == target(*args, **kw)`
+        `builds(target, *args, **kw)` returns a Hydra-compatible config that, when
+        instantiated, returns `target(*args, **kw)`.
+
+        I.e., `instantiate(builds(target, *args, **kw)) == target(*args, **kw)`
 
-         Consult the Notes section for more details, and the Examples section to see
-         the various features of `builds` in action.
+        Consult the Notes section for more details, and the Examples section to see
+        the various features of `builds` in action.
 
-         Parameters
-         ----------
-         hydra_target : T (Callable)
-             The target object to be configured. This is a required, **positional-only**
-             argument.
-
-         *pos_args : SupportedPrimitive
-             Positional arguments passed as ``<hydra_target>(*pos_args, ...)`` upon
-             instantiation.
-
-             Arguments specified positionally are not included in the config's signature
-             and are stored as a tuple bound to in the ``_args_`` field.
+        Parameters
+        ----------
+        hydra_target : T (Callable)
+            The target object to be configured. This is a required, **positional-only**
+            argument.
+
+        *pos_args : SupportedPrimitive
+            Positional arguments passed as ``<hydra_target>(*pos_args, ...)`` upon
+            instantiation.
+
+            Arguments specified positionally are not included in the config's signature
+            and are stored as a tuple bound to in the ``_args_`` field.
 
-         **kwargs_for_target : SupportedPrimitive
-             The keyword arguments passed as ``<hydra_target>(..., **kwargs_for_target)``
-             upon instantiation.
+        **kwargs_for_target : SupportedPrimitive
+            The keyword arguments passed as ``<hydra_target>(..., **kwargs_for_target)``
+            upon instantiation.
 
-             The arguments specified here determine the signature of the resulting
-             config, unless ``populate_full_signature=True`` is specified (see below).
+            The arguments specified here determine the signature of the resulting
+            config, unless ``populate_full_signature=True`` is specified (see below).
 
-             Named parameters of the forms that have the prefixes ``hydra_``, ``zen_`` or
-             ``_zen_`` are reserved to ensure future-compatibility, and thus cannot be
-             specified by the user.
-
-         zen_partial : Optional[bool]
-             If ``True``, then the resulting config will instantiate as
-             ``functools.partial(<hydra_target>, *pos_args, **kwargs_for_target)``. Thus
-             this enables the partial-configuration of objects.
+            Named parameters of the forms that have the prefixes ``hydra_``, ``zen_`` or
+            ``_zen_`` are reserved to ensure future-compatibility, and thus cannot be
+            specified by the user.
+
+        zen_partial : Optional[bool]
+            If ``True``, then the resulting config will instantiate as
+            ``functools.partial(<hydra_target>, *pos_args, **kwargs_for_target)``. Thus
+            this enables the partial-configuration of objects.
 
-             Specifying ``zen_partial=True`` and ``populate_full_signature=True`` together
-             will populate the config's signature only with parameters that: are explicitly
-             specified by the user, or that have default values specified in the target's
-             signature. I.e. it is presumed that un-specified parameters that have no
-             default values are to be excluded from the config.
-
-         zen_wrappers : None | Callable | Builds | InterpStr | Sequence[None | Callable | Builds | InterpStr]
-             One or more wrappers, which will wrap ``hydra_target`` prior to instantiation.
-             E.g. specifying the wrappers ``[f1, f2, f3]`` will instantiate as::
-
-                 f3(f2(f1(<hydra_target>)))(*args, **kwargs)
-
-             Wrappers can also be specified as interpolated strings [2]_ or targeted
-             configs.
-
-         zen_meta : Optional[Mapping[str, SupportedPrimitive]]
-             Specifies field-names and corresponding values that will be included in the
-             resulting config, but that will *not* be used to instantiate
-             ``<hydra_target>``. These are called "meta" fields.
+            Specifying ``zen_partial=True`` and ``populate_full_signature=True`` together
+            will populate the config's signature only with parameters that: are explicitly
+            specified by the user, or that have default values specified in the target's
+            signature. I.e. it is presumed that un-specified parameters that have no
+            default values are to be excluded from the config.
+
+        zen_wrappers : None | Callable | Builds | InterpStr | Sequence[None | Callable | Builds | InterpStr]
+            One or more wrappers, which will wrap ``hydra_target`` prior to instantiation.
+            E.g. specifying the wrappers ``[f1, f2, f3]`` will instantiate as::
+
+                f3(f2(f1(<hydra_target>)))(*args, **kwargs)
+
+            Wrappers can also be specified as interpolated strings [2]_ or targeted
+            configs.
+
+        zen_meta : Optional[Mapping[str, SupportedPrimitive]]
+            Specifies field-names and corresponding values that will be included in the
+            resulting config, but that will *not* be used to instantiate
+            ``<hydra_target>``. These are called "meta" fields.
 
-         populate_full_signature : bool, optional (default=False)
-             If ``True``, then the resulting config's signature and fields will be
-             populated according to the signature of ``<hydra_target>``; values also
-             specified in ``**kwargs_for_target`` take precedent.
-
-             This option is not available for objects with inaccessible signatures, such
-             as NumPy's various ufuncs.
-
-         zen_exclude : Collection[str] | Callable[[str], bool], optional (default=[])
-             Specifies parameter names, or a function for checking names, to exclude
-             those parameters from the config-creation process.
-
-         Note that inherited fields cannot be excluded.
-         zen_convert : Optional[ZenConvert]
-             A dictionary that modifies hydra-zen's value and type conversion behavior.
-             Consists of the following optional key-value pairs (:ref:`zen-convert`):
-
-             - `dataclass` : `bool` (default=True):
-                 If `True` any dataclass type/instance without a
-                 `_target_` field is automatically converted to a targeted config
-                 that will instantiate to that type/instance. Otherwise the dataclass
-                 type/instance will be passed through as-is.
-
-             - `flat_target`: `bool` (default=True)
-                 If `True` (default), `builds(builds(f))` is equivalent to `builds(f)`. I.e. the second `builds` call will use the `_target_` field of its input, if it exists.
-
-         builds_bases : Tuple[Type[DataClass], ...]
-             Specifies a tuple of parent classes that the resulting config inherits from.
-
-         hydra_recursive : Optional[bool], optional (default=True)
-             If ``True``, then Hydra will recursively instantiate all other
-             hydra-config objects nested within this config [3]_.
-
-             If ``None``, the ``_recursive_`` attribute is not set on the resulting config.
-
-         hydra_convert : Optional[Literal["none", "partial", "all", "object"]], optional (default="none")
-             Determines how Hydra handles the non-primitive, omegaconf-specific objects passed to
-             ``<hydra_target>`` [4]_.
-
-             - ``"none"``: No conversion occurs; omegaconf containers are passed through (Default)
-             - ``"partial"``: ``DictConfig`` and ``ListConfig`` objects converted to ``dict`` and
-             ``list``, respectively. Structured configs and their fields are passed without conversion.
-             - ``"all"``: All passed objects are converted to dicts, lists, and primitives, without
-             a trace of OmegaConf containers.
-             - ``"object"``: Passed objects are converted to dict and list. Structured Configs are converted to instances of the backing dataclass / attr class.
-
-             If ``None``, the ``_convert_`` attribute is not set on the resulting config.
-
-         hydra_defaults : None | list[str | dict[str, str | list[str] | None ]], optional (default = None)
-             A list in an input config that instructs Hydra how to build the output config
-             [6]_ [7]_. Each input config can have a Defaults List as a top level element. The
-             Defaults List itself is not a part of output config.
-
-         zen_dataclass : Optional[DataclassOptions]
-             A dictionary that can specify any option that is supported by
-             :py:func:`dataclasses.make_dataclass` other than `fields`.
-             The default value for `unsafe_hash` is `True`.
-
-             Additionally, the `module` field can be specified to enable pickle
-             compatibility. See `hydra_zen.typing.DataclassOptions` for details.
-
-         frozen : bool, optional (default=False)
-             .. deprecated:: 0.9.0
-                 `frozen` will be removed in hydra-zen 0.10.0. It is replaced by
-                 `zen_dataclass={'frozen': <bool>}`.
-
-             If ``True``, the resulting config will create frozen (i.e. immutable) instances.
-             I.e. setting/deleting an attribute of an instance will raise
-             :py:class:`dataclasses.FrozenInstanceError` at runtime.
-
-         dataclass_name : Optional[str]
-             .. deprecated:: 0.9.0
-                 `dataclass_name` will be removed in hydra-zen 0.10.0. It is replaced by
-                 `zen_dataclass={'cls_name': <str>}`.
-
-             If specified, determines the name of the returned class object.
-
-         Returns
-         -------
-         Config : Type[Builds[Type[T]]] | Type[PartialBuilds[Type[T]]]
-             A dynamically-generated structured config (i.e. a dataclass type) that
-             describes how to build ``hydra_target``.
-
-         Raises
-         ------
-         hydra_zen.errors.HydraZenUnsupportedPrimitiveError
-             The provided configured value cannot be serialized by Hydra, nor does
-             hydra-zen provide specialized support for it. See :ref:`valid-types` for
-             more details.
-
-         Notes
-         -----
-         The following pseudo code conveys the core functionality of `builds`:
-
-         .. code-block:: python
-
-             from dataclasses import make_dataclass
-
-             def builds(self,target, populate_full_signature=False, **kw):
-                 # Dynamically defines a Hydra-compatible dataclass type.
-                 # Akin to doing:
-                 #
-                 # @dataclass
-                 # class Builds_thing:
-                 #     _target_: str = get_import_path(target)
-                 #     # etc.
-
-                 _target_ = get_import_path(target)
-
-                 if populate_full_signature:
-                     sig = get_signature(target)
-                     kw = {**sig, **kw}  # merge w/ preference for kw
-
-                 type_annots = [get_hints(target)[k] for k in kw]
-
-                 fields = [("_target_", str, _target_)]
-                 fields += [
-                     (
-                         field_name,
-                         hydra_compat_type_annot(hint),
-                         hydra_compat_val(v),
-                     )
-                     for hint, (field_name, v) in zip(type_annots, kw.items())
-                 ]
-
-                 Config = make_dataclass(f"Builds_{target}", fields)
-                 return Config
-
-         The resulting "config" is a dynamically-generated dataclass type [5]_ with
-         Hydra-specific attributes attached to it [1]_. It possesses a `_target_`
-         attribute that indicates the import path to the configured target as a string.
-
-         Using any of the ``zen_xx`` features will result in a config that depends
-         explicitly on hydra-zen. I.e. hydra-zen must be installed in order to
-         instantiate the resulting config, including its yaml version.
-
-         For details of the annotation `SupportedPrimitive`, see :ref:`valid-types`.
-
-         Type annotations are inferred from the target's signature and are only
-         retained if they are compatible with Hydra's limited set of supported
-         annotations; otherwise an annotation is automatically 'broadened' until
-         it is made compatible with Hydra.
-
-         `builds` provides runtime validation of user-specified arguments against
-         the target's signature. E.g. specifying mis-named arguments or too many
-         arguments will cause `builds` to raise.
+        populate_full_signature : bool, optional (default=False)
+            If ``True``, then the resulting config's signature and fields will be
+            populated according to the signature of ``<hydra_target>``; values also
+            specified in ``**kwargs_for_target`` take precedent.
+
+            This option is not available for objects with inaccessible signatures, such
+            as NumPy's various ufuncs.
+
+        zen_exclude : Collection[str] | Callable[[str], bool], optional (default=[])
+            Specifies parameter names, or a function for checking names, to exclude
+            those parameters from the config-creation process.
+
+        Note that inherited fields cannot be excluded.
+        zen_convert : Optional[ZenConvert]
+            A dictionary that modifies hydra-zen's value and type conversion behavior.
+            Consists of the following optional key-value pairs (:ref:`zen-convert`):
+
+            - `dataclass` : `bool` (default=True):
+                If `True` any dataclass type/instance without a
+                `_target_` field is automatically converted to a targeted config
+                that will instantiate to that type/instance. Otherwise the dataclass
+                type/instance will be passed through as-is.
+
+            - `flat_target`: `bool` (default=True)
+                If `True` (default), `builds(builds(f))` is equivalent to `builds(f)`. I.e. the second `builds` call will use the `_target_` field of its input, if it exists.
+
+        builds_bases : Tuple[Type[DataClass], ...]
+            Specifies a tuple of parent classes that the resulting config inherits from.
+
+        hydra_recursive : Optional[bool], optional (default=True)
+            If ``True``, then Hydra will recursively instantiate all other
+            hydra-config objects nested within this config [3]_.
+
+            If ``None``, the ``_recursive_`` attribute is not set on the resulting config.
+
+        hydra_convert : Optional[Literal["none", "partial", "all", "object"]], optional (default="none")
+            Determines how Hydra handles the non-primitive, omegaconf-specific objects passed to
+            ``<hydra_target>`` [4]_.
+
+            - ``"none"``: No conversion occurs; omegaconf containers are passed through (Default)
+            - ``"partial"``: ``DictConfig`` and ``ListConfig`` objects converted to ``dict`` and
+            ``list``, respectively. Structured configs and their fields are passed without conversion.
+            - ``"all"``: All passed objects are converted to dicts, lists, and primitives, without
+            a trace of OmegaConf containers.
+            - ``"object"``: Passed objects are converted to dict and list. Structured Configs are converted to instances of the backing dataclass / attr class.
+
+            If ``None``, the ``_convert_`` attribute is not set on the resulting config.
+
+        hydra_defaults : None | list[str | dict[str, str | list[str] | None ]], optional (default = None)
+            A list in an input config that instructs Hydra how to build the output config
+            [6]_ [7]_. Each input config can have a Defaults List as a top level element. The
+            Defaults List itself is not a part of output config.
+
+        zen_dataclass : Optional[DataclassOptions]
+            A dictionary that can specify any option that is supported by
+            :py:func:`dataclasses.make_dataclass` other than `fields`.
+            The default value for `unsafe_hash` is `True`.
+
+            Additionally, the `module` field can be specified to enable pickle
+            compatibility. See `hydra_zen.typing.DataclassOptions` for details.
+
+        frozen : bool, optional (default=False)
+            .. deprecated:: 0.9.0
+                `frozen` will be removed in hydra-zen 0.10.0. It is replaced by
+                `zen_dataclass={'frozen': <bool>}`.
+
+            If ``True``, the resulting config will create frozen (i.e. immutable) instances.
+            I.e. setting/deleting an attribute of an instance will raise
+            :py:class:`dataclasses.FrozenInstanceError` at runtime.
+
+        dataclass_name : Optional[str]
+            .. deprecated:: 0.9.0
+                `dataclass_name` will be removed in hydra-zen 0.10.0. It is replaced by
+                `zen_dataclass={'cls_name': <str>}`.
+
+            If specified, determines the name of the returned class object.
+
+        Returns
+        -------
+        Config : Type[Builds[Type[T]]] | Type[PartialBuilds[Type[T]]]
+            A dynamically-generated structured config (i.e. a dataclass type) that
+            describes how to build ``hydra_target``.
+
+        Raises
+        ------
+        hydra_zen.errors.HydraZenUnsupportedPrimitiveError
+            The provided configured value cannot be serialized by Hydra, nor does
+            hydra-zen provide specialized support for it. See :ref:`valid-types` for
+            more details.
+
+        Notes
+        -----
+        The following pseudo code conveys the core functionality of `builds`:
+
+        .. code-block:: python
+
+            from dataclasses import make_dataclass
+
+            def builds(self,target, populate_full_signature=False, **kw):
+                # Dynamically defines a Hydra-compatible dataclass type.
+                # Akin to doing:
+                #
+                # @dataclass
+                # class Builds_thing:
+                #     _target_: str = get_import_path(target)
+                #     # etc.
+
+                _target_ = get_import_path(target)
+
+                if populate_full_signature:
+                    sig = get_signature(target)
+                    kw = {**sig, **kw}  # merge w/ preference for kw
+
+                type_annots = [get_hints(target)[k] for k in kw]
+
+                fields = [("_target_", str, _target_)]
+                fields += [
+                    (
+                        field_name,
+                        hydra_compat_type_annot(hint),
+                        hydra_compat_val(v),
+                    )
+                    for hint, (field_name, v) in zip(type_annots, kw.items())
+                ]
+
+                Config = make_dataclass(f"Builds_{target}", fields)
+                return Config
+
+        The resulting "config" is a dynamically-generated dataclass type [5]_ with
+        Hydra-specific attributes attached to it [1]_. It possesses a `_target_`
+        attribute that indicates the import path to the configured target as a string.
+
+        Using any of the ``zen_xx`` features will result in a config that depends
+        explicitly on hydra-zen. I.e. hydra-zen must be installed in order to
+        instantiate the resulting config, including its yaml version.
+
+        For details of the annotation `SupportedPrimitive`, see :ref:`valid-types`.
+
+        Type annotations are inferred from the target's signature and are only
+        retained if they are compatible with Hydra's limited set of supported
+        annotations; otherwise an annotation is automatically 'broadened' until
+        it is made compatible with Hydra.
+
+        `builds` provides runtime validation of user-specified arguments against
+        the target's signature. E.g. specifying mis-named arguments or too many
+        arguments will cause `builds` to raise.
 
-         References
-         ----------
-         .. [1] https://hydra.cc/docs/tutorials/structured_config/intro/
-         .. [2] https://omegaconf.readthedocs.io/en/2.1_branch/usage.html#variable-interpolation
-         .. [3] https://hydra.cc/docs/advanced/instantiate_objects/overview/#recursive-instantiation
-         .. [4] https://hydra.cc/docs/advanced/instantiate_objects/overview/#parameter-conversion-strategies
-         .. [5] https://docs.python.org/3/library/dataclasses.html
-         .. [6] https://hydra.cc/docs/tutorials/structured_config/defaults/
-         .. [7] https://hydra.cc/docs/advanced/defaults_list/
+        References
+        ----------
+        .. [1] https://hydra.cc/docs/tutorials/structured_config/intro/
+        .. [2] https://omegaconf.readthedocs.io/en/2.1_branch/usage.html#variable-interpolation
+        .. [3] https://hydra.cc/docs/advanced/instantiate_objects/overview/#recursive-instantiation
+        .. [4] https://hydra.cc/docs/advanced/instantiate_objects/overview/#parameter-conversion-strategies
+        .. [5] https://docs.python.org/3/library/dataclasses.html
+        .. [6] https://hydra.cc/docs/tutorials/structured_config/defaults/
+        .. [7] https://hydra.cc/docs/advanced/defaults_list/
 
-         See Also
-         --------
-         instantiate: Instantiates a configuration created by `builds`, returning the instantiated target.
-         make_custom_builds_fn: Returns a new `builds` function with customized default values.
-         make_config: Creates a general config with customized field names, default values, and annotations.
-         get_target: Returns the target-object from a targeted structured config.
-         just: Produces a config that, when instantiated by Hydra, "just" returns the un-instantiated target-object.
-         to_yaml: Serialize a config as a yaml-formatted string.
+        See Also
+        --------
+        instantiate: Instantiates a configuration created by `builds`, returning the instantiated target.
+        make_custom_builds_fn: Returns a new `builds` function with customized default values.
+        make_config: Creates a general config with customized field names, default values, and annotations.
+        get_target: Returns the target-object from a targeted structured config.
+        just: Produces a config that, when instantiated by Hydra, "just" returns the un-instantiated target-object.
+        to_yaml: Serialize a config as a yaml-formatted string.
 
-         Examples
-         --------
-         These examples describe:
+        Examples
+        --------
+        These examples describe:
 
-         - Basic usage
-         - Creating a partial config
-         - Auto-populating parameters
-         - Composing configs via inheritance
-         - Runtime validation performed by builds
-         - Using meta-fields
-         - Using zen-wrappers
-         - Creating a pickle-compatible config
-         - Creating a frozen config
-         - Support for partial'd targets
+        - Basic usage
+        - Creating a partial config
+        - Auto-populating parameters
+        - Composing configs via inheritance
+        - Runtime validation performed by builds
+        - Using meta-fields
+        - Using zen-wrappers
+        - Creating a pickle-compatible config
+        - Creating a frozen config
+        - Support for partial'd targets
 
-         A helpful utility for printing examples
+        A helpful utility for printing examples
 
-         >>> from hydra_zen import builds, instantiate, to_yaml
-         >>> def pyaml(x):
-         ...     # for pretty printing configs
-         ...     print(to_yaml(x))
+        >>> from hydra_zen import builds, instantiate, to_yaml
+        >>> def pyaml(x):
+        ...     # for pretty printing configs
+        ...     print(to_yaml(x))
 
-         **Basic Usage**
+        **Basic Usage**
 
-         Lets create a basic config that describes how to 'build' a particular dictionary.
+        Lets create a basic config that describes how to 'build' a particular dictionary.
 
-         >>> Conf = builds(dict, a=1, b='x')
+        >>> Conf = builds(dict, a=1, b='x')
 
-         The resulting config is a dataclass with the following signature and attributes:
+        The resulting config is a dataclass with the following signature and attributes:
 
-         >>> Conf  # signature: Conf(a: Any = 1, b: Any = 'x')
-         <class 'types.Builds_dict'>
+        >>> Conf  # signature: Conf(a: Any = 1, b: Any = 'x')
+        <class 'types.Builds_dict'>
 
-         >>> pyaml(Conf)
-         _target_: builtins.dict
-         a: 1
-         b: x
+        >>> pyaml(Conf)
+        _target_: builtins.dict
+        a: 1
+        b: x
 
-         The `instantiate` function is used to enact this build – to create the dictionary.
+        The `instantiate` function is used to enact this build – to create the dictionary.
 
-         >>> instantiate(Conf)  # calls: `dict(a=1, b='x')`
-         {'a': 1, 'b': 'x'}
+        >>> instantiate(Conf)  # calls: `dict(a=1, b='x')`
+        {'a': 1, 'b': 'x'}
 
-         The default parameters that we provided can be overridden.
+        The default parameters that we provided can be overridden.
 
-         >>> new_conf = Conf(a=10, b="hi")  # an instance of our dataclass
-         >>> instantiate(new_conf)  # calls: `dict(a=10, b='hi')`
-         {'a': 10, 'b': 'hi'}
+        >>> new_conf = Conf(a=10, b="hi")  # an instance of our dataclass
+        >>> instantiate(new_conf)  # calls: `dict(a=10, b='hi')`
+        {'a': 10, 'b': 'hi'}
 
-         Positional arguments are supported.
+        Positional arguments are supported.
 
-         >>> Conf = builds(len, [1, 2, 3])
-         >>> Conf._args_  # type: ignore
-         [1, 2, 3]
-         >>> instantiate(Conf)
-         3
+        >>> Conf = builds(len, [1, 2, 3])
+        >>> Conf._args_  # type: ignore
+        [1, 2, 3]
+        >>> instantiate(Conf)
+        3
 
-         **Creating a Partial Config**
+        **Creating a Partial Config**
 
-         `builds` can be used to partially-configure a target. Let's
-         create a config for the following function
+        `builds` can be used to partially-configure a target. Let's
+        create a config for the following function
 
-         >>> def a_two_tuple(x: int, y: float): return x, y
+        >>> def a_two_tuple(x: int, y: float): return x, y
 
-         such that we only configure the parameter ``x``.
+        such that we only configure the parameter ``x``.
 
-         >>> PartialConf = builds(a_two_tuple, x=1, zen_partial=True)  # configures only `x`
-         >>> pyaml(PartialConf)
-         _target_: __main__.a_two_tuple
-         _partial_: true
-         x: 1
+        >>> PartialConf = builds(a_two_tuple, x=1, zen_partial=True)  # configures only `x`
+        >>> pyaml(PartialConf)
+        _target_: __main__.a_two_tuple
+        _partial_: true
+        x: 1
 
-         Instantiating this config will return ``functools.partial(a_two_tuple, x=1)``.
+        Instantiating this config will return ``functools.partial(a_two_tuple, x=1)``.
 
-         >>> partial_func = instantiate(PartialConf)
-         >>> partial_func
-         functools.partial(<function a_two_tuple at 0x00000220A7820EE0>, x=1)
+        >>> partial_func = instantiate(PartialConf)
+        >>> partial_func
+        functools.partial(<function a_two_tuple at 0x00000220A7820EE0>, x=1)
 
-         And thus the remaining parameter can be provided post-instantiation.
+        And thus the remaining parameter can be provided post-instantiation.
 
-         >>> partial_func(y=22.0)  # providing the remaining parameter
-         (1, 22.0)
+        >>> partial_func(y=22.0)  # providing the remaining parameter
+        (1, 22.0)
 
-         **Auto-populating parameters**
+        **Auto-populating parameters**
 
-         The configurable parameters of a target can be auto-populated in our config.
-         Suppose we want to configure the following function.
+        The configurable parameters of a target can be auto-populated in our config.
+        Suppose we want to configure the following function.
 
-         >>> def bar(x: bool, y: str = 'foo'): return x, y
+        >>> def bar(x: bool, y: str = 'foo'): return x, y
 
-         The following config will have a signature that matches ``f``; the
-         annotations and default values of the parameters of ``f`` are explicitly
-         incorporated into the config.
+        The following config will have a signature that matches ``f``; the
+        annotations and default values of the parameters of ``f`` are explicitly
+        incorporated into the config.
 
-         >>> # signature: `Builds_bar(x: bool, y: str = 'foo')`
-         >>> Conf = builds(bar, populate_full_signature=True)
-         >>> pyaml(Conf)
-         _target_: __main__.bar
-         x: ???
-         'y': foo
+        >>> # signature: `Builds_bar(x: bool, y: str = 'foo')`
+        >>> Conf = builds(bar, populate_full_signature=True)
+        >>> pyaml(Conf)
+        _target_: __main__.bar
+        x: ???
+        'y': foo
 
-         `zen_exclude` can be used to either name parameter to be excluded from the
-         auto-population process:
+        `zen_exclude` can be used to either name parameter to be excluded from the
+        auto-population process:
 
-         >>> Conf2 = builds(bar, populate_full_signature=True, zen_exclude=["y"])
-         >>> pyaml(Conf2)
-         _target_: __main__.bar
-         x: ???
-         'y': foo
+        >>> Conf2 = builds(bar, populate_full_signature=True, zen_exclude=["y"])
+        >>> pyaml(Conf2)
+        _target_: __main__.bar
+        x: ???
+        'y': foo
 
-         or specify a pattern - via a function - for excluding parameters:
+        or specify a pattern - via a function - for excluding parameters:
 
         >>> Conf3 = builds(bar, populate_full_signature=True, zen_exclude=lambda name: name.startswith("x"))
-         >>> pyaml(Conf3)
-         _target_: __main__.bar
-         'y': foo
+        >>> pyaml(Conf3)
+        _target_: __main__.bar
+        'y': foo
 
-         Annotations will be used by Hydra to provide limited runtime type-checking
-         during instantiation. Here, we'll pass a float for ``x``, which expects a
-         boolean value.
+        Annotations will be used by Hydra to provide limited runtime type-checking
+        during instantiation. Here, we'll pass a float for ``x``, which expects a
+        boolean value.
 
-         >>> instantiate(Conf(x=10.0))  # type: ignore
-         ValidationError: Value '10.0' is not a valid bool (type float)
-             full_key: x
-             object_type=Builds_func
+        >>> instantiate(Conf(x=10.0))  # type: ignore
+        ValidationError: Value '10.0' is not a valid bool (type float)
+            full_key: x
+            object_type=Builds_func
 
-         **Composing configs via inheritance**
+        **Composing configs via inheritance**
 
-         Because a config produced via `builds` is simply a class-object, we can
-         compose configs via class inheritance.
+        Because a config produced via `builds` is simply a class-object, we can
+        compose configs via class inheritance.
 
-         >>> ParentConf = builds(dict, a=1, b=2)
-         >>> ChildConf = builds(dict, b=-2, c=-3, builds_bases=(ParentConf,))
-         >>> instantiate(ChildConf)
-         {'a': 1, 'b': -2, 'c': -3}
-         >>> issubclass(ChildConf, ParentConf)
-         True
+        >>> ParentConf = builds(dict, a=1, b=2)
+        >>> ChildConf = builds(dict, b=-2, c=-3, builds_bases=(ParentConf,))
+        >>> instantiate(ChildConf)
+        {'a': 1, 'b': -2, 'c': -3}
+        >>> issubclass(ChildConf, ParentConf)
+        True
 
-         .. _builds-validation:
+        .. _builds-validation:
 
-         **Runtime validation performed by builds**
+        **Runtime validation performed by builds**
 
-         Misspelled parameter names and other invalid configurations for the target’s
-         signature will be caught by `builds` so that such errors are caught prior to
-         instantiation.
+        Misspelled parameter names and other invalid configurations for the target’s
+        signature will be caught by `builds` so that such errors are caught prior to
+        instantiation.
 
-         >>> def func(a_number: int): pass
+        >>> def func(a_number: int): pass
 
-         >>> builds(func, a_nmbr=2)  # misspelled parameter name
-         TypeError: Building: func ..
+        >>> builds(func, a_nmbr=2)  # misspelled parameter name
+        TypeError: Building: func ..
 
-         >>> builds(func, 1, 2)  # too many arguments
-         TypeError: Building: func ..
+        >>> builds(func, 1, 2)  # too many arguments
+        TypeError: Building: func ..
 
-         >>> BaseConf = builds(func, a_number=2)
-         >>> builds(func, 1, builds_bases=(BaseConf,))  # too many args (via inheritance)
-         TypeError: Building: func ..
+        >>> BaseConf = builds(func, a_number=2)
+        >>> builds(func, 1, builds_bases=(BaseConf,))  # too many args (via inheritance)
+        TypeError: Building: func ..
 
-         >>> # value type not supported by Hydra
-         >>> builds(int, (i for i in range(10)))  # type: ignore
-         hydra_zen.errors.HydraZenUnsupportedPrimitiveError: Building: int ..
-
-
-         .. _meta-field:
-
-         **Using meta-fields**
-
-         Meta-fields are fields that are included in a config but are excluded by the
-         instantiation process. Thus arbitrary metadata can be attached to a config.
-
-         Let's create a config whose fields reference a meta-field via
-         relative-interpolation [2]_.
-
-         >>> Conf = builds(dict, a="${.s}", b="${.s}", zen_meta=dict(s=-10))
-         >>> instantiate(Conf)
-         {'a': -10, 'b': -10}
-         >>> instantiate(Conf, s=2)
-         {'a': 2, 'b': 2}
-
-         .. _zen-wrapper:
-
-         **Using zen-wrappers**
-
-         Zen-wrappers enables us to make arbitrary changes to ``<hydra_target>``, its inputs,
-         and/or its outputs during the instantiation process.
-
-         Let's use a wrapper to add a unit-conversion step to a config. We'll modify a
-         config that builds a function, which converts a temperature in Fahrenheit to
-         Celsius, and add a wrapper to it so that it will convert from Fahrenheit to
-         Kelvin instead.
-
-         >>> def faren_to_celsius(temp_f):  # our target
-         ...     return ((temp_f - 32) * 5) / 9
-
-         >>> def change_celcius_to_kelvin(celc_func):  # our wrapper
-         ...     def wraps(*args, **kwargs):
-         ...         return 273.15 + celc_func(*args, **kwargs)
-         ...     return wraps
-
-         >>> AsCelcius = builds(faren_to_celsius)
-         >>> AsKelvin = builds(faren_to_celsius, zen_wrappers=change_celcius_to_kelvin)
-         >>> instantiate(AsCelcius, temp_f=32)
-         0.0
-         >>> instantiate(AsKelvin, temp_f=32)
-         273.15
-
-         **Creating a pickle-compatible config**
-
-         The dynamically-generated classes created by `builds` can be made pickle-compatible
-         by specifying the name of the symbol that it is assigned to and the module in which
-         it was defined.
-
-         .. code-block:: python
-
-            # contents of mylib/foo.py
-            from pickle import dumps, loads
-
-            DictConf = builds(dict,
-                                zen_dataclass={'module': 'mylib.foo',
-                                                'cls_name': 'DictConf'})
-
-            assert DictConf is loads(dumps(DictConf))
+        >>> # value type not supported by Hydra
+        >>> builds(int, (i for i in range(10)))  # type: ignore
+        hydra_zen.errors.HydraZenUnsupportedPrimitiveError: Building: int ..
 
 
-         **Creating a frozen config**
+        .. _meta-field:
 
-         Let's create a config object whose instances will by "frozen" (i.e., immutable).
+        **Using meta-fields**
 
-         >>> RouterConfig = builds(dict, ip_address=None, zen_dataclass={'frozen': True})
-         >>> my_router = RouterConfig(ip_address="192.168.56.1")  # an immutable instance
+        Meta-fields are fields that are included in a config but are excluded by the
+        instantiation process. Thus arbitrary metadata can be attached to a config.
 
-         Attempting to overwrite the attributes of ``my_router`` will raise.
+        Let's create a config whose fields reference a meta-field via
+        relative-interpolation [2]_.
 
-         >>> my_router.ip_address = "148.109.37.2"
-         FrozenInstanceError: cannot assign to field 'ip_address'
+        >>> Conf = builds(dict, a="${.s}", b="${.s}", zen_meta=dict(s=-10))
+        >>> instantiate(Conf)
+        {'a': -10, 'b': -10}
+        >>> instantiate(Conf, s=2)
+        {'a': 2, 'b': 2}
 
-         **Support for partial'd targets**
+        .. _zen-wrapper:
 
-         Specifying ``builds(functools.partial(<target>, ...), ...)`` is supported; `builds`
-         will automatically "unpack" a partial'd object that is passed as its target.
+        **Using zen-wrappers**
 
-         >>> import functools
-         >>> partiald_dict = functools.partial(dict, a=1, b=2)
-         >>> Conf = builds(partiald_dict)  # signature: (a = 1, b = 2)
-         >>> instantiate(Conf)  # equivalent to calling: `partiald_dict()`
-         {'a': 1, 'b': 2}
-         >>> instantiate(Conf(a=-4))  # equivalent to calling: `partiald_dict(a=-4)`
-         {'a': -4, 'b': 2}
+        Zen-wrappers enables us to make arbitrary changes to ``<hydra_target>``, its inputs,
+        and/or its outputs during the instantiation process.
+
+        Let's use a wrapper to add a unit-conversion step to a config. We'll modify a
+        config that builds a function, which converts a temperature in Fahrenheit to
+        Celsius, and add a wrapper to it so that it will convert from Fahrenheit to
+        Kelvin instead.
+
+        >>> def faren_to_celsius(temp_f):  # our target
+        ...     return ((temp_f - 32) * 5) / 9
+
+        >>> def change_celcius_to_kelvin(celc_func):  # our wrapper
+        ...     def wraps(*args, **kwargs):
+        ...         return 273.15 + celc_func(*args, **kwargs)
+        ...     return wraps
+
+        >>> AsCelcius = builds(faren_to_celsius)
+        >>> AsKelvin = builds(faren_to_celsius, zen_wrappers=change_celcius_to_kelvin)
+        >>> instantiate(AsCelcius, temp_f=32)
+        0.0
+        >>> instantiate(AsKelvin, temp_f=32)
+        273.15
+
+        **Creating a pickle-compatible config**
+
+        The dynamically-generated classes created by `builds` can be made pickle-compatible
+        by specifying the name of the symbol that it is assigned to and the module in which
+        it was defined.
+
+        .. code-block:: python
+
+           # contents of mylib/foo.py
+           from pickle import dumps, loads
+
+           DictConf = builds(dict,
+                               zen_dataclass={'module': 'mylib.foo',
+                                               'cls_name': 'DictConf'})
+
+           assert DictConf is loads(dumps(DictConf))
+
+
+        **Creating a frozen config**
+
+        Let's create a config object whose instances will by "frozen" (i.e., immutable).
+
+        >>> RouterConfig = builds(dict, ip_address=None, zen_dataclass={'frozen': True})
+        >>> my_router = RouterConfig(ip_address="192.168.56.1")  # an immutable instance
+
+        Attempting to overwrite the attributes of ``my_router`` will raise.
+
+        >>> my_router.ip_address = "148.109.37.2"
+        FrozenInstanceError: cannot assign to field 'ip_address'
+
+        **Support for partial'd targets**
+
+        Specifying ``builds(functools.partial(<target>, ...), ...)`` is supported; `builds`
+        will automatically "unpack" a partial'd object that is passed as its target.
+
+        >>> import functools
+        >>> partiald_dict = functools.partial(dict, a=1, b=2)
+        >>> Conf = builds(partiald_dict)  # signature: (a = 1, b = 2)
+        >>> instantiate(Conf)  # equivalent to calling: `partiald_dict()`
+        {'a': 1, 'b': 2}
+        >>> instantiate(Conf(a=-4))  # equivalent to calling: `partiald_dict(a=-4)`
+        {'a': -4, 'b': 2}
         """
 
         zen_convert_settings = _utils.merge_settings(

--- a/src/hydra_zen/structured_configs/_make_custom_builds.py
+++ b/src/hydra_zen/structured_configs/_make_custom_builds.py
@@ -8,6 +8,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Collection,
     Dict,
     Mapping,
     Optional,
@@ -36,6 +37,7 @@ __BUILDS_DEFAULTS: Final[Dict[str, Any]] = {
     for name, p in _builds_sig.parameters.items()
     if p.kind is p.KEYWORD_ONLY
 }
+__BUILDS_DEFAULTS["zen_exclude"] = frozenset()
 # TODO: Remove deprecated options once they are phased out
 __BUILDS_DEFAULTS["frozen"] = False
 __BUILDS_DEFAULTS["dataclass_name"] = None
@@ -55,6 +57,7 @@ def make_custom_builds_fn(
     zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, Any]] = ...,
     populate_full_signature: Literal[True],
+    zen_exclude: Union[Collection[str], Callable[[str], bool]] = ...,
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all", "object"]] = ...,
     zen_dataclass: Optional[DataclassOptions] = ...,
@@ -73,6 +76,7 @@ def make_custom_builds_fn(
     zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, Any]] = ...,
     populate_full_signature: bool = ...,
+    zen_exclude: Union[Collection[str], Callable[[str], bool]] = ...,
     hydra_recursive: Optional[bool] = ...,
     hydra_convert: Optional[Literal["none", "partial", "all", "object"]] = ...,
     zen_dataclass: Optional[DataclassOptions] = ...,
@@ -89,6 +93,7 @@ def make_custom_builds_fn(
     *,
     zen_partial: Literal[False, None] = ...,
     populate_full_signature: Literal[False] = ...,
+    zen_exclude: Union[Collection[str], Callable[[str], bool]] = ...,
     zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, Any]] = ...,
     hydra_recursive: Optional[bool] = ...,
@@ -107,6 +112,7 @@ def make_custom_builds_fn(
     *,
     zen_partial: Literal[False, None] = ...,
     populate_full_signature: bool,
+    zen_exclude: Union[Collection[str], Callable[[str], bool]] = ...,
     zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, Any]] = ...,
     hydra_recursive: Optional[bool] = ...,
@@ -125,6 +131,7 @@ def make_custom_builds_fn(
     *,
     zen_partial: Union[bool, None],
     populate_full_signature: Literal[False] = ...,
+    zen_exclude: Union[Collection[str], Callable[[str], bool]] = ...,
     zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, Any]] = ...,
     hydra_recursive: Optional[bool] = ...,
@@ -143,6 +150,7 @@ def make_custom_builds_fn(
     *,
     zen_partial: Union[bool, None],
     populate_full_signature: bool,
+    zen_exclude: Union[Collection[str], Callable[[str], bool]] = ...,
     zen_wrappers: ZenWrappers[Callable[..., Any]] = ...,
     zen_meta: Optional[Mapping[str, Any]] = ...,
     hydra_recursive: Optional[bool] = ...,
@@ -159,6 +167,7 @@ def make_custom_builds_fn(
     *,
     zen_partial: Optional[bool] = None,
     populate_full_signature: bool = False,
+    zen_exclude: Union[Collection[str], Callable[[str], bool]] = frozenset(),
     zen_wrappers: ZenWrappers[Callable[..., Any]] = tuple(),
     zen_meta: Optional[Mapping[str, Any]] = None,
     hydra_recursive: Optional[bool] = None,
@@ -187,6 +196,12 @@ def make_custom_builds_fn(
 
     populate_full_signature : bool, optional (default=False)
         Specifies a new the default value for ``builds(..., populate_full_signature=<..>)``
+
+    zen_exclude : Collection[str] | Callable[[str], bool], optional (default=[])
+        Specifies parameter names, or a function for checking names, to exclude
+        those parameters from the config-creation process.
+
+        Note that inherited fields cannot be excluded.
 
     zen_convert : Optional[ZenConvert]
         A dictionary that modifies hydra-zen's value and type conversion behavior.

--- a/tests/custom_strategies.py
+++ b/tests/custom_strategies.py
@@ -91,6 +91,8 @@ _valid_builds_strats = dict(
     builds_bases=st.just(()),
     zen_convert=st.none() | st.from_type(ZenConvert),
     zen_dataclass=st.none() | st.from_type(DataclassOptions),
+    zen_exclude=st.just(())
+    | st.sampled_from([set(), ["momomomo"], lambda x: x.endswith("momomomo")]),
 )
 
 

--- a/tests/test_custom_strategies.py
+++ b/tests/test_custom_strategies.py
@@ -28,6 +28,7 @@ def test_valid_build_strats_are_exhaustive():
         for n, p in inspect.signature(builds).parameters.items()
         if p.kind is p.KEYWORD_ONLY
     )
+    nameable_builds_args.add("zen_exclude")
     assert nameable_builds_args - {"dataclass_name", "hydra_defaults"} == set(
         _valid_builds_strats
     )

--- a/tests/test_zen_exclude.py
+++ b/tests/test_zen_exclude.py
@@ -1,0 +1,35 @@
+import pytest
+
+from hydra_zen import builds, instantiate, make_custom_builds_fn
+
+
+@pytest.mark.parametrize("bad_exclude", [1, "x"])
+def test_validate_exclude(bad_exclude):
+    with pytest.raises(TypeError):
+        builds(dict, zen_exclude=bad_exclude)
+
+
+def foo(x=1, _y=2, _z=3):
+    return "apple"
+
+
+@pytest.mark.parametrize("partial", [True, False])
+@pytest.mark.parametrize("custom_builds", [True, False])
+@pytest.mark.parametrize("exclude", [["_y", "_z"], lambda x: x.startswith("_")])
+def test_exclude_named(partial: bool, custom_builds: bool, exclude):
+    if custom_builds:
+        b = make_custom_builds_fn(
+            populate_full_signature=True, zen_partial=partial, zen_exclude=exclude
+        )
+        conf = b(foo)()
+    else:
+        conf = builds(
+            foo, populate_full_signature=True, zen_partial=partial, zen_exclude=exclude
+        )()
+    assert not hasattr(conf, "_y")
+    assert not hasattr(conf, "_z")
+    assert conf.x == 1
+    if not partial:
+        assert instantiate(conf) == "apple"
+    else:
+        assert instantiate(conf)() == "apple"  # type: ignore

--- a/tests/test_zen_exclude.py
+++ b/tests/test_zen_exclude.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Massachusetts Institute of Technology
+# SPDX-License-Identifier: MIT
 import pytest
 
 from hydra_zen import builds, instantiate, make_custom_builds_fn


### PR DESCRIPTION
This PR adds the ability to exclude parameters - either by name or by pattern (i.e. `callable[[name], bool]`) - from `builds` when `populate_full_signature=True`.

```python
from hydra_zen import builds

def f(x=1, y=2, _z=3): ...

builds(f, populate_full_signature=True, zen_exclude=['y'])  # exclude `y` from config
builds(f, populate_full_signature=True, zen_exclude=lambda x: x.startwith("_")  # exclude any param starting with "_"
```

or

```python
from hydra_zen import make_custom_builds_fn

# a builds fn that always ignores parameters with "private" names from auto-populated parameters.
builds = make_custom_builds_fn(populate_full_signature=True, zen_exclude=lambda x: x.startwith("_"))
```

Note that this does **not** enable one to exclude inherited parameters.

## Implementation details

I have wanted to implement `zen_exclude` for a while, but doing so would make our typing-overloads for `populate_full_signature=True`  double, which I am absolutely not going to do.

Because specifying `zen_exclude` has the same effect, as far as typing is concerned, as a user specifying a target-kwarg in builds, I realized that I can just "smuggle" `zen_exclude` into `**target_kwargs`. The typing overloads work just fine. 

The downside to this is that `zen_exclude` does not explicitly appear in the signature of `builds`. Thus you will not see it autocomplete nor will you get type-checking on this parameter. This is unfortunate but ultimately it is better to have `zen_exclude` with some lack in tooling support rather than not at all.