### PR TITLE
Add automatic config-creation support for staticmethods

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -64,9 +64,10 @@ For more details and examples, see :pull:`553`.
 
 Improvements
 ------------
-- Adds formal support for Python 3.12. See :pull:`555`
 - :func:`~hydra_zen.BuildsFn` was introduced to permit customizable auto-config and type-refinement support in config-creation functions. See :pull:`553`.
 - :func:`~hydra_zen.builds` and :func:`~hydra_zen.make_custom_builds_fn` now accept a `zen_exclude` field for excluding parameters from auto-population, either by name or by pattern. See :pull:`558`.
+- :func:`~hydra_zen.builds` and :func:`~hydra_zen.just` can now configure static methods. Previously they incorrect import path would be found. See :pull:`566`
+- Adds formal support for Python 3.12. See :pull:`555`
 
 
 .. _v0.11.0:

--- a/tests/test_BuildsFn.py
+++ b/tests/test_BuildsFn.py
@@ -151,12 +151,6 @@ def test_sanitized_type_override():
     assert out.annotation is A
 
 
-def test_get_obj_path_override():
-    with pytest.raises(Exception, match="Error locating target"):
-        assert instantiate(builds(A.static)) == 11
-    assert instantiate(my_builds(A.static)) == 11
-
-
 def test_make_config():
     with pytest.raises(HydraZenUnsupportedPrimitiveError):
         make_config(x=A(1))  # type: ignore

--- a/tests/test_staticmethod_support.py
+++ b/tests/test_staticmethod_support.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023 Massachusetts Institute of Technology
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from hydra_zen import builds, instantiate, just
+
+
+class A1:
+    @staticmethod
+    def foo(x: int):
+        return "A.foo" * x
+
+
+class B1(A1):
+    pass
+
+
+class C1(A1):
+    @staticmethod
+    def foo(x: int):
+        return "C.foo" * x
+
+
+class A2:
+    class B2:
+        @staticmethod
+        def f():
+            return "nested"
+
+
+def test_builds_static_methods():
+    assert instantiate(builds(A1.foo, 2)) == "A.foo" * 2
+    assert instantiate(builds(B1.foo, 3)) == "A.foo" * 3
+    assert instantiate(builds(C1.foo, 4)) == "C.foo" * 4
+
+
+@pytest.mark.parametrize("obj", [C1.foo, A2.B2.f])
+def test_just_static_method(obj):
+    assert instantiate(just(obj)) is obj
+
+
+def some_func():
+    return 22
+
+
+@pytest.mark.parametrize("qualname", ["a", "a.", "1a.a"])
+def test_that_we_dont_look_at_qualname_unless_it_looks_like_a_path(qualname):
+    some_func.__qualname__ = qualname
+    assert instantiate(builds(some_func)) == 22


### PR DESCRIPTION
hydra-zen's config creation functions now have special logic for determining the import-path of a static method. E.g.

Given:

```python
class A:
    @staticmethod
    def f(): return "woo"
```

Before:

```python
>>> from hydra_zen import builds, instantiate
>>> instantiate(builds(A.f))
--------------------------------------------
InstantiationException: Error locating target '__main__.f', set env var HYDRA_FULL_ERROR=1 to see chained exception.
```

After:

```python
>>> from hydra_zen import builds, just, instantiate
>>> instantiate(builds(A.f))                 
woo
>>> instantiate(just(A.f))
<function __main__.A.f()>
```

## Implementation details
It is not possible to distinguish a staticmethod that has already been bound to a class versus a function. That being said, we can inspect the `__qualname__` of a function to see if it is distinct from the function's `__name__` and if it looks something like `SomeClass.some_func`. 

There may be some edge cases / false positives, but the net result of supporting static methods is very much worth it. I am also more willing to include this logic now that people can customize `BuildsFn._get_obj_path` in case, somehow, this change really breaks their application.
