### PR TITLE
Add `zen(..., run_in_context: bool)`

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -11,7 +11,7 @@ chronological order. All previous releases should still be available on pip.
 .. _v0.12.0:
 
 ----------------------
-0.12.0rc4 - 2023-11-07
+0.12.0rc5 - 2023-11-12
 ----------------------
 
 

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -67,6 +67,7 @@ Improvements
 - :class:`~hydra_zen.BuildsFn` was introduced to permit customizable auto-config and type-refinement support in config-creation functions. See :pull:`553`.
 - :func:`~hydra_zen.builds` and :func:`~hydra_zen.make_custom_builds_fn` now accept a `zen_exclude` field for excluding parameters from auto-population, either by name or by pattern. See :pull:`558`.
 - :func:`~hydra_zen.builds` and :func:`~hydra_zen.just` can now configure static methods. Previously the incorrect ``_target_`` would be resolved. See :pull:`566`
+- :func:`hydra_zen.zen` now has first class support for running code in an isolated :py:class:`contextvars.Context`. This enables users to safely leverage state via :py:class:`contextvars.ContextVar` in their task functions. See :pull:`583`.
 - Adds formal support for Python 3.12. See :pull:`555`
 - Several new methods were added to :class:`~hydra_zen.ZenStore`, including the abilities to copy, update, and merge stores. As well as remap the groups of a store's entries and delete individual entries. See :pull:`569`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest >= 3.8", "hypothesis >= 6.28.0"]
+test = ["pytest >= 3.8", "hypothesis >= 6.28.0", "pytest-trio >= 0.8.0"]
 pydantic = ["pydantic>=1.8.2,<2.0.0"]
 beartype = ["beartype>=0.8.0"]
 
@@ -104,6 +104,7 @@ exclude_lines = [
 
 [tool.pytest.ini_options]
 xfail_strict = true
+trio_mode = true
 
 
 [tool.pyright]
@@ -149,6 +150,7 @@ deps = setuptools
        pytest
        hypothesis
        pytest-xdist
+       pytest-trio
        tzdata
 commands = pytest tests/ {posargs: -n auto --maxprocesses=4}
 

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -177,7 +177,7 @@ class Zen(Generic[P, R]):
             If `True`, the zen-wrapped function - and the `pre_call` function, if
             specified - is run in a copied :py:class:`contextvars.Context`; i.e.
             changes made to any :py:class:`contextvars.ContextVar` will be isolated to
-            the context of the function.
+            that call of the wrapped function.
 
             `run_in_context` is not supported for async functions.
         """
@@ -583,7 +583,7 @@ def zen(
         If `True`, the zen-wrapped function - and the `pre_call` function, if
         specified - is run in a copied :py:class:`contextvars.Context`; i.e.
         changes made to any :py:class:`contextvars.ContextVar` will be isolated to
-        the context of the call to the wrapped function.
+        that call of the wrapped function.
 
         `run_in_context` is not supported for async functions.
 

--- a/tests/test_zen.py
+++ b/tests/test_zen.py
@@ -625,3 +625,10 @@ zpikl = zen(pikl)
 def test_pickle_compatible():
     loaded = pickle.loads(pickle.dumps(zpikl))
     assert loaded({"x": 3}) == pikl(3)
+
+
+async def test_async_compatible():
+    async def foo(x: int):
+        return x
+
+    assert await zen(foo)(dict(x=builds(int, 22))) == 22

--- a/tests/test_zen_context_isolation.py
+++ b/tests/test_zen_context_isolation.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2023 Massachusetts Institute of Technology
+# SPDX-License-Identifier: MIT
+
+import random
+from contextvars import ContextVar
+from typing import Any, Dict, Optional
+
+import pytest
+
+from hydra_zen import zen
+
+config: ContextVar[Optional[Dict[str, Any]]] = ContextVar("config", default=None)
+var: ContextVar[Dict[str, Any]] = ContextVar("var", default=dict())
+
+
+@pytest.fixture(autouse=True)
+def clean_context_vars():
+    assert config.get() is None
+    assert var.get() == {}
+    yield
+    config.set(None)
+    var.set({})
+
+
+@pytest.mark.parametrize(
+    "run_in_context",
+    [
+        True,
+        pytest.param(False, marks=pytest.mark.xfail),
+    ],
+)
+def test_context_isolation(run_in_context: bool):
+    def foo(x: str, zen_cfg):
+        config.set(zen_cfg)
+        conf = var.get().copy()
+        conf[str(random.randint(1, 100))] = random.randint(1, 100)
+        var.set(conf)
+        assert len(conf) == 1
+
+    zfoo = zen(foo, run_in_context=run_in_context)
+
+    for letter in "ab":
+        zfoo(dict(x=letter))
+        assert config.get() is None
+        assert var.get() == dict()
+
+
+async def async_func_run_in_context_not_supported():
+    async def foo():
+        ...
+
+    with pytest.raises(TypeError, match="not supported"):
+        zen(foo, run_in_context=True)
+
+
+@pytest.mark.parametrize(
+    "run_in_context",
+    [
+        True,
+        pytest.param(False, marks=pytest.mark.xfail),
+    ],
+)
+def test_pre_call_shares_context_with_wrapped_func(run_in_context: bool):
+    assert var.get() == {}
+
+    def pre_call(cfg):
+        var.set({"swagger": 22})
+
+    def func():
+        assert var.get() == {"swagger": 22}
+
+    zen(func, pre_call=pre_call, run_in_context=run_in_context)({})
+    assert var.get() == {}

--- a/tests/test_zen_context_isolation.py
+++ b/tests/test_zen_context_isolation.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 import pytest
 
 from hydra_zen import zen
+from hydra_zen.errors import HydraZenValidationError
 
 config: ContextVar[Optional[Dict[str, Any]]] = ContextVar("config", default=None)
 var: ContextVar[Dict[str, Any]] = ContextVar("var", default=dict())
@@ -71,3 +72,16 @@ def test_pre_call_shares_context_with_wrapped_func(run_in_context: bool):
 
     zen(func, pre_call=pre_call, run_in_context=run_in_context)({})
     assert var.get() == {}
+
+
+def test_pre_call_run_in_its_own_context_is_forbidden():
+    def f(x):
+        ...
+
+    with pytest.raises(HydraZenValidationError):
+        zen(f, pre_call=zen(f, run_in_context=True), run_in_context=True)
+
+
+def test_validation():
+    with pytest.raises(TypeError, match="must be type"):
+        zen(lambda x: x, run_in_context=None)  # type: ignore

--- a/tests/test_zen_context_isolation.py
+++ b/tests/test_zen_context_isolation.py
@@ -45,7 +45,7 @@ def test_context_isolation(run_in_context: bool):
         assert var.get() == dict()
 
 
-async def async_func_run_in_context_not_supported():
+def test_async_func_run_in_context_not_supported():
     async def foo():
         ...
 


### PR DESCRIPTION
This PR adds the ability to run a zen-wrapped function in an isolated copy of [`contextvars.Context`](https://docs.python.org/3/library/contextvars.html) by specifying `zen(func, run_in_context=True)`.  I.e. changes made to any `contextvars.ContextVar` will be isolated to that call of the wrapped function.

This permits some powerful patterns where you can make information (e.g., about your run's config) globally available to any function called within the wrapped function - via `contextvars.ContextVar` - without having to worry about state bleeding outside of runs.

Check this out

```python
from contextvars import ContextVar
from dataclasses import dataclass

from hydra_zen import zen


@dataclass
class Config:
    x: int
    experiment_name: str

config_var: ContextVar[Config] = ContextVar("config")


def log(msg):
    # You can call this anywhere in your experiment code
    # and not worry about having to pass your config through
    # to the log function.
    config = config_var.get()
    print(f"{config=}: {msg}")


def setup_context_vars(cfg: Config):
    # This will be our task's pre-call function
    #
    # You can do this in your task function if you'd like, but
    # a `pre_call` function gets easy-access to the full experiment
    # config
    config_var.set(cfg)


def task_function(x: int):
    def func():
        # some function deep within your experiment's code
        log("hello world")

    func()


zen_taskfn = zen(
    task_function,
    pre_call=setup_context_vars,
    run_in_context=True,  # <-- this!
)

zen_taskfn(Config(experiment_name="a", x=1))
zen_taskfn(Config(experiment_name="b", x=2))

try:
    config_var.get()
except LookupError:
    print("Global state is clean :)")
```

Running this produces:

```
config={'x': 1, 'experiment_name': 'a'}: hello world
config={'x': 2, 'experiment_name': 'b'}: hello world
Global state is clean :)
```

This is equivalent to running:

```python
from contextvars import copy_context

zen_taskfn = zen(task_function, pre_call=setup_context_vars)
ctx1 = copy_context()
ctx1.run(zen_taskfn, Config(experiment_name="a", x=1))

ctx2 = copy_context()
ctx2.run(zen_taskfn, Config(experiment_name="b", x=2))
```

This PR useful beyond ergonomics when we want to launch a job via CLI or via `hydra_zen.launch`; here it is not possible to run your task function in an isolated context  using the `contextvars` API without having to write some complex wrappers.

Now, you can simply specify `run_in_context=True` when you wrap your task function and each job will be run - from the CLI - in an isolated context.

```python
# Same `Config`, `task_function`, and `setup_context_vars` as above

if __name__ == "__main__":
    from hydra_zen import store
    store(Config(experiment_name="a", x=1), name="config")
    store.add_to_hydra_store()

    zen_taskfn = zen(
        task_function,
        pre_call=setup_context_vars,
        run_in_context=True,  # <-- this!
    ).hydra_main(config_name="config", version_base="1.3")


    try:
        print("Global state is dirty!!!", config_var.get())
    except LookupError:
        print("Global state is clean :)")
```

We can do a multi-run and not worry about contextvar state bleeding outside of our jobs [^1].

```
$ python my_app.py experiment_name=a,b -m
[2023-11-12 12:56:24,018][HYDRA] Launching 2 jobs locally
[2023-11-12 12:56:24,018][HYDRA]        #0 : experiment_name=a
config={'x': 1, 'experiment_name': 'a'}: hello world
[2023-11-12 12:56:24,136][HYDRA]        #1 : experiment_name=b
config={'x': 1, 'experiment_name': 'b'}: hello world

Global state is clean :)
```

[^1]: That being said, if we were to try to do parallel jobs via threads, we are doomed in a much bigger way because Hydra & omegaconf uses singletons and global state everywhere.