### PR TITLE
add `hydra_zen.note_static_method`

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -38,6 +38,7 @@ Creating Configs
    builds
    just
    hydrated_dataclass
+   note_static_method
 
 
 Storing Configs

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -67,6 +67,7 @@ Improvements
 - Adds formal support for Python 3.12. See :pull:`555`
 - :func:`~hydra_zen.BuildsFn` was introduced to permit customizable auto-config and type-refinement support in config-creation functions. See :pull:`553`.
 - :func:`~hydra_zen.builds` and :func:`~hydra_zen.make_custom_builds_fn` now accept a `zen_exclude` field for excluding parameters from auto-population, either by name or by pattern. See :pull:`558`.
+- :func:`~hydra_zen.note_static_method` and :func:`~hydra_zen.BuildsFn.note_static_method` have been added to enable support for passing a static method to :func:`~hydra_zen.builds`. See :pull:`565`.
 
 
 .. _v0.11.0:

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -67,7 +67,7 @@ Improvements
 - Adds formal support for Python 3.12. See :pull:`555`
 - :func:`~hydra_zen.BuildsFn` was introduced to permit customizable auto-config and type-refinement support in config-creation functions. See :pull:`553`.
 - :func:`~hydra_zen.builds` and :func:`~hydra_zen.make_custom_builds_fn` now accept a `zen_exclude` field for excluding parameters from auto-population, either by name or by pattern. See :pull:`558`.
-- :func:`~hydra_zen.note_static_method` and :func:`~hydra_zen.BuildsFn.note_static_method` have been added to enable support for passing a static method to :func:`~hydra_zen.builds`. See :pull:`565`.
+- :func:`~hydra_zen.note_static_method` and ``hydra_zen.BuildsFn.note_static_method`` have been added to enable support for passing a static method to :func:`~hydra_zen.builds`. See :pull:`565`.
 
 
 .. _v0.11.0:

--- a/src/hydra_zen/__init__.py
+++ b/src/hydra_zen/__init__.py
@@ -19,7 +19,12 @@ from .structured_configs import (
     make_custom_builds_fn,
     mutable_value,
 )
-from .structured_configs._implementations import BuildsFn, DefaultBuilds, get_target
+from .structured_configs._implementations import (
+    BuildsFn,
+    DefaultBuilds,
+    get_target,
+    note_static_method,
+)
 from .structured_configs._type_guards import is_partial_builds, uses_zen_processing
 from .wrapper import ZenStore, store, zen
 
@@ -28,6 +33,7 @@ __all__ = [
     "BuildsFn",
     "DefaultBuilds",
     "hydrated_dataclass",
+    "note_static_method",
     "just",
     "mutable_value",
     "get_target",

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -713,15 +713,19 @@ class BuildsFn(Generic[T]):
         >>> instantiate(builds(Bar.g))
         "MEOW:
         """
+        if not TYPE_CHECKING:  # pragma: no cover
+            if isinstance(__x, staticmethod):
+                if sys.version_info < (3, 10):
+                    raise TypeError(
+                        "`note_static_method` can only be used as a decorator for Python 3.10+"
+                    )
 
-        if (
-            not TYPE_CHECKING
-            and isinstance(__x, staticmethod)
-            and sys.version_info < (3, 10)
-        ):  # pragma: no cover
-            raise TypeError(
-                "`note_static_method` can only be used as a decorator for Python 3.10+"
-            )
+            elif not inspect.isfunction(__x):
+                raise TypeError(
+                    f"`note_static_method` must be passed a "
+                    f"static method, got {__x}"
+                )
+
         cls._registered_static_methods.add((__x.__module__, __x.__qualname__))
         return __x
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -682,7 +682,7 @@ class BuildsFn(Generic[T]):
         -----
         A staticmethod does not possess any information to indicate that it is not
         merely a function; e.g. it does not have any reference to its parent class.
-        Thus `builds` is unsable to resolve the import path of a static method. Instead,
+        Thus `builds` is unable to resolve the import path of a static method. Instead,
         `note_static_method` explicitly stores the module and qualname of the
         static method in a global set that `builds` can reference later.
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -21,6 +21,7 @@ from functools import partial
 from itertools import chain
 from pathlib import Path, PosixPath, WindowsPath
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -713,9 +714,11 @@ class BuildsFn(Generic[T]):
         "MEOW:
         """
 
-        # if x is staticmethod:
-        #     return _as_static_method if sys.version_info >= (3, 10) else staticmethod
-        if isinstance(__x, staticmethod) and sys.version_info < (3, 10):
+        if (
+            not TYPE_CHECKING
+            and isinstance(__x, staticmethod)
+            and sys.version_info < (3, 10)
+        ):  # pragma: no cover
             raise TypeError(
                 "`note_static_method` can only be used as a decorator for Python 3.10+"
             )

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -2019,6 +2019,20 @@ class BuildsFn(Generic[T]):
         {'a': 1, 'b': 2}
         >>> instantiate(Conf(a=-4))  # equivalent to calling: `partiald_dict(a=-4)`
         {'a': -4, 'b': 2}
+
+        **Building a config for a static method**
+
+        A static method must first be passed to :func:`~hydra_zen.note_static_method`
+        before being passed to builds.
+
+        >>> from hydra_zen import note_static_method, builds, instantiate
+        >>> class Foo:
+        ...     @staticmethod
+        ...     def f():
+        ...         return "BARK"
+        >>> note_static_method(Foo.f)
+        >>> builds(Foo.f)._target_
+        "__main__.Foo.f"
         """
 
         zen_convert_settings = _utils.merge_settings(

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -44,6 +44,7 @@ from hydra_zen import (
     make_config,
     make_custom_builds_fn,
     mutable_value,
+    note_static_method,
     store,
     zen,
 )
@@ -1477,3 +1478,14 @@ def check_parameterized_BuildsFn():
     assert_type(bg(A, B()), Type[Builds[Type[A]]])
     assert_type(bg(A, B(), zen_partial=True), Type[PartialBuilds[Type[A]]])
     bg(A, C())  # type: ignore
+
+
+def check_noted_static_method():
+    class A:
+        @staticmethod
+        def foo(x: int) -> bool:
+            ...
+
+    reveal_type(note_static_method(A.foo), expected_text="(x: int) -> bool")
+
+    note_static_method(None)  # type: ignore

--- a/tests/test_py310.py
+++ b/tests/test_py310.py
@@ -10,7 +10,7 @@ import hypothesis.strategies as st
 import pytest
 from hypothesis import assume, given
 
-from hydra_zen import builds, instantiate, just, make_config
+from hydra_zen import builds, instantiate, just, make_config, note_static_method
 from hydra_zen.structured_configs._type_guards import safe_getattr
 from hydra_zen.typing import DataclassOptions as Dc
 from tests.custom_strategies import valid_builds_args
@@ -97,3 +97,14 @@ def test_safe_getattr_no_default():
         safe_getattr(conf, "x")
 
     assert safe_getattr(conf, "x", 1) == 1
+
+
+class A:
+    @note_static_method
+    @staticmethod
+    def foo(x: int):
+        return "A.grr" * x
+
+
+def test_note_static_method_as_decorator():
+    assert instantiate(builds(A.foo, 2)) == "A.grr" * 2

--- a/tests/test_staticmethod_support.py
+++ b/tests/test_staticmethod_support.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Massachusetts Institute of Technology
+# SPDX-License-Identifier: MIT
 import pytest
 
 from hydra_zen import BuildsFn, builds, instantiate, note_static_method

--- a/tests/test_staticmethod_support.py
+++ b/tests/test_staticmethod_support.py
@@ -64,3 +64,8 @@ def test_local_registry_is_isolated():
 
     assert instantiate(MyBuilds.builds(MyBuilds.note_static_method(BB.f))) == "moo"
     assert num_global_registered == len(BuildsFn._registered_static_methods)
+
+
+def test_validation():
+    with pytest.raises(TypeError):
+        note_static_method(BB)

--- a/tests/test_staticmethod_support.py
+++ b/tests/test_staticmethod_support.py
@@ -1,0 +1,50 @@
+import pytest
+
+from hydra_zen import BuildsFn, builds, instantiate, note_static_method
+
+
+class MyBuilds(BuildsFn):
+    _registered_static_methods = set()
+
+
+class A:
+    @staticmethod
+    def not_noted():
+        ...
+
+    @staticmethod
+    def foo(x: int):
+        return "A.foo" * x
+
+
+class B(A):
+    pass
+
+
+class C(A):
+    @staticmethod
+    def foo(x: int):
+        return "C.foo" * x
+
+
+note_static_method(A.foo)
+note_static_method(C.foo)
+
+
+def test_noting_is_necessary():
+    with pytest.raises(Exception, match="Error locating target"):
+        instantiate(builds(A.not_noted))
+
+
+def test_builds_static_methods():
+    assert instantiate(builds(A.foo, 2)) == "A.foo" * 2
+    assert instantiate(builds(B.foo, 3)) == "A.foo" * 3
+    assert instantiate(builds(C.foo, 4)) == "C.foo" * 4
+
+
+def test_local_registry_is_isolated():
+    assert not MyBuilds._registered_static_methods
+    assert BuildsFn._registered_static_methods
+
+    with pytest.raises(Exception, match="Error locating target"):
+        instantiate(MyBuilds.builds(A.foo))


### PR DESCRIPTION
This PR adds the ability to pass a static method to `builds` by first "noting" the static method via `hydra_zen.note_static_method` or `hydra_zen.BuildsFn.note_static_method`.

To be able to pass a static method to `builds` do:


```python
from hydra_zen import note_static_method, builds

class Foo:
    @staticmethod
    def f():
        return "BARK"

Conf = builds(note_static_method(Foo.f))
```

## Explanation

Consider the class:

```python
class Foo:
    @staticmethod
    def f():
        return "BARK"
```

Suppose that we want to make a config that will instantiate `Foo.f`. If we pass this static method to `builds` there is an issue:

```python
>>> from hydra_zen import builds
>>> builds(Foo.f)._target_
'__main__.f'
```

The correct `_target_` is `"__main__.Foo.f"`. `builds` is unable to find the correct import path for this static method because there is no way to distinguish a static method from a function once that static method has been attached to a class.

We can call

```python
from hydra_zen import note_static_method

note_static_method(Foo.f)
```

and this will register the appropriate import path for `Foo.f` in a registry associated with `BuildsFn`. And now `builds` can resolve the correct path:

```python
>>> builds(Foo.f)._target_
'__main__.Foo.f'
```

## Usage patterns

`note_static_method` need only be called on a given static method once. All of the following patterns are valid

```python
# "noting" prior to passing to `builds`
note_static_method(Foo.f)
builds(Foo.f)
```

```python
# noting inline within `builds`
builds(note_static_method(Foo.f))
```

For Python 3.10+ you can use `note_static_method` as a decorator:

```python
class Foo:
    @note_static_method
    @staticmethod
    def f():
        return "BARK"

builds(Foo.f)
```
(It is also possible to combine `note_static_method` and `staticmethod` into a single decorator[^scary])


## Implementation Details
`note_static_method` registers a tuple of strings to a set held by `BuildsFn`. If you want to isolate the registry that is populated and used by config-creation functions, do:

```python
from hydra_zen import BuildsFn

class MyBuilds(BuildsFn):
    _registered_static_methods = set()

builds = MyBuilds.builds
note_static_method = MyBuilds.note_static_method
```


[^scary]: 
    ```python
    # Merging `note_static_method` and `staticmethod` into one decorator.
    # Use at your own risk!
    from typing import TypeVar

    T = TypeVar("T")

    def st(__x: T) -> T:
        def merged(f):
            return  note_static_method(staticmethod(f))  # type: ignore
        return merged  # type: ignore

    new_static_method = st(staticmethod)

    class BB:
        @new_static_method
        def foo():
            print("meow")

    # `builds(BB.foo)` will "automatically" work now
    ```