### PR TITLE
Add rudimentary support for pydantic.BaseModel and for pydantic 2.0

### DIFF
--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -138,6 +138,21 @@ jobs:
     - name: Test with tox
       run: tox -e pre-release
 
+  smoke-test-pydantic-v2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox -e pydantic-v2p0-smoketest
+
   check-repo-format:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,14 @@ deps = {[testenv]deps}
        pydantic<2.0.0
        beartype
 
+[testenv:pydantic-v2p0-smoketest]
+description = Ensures that importing pydantic 2.0 doesn't break things
+install_command = pip install --upgrade --upgrade-strategy eager {opts} {packages}
+basepython = python3.10
+deps = {[testenv]deps}
+       pydantic>=2.0.0
+
+
 [testenv:pyright]
 description = Ensure that hydra-zen's source code and test suite scan clean
               under pyright, and that hydra-zen's public API has a 100 prcnt

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1094,8 +1094,6 @@ class BuildsFn(Generic[T]):
 
         # pydantic objects
         pydantic = sys.modules.get("pydantic")
-        if pydantic is not None and pydantic.__version__.startswith("2."):
-            assert False
 
         if pydantic is not None:  # pragma: no cover
             if isinstance(value, pydantic.fields.FieldInfo):

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1094,27 +1094,30 @@ class BuildsFn(Generic[T]):
 
         # pydantic objects
         pydantic = sys.modules.get("pydantic")
-        if pydantic is not None and isinstance(value, pydantic.fields.FieldInfo):
-            _val = (
-                value.default_factory()  # type: ignore
-                if value.default_factory is not None  # type: ignore
-                else value.default  # type: ignore
-            )
-            if isinstance(_val, pydantic.fields.UndefinedType):
-                return MISSING
+        if pydantic is not None:
+            if isinstance(value, pydantic.fields.FieldInfo):
+                _val = (
+                    value.default_factory()  # type: ignore
+                    if value.default_factory is not None  # type: ignore
+                    else value.default  # type: ignore
+                )
+                if isinstance(_val, pydantic.fields.UndefinedType):
+                    return MISSING
 
-            return cls._make_hydra_compatible(
-                _val,
-                allow_zen_conversion=allow_zen_conversion,
-                error_prefix=error_prefix,
-                field_name=field_name,
-                structured_conf_permitted=structured_conf_permitted,
-                convert_dataclass=convert_dataclass,
-                hydra_convert=hydra_convert,
-                hydra_recursive=hydra_recursive,
-            )
+                return cls._make_hydra_compatible(
+                    _val,
+                    allow_zen_conversion=allow_zen_conversion,
+                    error_prefix=error_prefix,
+                    field_name=field_name,
+                    structured_conf_permitted=structured_conf_permitted,
+                    convert_dataclass=convert_dataclass,
+                    hydra_convert=hydra_convert,
+                    hydra_recursive=hydra_recursive,
+                )
+            if isinstance(value, pydantic.BaseModel):
+                return cls.builds(type(value), **value.__dict__)
 
-        if isinstance(value, str):
+        if isinstance(value, str) or isinstance(value, pydantic.AnyUrl):
             # Supports pydantic.AnyURL
             _v = str(value)
             if type(_v) is str:  # pragma: no branch
@@ -2363,7 +2366,7 @@ class BuildsFn(Generic[T]):
             )
 
         _sig_target = cls._get_sig_obj(target)
-
+        pydantic = sys.modules.get("pydantic")
         try:
             # We want to rely on `inspect.signature` logic for raising
             # against an uninspectable sig, before we start inspecting
@@ -2395,7 +2398,14 @@ class BuildsFn(Generic[T]):
             # has inherited from a parent that implements __new__ and
             # the target implements only __init__.
 
-            if _sig_target is not target:
+            if pydantic is not None and (
+                _sig_target is pydantic.BaseModel.__init__
+                # pydantic v2.0
+                or is_dataclass(target)
+                and hasattr(target, "__pydantic_config__")
+            ):
+                pass
+            elif _sig_target is not target:
                 _params = tuple(inspect.signature(_sig_target).parameters.items())
 
                 if (
@@ -2414,19 +2424,26 @@ class BuildsFn(Generic[T]):
 
             target_has_valid_signature: bool = True
 
-        if is_dataclass(target):
+        if is_dataclass(target) or (
+            pydantic is not None
+            and isinstance(target, type)
+            and issubclass(target, pydantic.BaseModel)
+        ):
             # Update `signature_params` so that any param with `default=<factory>`
             # has its default replaced with `<factory>()`
             # If this is a mutable value, `builds` will automatically re-pack
             # it using a default factory
-            _fields = {f.name: f for f in fields(target)}
+            if is_dataclass(target):
+                _fields = {f.name: f for f in fields(target)}
+            else:
+                _fields = target.__fields__  # type: ignore
             _update = {}
             for name, param in signature_params.items():
                 if name not in _fields:
                     # field is InitVar
                     continue
                 f = _fields[name]
-                if f.default_factory is not MISSING:
+                if f.default_factory is not MISSING and f.default_factory is not None:
                     _update[name] = inspect.Parameter(
                         name,
                         param.kind,

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1094,6 +1094,9 @@ class BuildsFn(Generic[T]):
 
         # pydantic objects
         pydantic = sys.modules.get("pydantic")
+        if pydantic is not None and pydantic.__version__.startswith("2."):
+            assert False
+
         if pydantic is not None:  # pragma: no cover
             if isinstance(value, pydantic.fields.FieldInfo):
                 _val = (

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1094,7 +1094,7 @@ class BuildsFn(Generic[T]):
 
         # pydantic objects
         pydantic = sys.modules.get("pydantic")
-        if pydantic is not None:
+        if pydantic is not None:  # pragma: no cover
             if isinstance(value, pydantic.fields.FieldInfo):
                 _val = (
                     value.default_factory()  # type: ignore

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1117,7 +1117,9 @@ class BuildsFn(Generic[T]):
             if isinstance(value, pydantic.BaseModel):
                 return cls.builds(type(value), **value.__dict__)
 
-        if isinstance(value, str) or isinstance(value, pydantic.AnyUrl):
+        if isinstance(value, str) or (
+            pydantic is not None and isinstance(value, pydantic.AnyUrl)
+        ):
             # Supports pydantic.AnyURL
             _v = str(value)
             if type(_v) is str:  # pragma: no branch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2023 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
+import importlib
 import logging
 import os
 import sys
@@ -37,6 +38,12 @@ _installed = {pkg.key for pkg in pkg_resources.working_set}
 for _module_name in OPTIONAL_TEST_DEPENDENCIES:
     if _module_name not in _installed:
         collect_ignore_glob.append(f"*{_module_name}*.py")
+    else:
+        # Some of hydra-zen's logic for supporting 3rd party libraries
+        # depends on that library being imported. We want to ensure that
+        # we import these when they are available so that the full test
+        # suite runs against these paths being enabled
+        importlib.import_module(_module_name)
 
 if sys.version_info > (3, 6):
     collect_ignore_glob.append("*py36*")

--- a/tests/test_third_party/test_using_pydantic.py
+++ b/tests/test_third_party/test_using_pydantic.py
@@ -8,11 +8,11 @@ import pytest
 from hydra.errors import InstantiationException
 from hypothesis import given, settings
 from omegaconf import OmegaConf
-from pydantic import AnyUrl, Field, PositiveFloat
+from pydantic import AnyUrl, BaseModel, Field, PositiveFloat
 from pydantic.dataclasses import dataclass as pyd_dataclass
 from typing_extensions import Literal
 
-from hydra_zen import builds, instantiate, just, to_yaml
+from hydra_zen import builds, get_target, instantiate, just, to_yaml
 from hydra_zen.third_party.pydantic import validates_with_pydantic
 
 parametrize_pydantic_fields = pytest.mark.parametrize(
@@ -86,12 +86,19 @@ class PydanticConf:
     y: int = 2
 
 
+class BaseModelConf(BaseModel):
+    x: Literal[1, 2]
+    y: int = 2
+
+
+@pytest.mark.parametrize("Target", [PydanticConf, BaseModelConf])
 @pytest.mark.parametrize("x", [1, 2])
-def test_documented_example_passes(x):
-    HydraConf = builds(PydanticConf, populate_full_signature=True)
+def test_documented_example_passes(Target, x):
+    HydraConf = builds(Target, populate_full_signature=True)
     conf = instantiate(HydraConf, x=x)
-    assert isinstance(conf, PydanticConf)
-    assert conf == PydanticConf(x=x, y=2)
+    assert isinstance(conf, Target)
+    assert conf == Target(x=x, y=2)
+    assert get_target(HydraConf) is Target
 
 
 @settings(max_examples=20)
@@ -151,13 +158,25 @@ class HasDefaultFactory:
     x: Any = Field(default_factory=lambda: [1 + 2j])
 
 
+class BaseModelHasDefault(BaseModel):
+    x: int = Field(default=1)
+
+
+class BaseModelHasDefaultFactory(BaseModel):
+    x: Any = Field(default_factory=lambda: [1 + 2j])
+
+
 @pytest.mark.parametrize(
     "target,kwargs",
     [
         (HasDefault, {}),
+        (BaseModelHasDefault, {}),
         (HasDefaultFactory, {}),
+        (BaseModelHasDefaultFactory, {}),
         (HasDefault, {"x": 12}),
+        (BaseModelHasDefault, {"x": 12}),
         (HasDefaultFactory, {"x": [[-2j, 1 + 1j]]}),
+        (BaseModelHasDefaultFactory, {"x": [[-2j, 1 + 1j]]}),
     ],
 )
 def test_pop_sig_with_pydantic_Field(target, kwargs):
@@ -178,6 +197,25 @@ class Navbar:
 @given(...)
 def test_nested_dataclasses(via_yaml: bool):
     navbar = Navbar(button=("https://example.com",))  # type: ignore
+    conf = just(navbar)
+    if via_yaml:
+        # ensure serializable
+        assert instantiate(OmegaConf.create(to_yaml(conf))) == navbar
+    else:
+        assert instantiate(conf) == navbar
+
+
+class ModelNavbarButton(BaseModel):
+    href: AnyUrl
+
+
+class ModelNavbar(BaseModel):
+    button: ModelNavbarButton
+
+
+@given(...)
+def test_nested_base_models(via_yaml: bool):
+    navbar = ModelNavbar(button=ModelNavbarButton(href="https://example.com"))  # type: ignore
     conf = just(navbar)
     if via_yaml:
         # ensure serializable

--- a/tests/test_third_party/test_using_v1_pydantic.py
+++ b/tests/test_third_party/test_using_v1_pydantic.py
@@ -4,6 +4,7 @@ import dataclasses
 from typing import Any, List, Optional
 
 import hypothesis.strategies as st
+import pydantic
 import pytest
 from hydra.errors import InstantiationException
 from hypothesis import given, settings
@@ -14,6 +15,9 @@ from typing_extensions import Literal
 
 from hydra_zen import builds, get_target, instantiate, just, to_yaml
 from hydra_zen.third_party.pydantic import validates_with_pydantic
+
+if pydantic.__version__.startswith("2."):
+    pytest.skip("These tests are for pydantic v1")
 
 parametrize_pydantic_fields = pytest.mark.parametrize(
     "custom_type, good_val, bad_val",

--- a/tests/test_third_party/test_using_v1_pydantic.py
+++ b/tests/test_third_party/test_using_v1_pydantic.py
@@ -17,7 +17,7 @@ from hydra_zen import builds, get_target, instantiate, just, to_yaml
 from hydra_zen.third_party.pydantic import validates_with_pydantic
 
 if pydantic.__version__.startswith("2."):
-    pytest.skip("These tests are for pydantic v1")
+    pytest.skip("These tests are for pydantic v1", allow_module_level=True)
 
 parametrize_pydantic_fields = pytest.mark.parametrize(
     "custom_type, good_val, bad_val",


### PR DESCRIPTION
- Closes https://github.com/mit-ll-responsible-ai/hydra-zen/issues/585
- Adds smoke test for pydantic v2 to make sure merely importing pydantic v2 w/ hydra-zen doesn't break things