### PR TITLE
Add features to `ZenStore`

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -68,6 +68,7 @@ Improvements
 - :func:`~hydra_zen.builds` and :func:`~hydra_zen.make_custom_builds_fn` now accept a `zen_exclude` field for excluding parameters from auto-population, either by name or by pattern. See :pull:`558`.
 - :func:`~hydra_zen.builds` and :func:`~hydra_zen.just` can now configure static methods. Previously the incorrect ``_target_`` would be resolved. See :pull:`566`
 - Adds formal support for Python 3.12. See :pull:`555`
+- Several new methods were added to :class:`~hydra_zen.ZenStore`, including the abilities to copy, update, and merge stores. As well as remap the groups of a store's entries and delete individual entries. See :pull:`569`
 
 
 .. _v0.11.0:

--- a/docs/source/generated/hydra_zen.ZenStore.rst
+++ b/docs/source/generated/hydra_zen.ZenStore.rst
@@ -16,7 +16,10 @@ hydra\_zen.ZenStore
    .. automethod:: copy_with_mapped_groups
    .. automethod:: get_entry
    .. automethod:: delete_entry
+   .. automethod:: update
+   .. automethod:: merge
    .. automethod:: has_enqueued
+   .. automethod:: enqueue_all
    .. automethod:: __iter__
    .. automethod:: __eq__
    

--- a/docs/source/generated/hydra_zen.ZenStore.rst
+++ b/docs/source/generated/hydra_zen.ZenStore.rst
@@ -12,7 +12,10 @@ hydra\_zen.ZenStore
    .. automethod:: __call__
    .. automethod:: __getitem__
    .. automethod:: add_to_hydra_store
+   .. automethod:: copy
+   .. automethod:: copy_with_mapped_groups
    .. automethod:: get_entry
+   .. automethod:: delete_entry
    .. automethod:: has_enqueued
    .. automethod:: __iter__
    .. automethod:: __eq__

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -1552,13 +1552,12 @@ class ZenStore:
             self._set_entry(entry, overwrite=self._overwrite_ok)
             return cast(Union[F, Self], __target)
 
-    def copy(self: Self, name: Optional[str] = None) -> Self:
+    def copy(self: Self, store_name: Optional[str] = None) -> Self:
         """Returns a copy of the store with the same overridden defaults.
 
         Parameters
         ----------
-        name : str | None, optional (default=None)
-            The name of the new store.
+        store_name : str | None, optional (default=None)
 
         Returns
         -------
@@ -1580,7 +1579,7 @@ class ZenStore:
         """
         cp = deepcopy(self)
 
-        cp.name = name if name is not None else self.name + "_copy"
+        cp.name = store_name if store_name is not None else self.name + "_copy"
         return cp
 
     def copy_with_mapped_groups(
@@ -1588,10 +1587,11 @@ class ZenStore:
         old_group_to_new_group: Union[
             Mapping[GroupName, GroupName], Callable[[GroupName], GroupName]
         ],
+        *,
         store_name: Optional[str] = None,
         overwrite_ok: Optional[bool] = None,
     ) -> Self:
-        """Create a copy of a store, whose group entries have been updated according to the provided mapping.
+        """Create a copy of a store whose entries' groups have been updated according to the provided mapping.
 
         Parameters
         ----------
@@ -1606,12 +1606,12 @@ class ZenStore:
 
         overwrite_ok : Optional[bool]:
             If specified, determines if the mapping can overwrite existing store
-            entries. Otherwise, defers to `self._overwrite_ok`.
+            entries. Otherwise, defers to `ZenStore(overwrite_ok)`.
 
         Returns
         -------
         new_store
-            A copy of `self` with remapped group entries.
+            A copy of `self` with remapped groups.
 
         Examples
         --------

--- a/tests/test_dataclass_semantics.py
+++ b/tests/test_dataclass_semantics.py
@@ -17,6 +17,7 @@ from hydra_zen import (
     just,
     make_config,
     make_custom_builds_fn,
+    to_yaml,
 )
 from hydra_zen.errors import HydraZenDeprecationWarning
 
@@ -451,3 +452,14 @@ def test_module_is_not_specified(Conf):
 )
 def test_modules_is_specified(Conf):
     assert Conf.__module__ == "aaa"
+
+
+@pytest.mark.parametrize(
+    "cfg",
+    [
+        builds(dict, x=1),
+        builds(dict, x=2)(),
+    ],
+)
+def test_builds_is_copyable(cfg):
+    assert to_yaml(cfg) == to_yaml(deepcopy(cfg))

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -932,11 +932,20 @@ def test_update():
     s2({"x": 1}, name="b")
     s2({}, name="c", group="G")  # should be added
 
+    s3 = s1(group="BB")
+    assert s3 == s1
     s1 |= s2
+
     assert len(s1) == 3
     assert s1._queue == {(None, "a"), (None, "b"), ("G", "c")}
     assert s1._internal_repo[None, "b"] is not s2._internal_repo[None, "b"]
     assert s2[None, "b"] == {"x": 1}
+
+    # make sure partiald stores are still connected
+    assert s3 == s1
+    assert ("BB", "foo") not in s1
+    s3({}, name="foo")
+    assert ("BB", "foo") in s1
 
 
 @pytest.mark.usefixtures("clean_store")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -939,6 +939,20 @@ def test_update():
     assert s2[None, "b"] == {"x": 1}
 
 
+@pytest.mark.usefixtures("clean_store")
+def test_update_respects_add_to_hydra_store():
+    s = ZenStore(deferred_hydra_store=True)
+    s({}, name="a")
+    s1 = ZenStore(deferred_hydra_store=True)
+    s2 = ZenStore(deferred_hydra_store=False)
+    s1.update(s)
+    with pytest.raises(KeyError):
+        instantiate_from_repo("a")
+
+    s2.update(s)
+    assert instantiate_from_repo("a") == {}
+
+
 def test_merge():
     s1 = ZenStore()
     s2 = ZenStore()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -827,3 +827,24 @@ def test_del():
     s.delete_entry(None, "b")
     assert not s
     assert not s._queue
+
+
+def test_copy():
+    s = ZenStore(name="s")(group="G")
+    s({}, name="a")
+    s({}, name="b")
+
+    s2 = s.copy()
+    s2({}, name="c")
+
+    assert s != s2
+
+    del s["G", "a"]
+    assert len(s) == 1
+    assert len(s._queue) == 1
+    assert len(s2) == 3
+    assert len(s2._queue) == 3
+    assert ("G", "c") in s2
+
+    assert s2.name == "s_copy"
+    assert s2.copy("moo").name == "moo"


### PR DESCRIPTION
Adds the following methods to `ZenStore`
- `copy`
- `copy_with_mapped_groups`
- `delete_entry` (or, `__delitem__`)
- `enqueue_all`
- `update` (or, `__ior__`)
- `merge` (or, `__or__`)
- `__len__`