### PR TITLE
fix store autoconfig issue

### DIFF
--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1108,7 +1108,7 @@ class BuildsFn(Generic[T]):
                 )
 
                 if _check_instance(
-                    "UndefinedType", module="pydantic.fields", value=value
+                    "UndefinedType", module="pydantic.fields", value=_val
                 ):
                     return MISSING
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -175,6 +175,10 @@ del _lru_cache_type
 del _builtin_function_or_method_type
 
 
+class _Null:
+    ...
+
+
 def _retain_type_info(type_: type, value: Any, hydra_recursive: Optional[bool]):
     # OmegaConf's type-checking occurs before instantiation occurs.
     # This means that, e.g., passing `Builds[int]` to a field `x: int`

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -564,6 +564,10 @@ _is_torch_optim_required = functools.partial(
     _check_instance, "required", module="torch.optim.optimizer"
 )
 
+_is_pydantic_BaseModel = functools.partial(
+    _check_instance, "BaseModel", module="pydantic"
+)
+
 
 def _check_for_dynamically_defined_dataclass_type(target_path: str, value: Any) -> None:
     if target_path.startswith("types."):
@@ -1100,7 +1104,7 @@ class BuildsFn(Generic[T]):
         pydantic = sys.modules.get("pydantic")
 
         if pydantic is not None:  # pragma: no cover
-            if isinstance(value, pydantic.fields.FieldInfo):
+            if _check_instance("FieldInfo", module="pydantic.fields", value=value):
                 _val = (
                     value.default_factory()  # type: ignore
                     if value.default_factory is not None  # type: ignore
@@ -1119,11 +1123,11 @@ class BuildsFn(Generic[T]):
                     hydra_convert=hydra_convert,
                     hydra_recursive=hydra_recursive,
                 )
-            if isinstance(value, pydantic.BaseModel):
+            if _is_pydantic_BaseModel(value=value):
                 return cls.builds(type(value), **value.__dict__)
 
-        if isinstance(value, str) or (
-            pydantic is not None and isinstance(value, pydantic.AnyUrl)
+        if isinstance(value, str) or _check_instance(
+            "AnyUrl", module="pydantic", value=value
         ):
             # Supports pydantic.AnyURL
             _v = str(value)

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -175,10 +175,6 @@ del _lru_cache_type
 del _builtin_function_or_method_type
 
 
-class _Null:
-    ...
-
-
 def _retain_type_info(type_: type, value: Any, hydra_recursive: Optional[bool]):
     # OmegaConf's type-checking occurs before instantiation occurs.
     # This means that, e.g., passing `Builds[int]` to a field `x: int`

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1106,7 +1106,10 @@ class BuildsFn(Generic[T]):
                     if value.default_factory is not None  # type: ignore
                     else value.default  # type: ignore
                 )
-                if isinstance(_val, pydantic.fields.UndefinedType):
+
+                if _check_instance(
+                    "UndefinedType", module="pydantic.fields", value=value
+                ):
                     return MISSING
 
                 return cls._make_hydra_compatible(

--- a/tests/test_BuildsFn.py
+++ b/tests/test_BuildsFn.py
@@ -167,7 +167,7 @@ def test_zen_field():
 
 def test_default_to_config():
     store = ZenStore("my store")(
-        to_config=partial(default_to_config, BuildsFn=MyBuildsFn)
+        to_config=partial(default_to_config, CustomBuildsFn=MyBuildsFn)
     )
     store(A, x=A(x=2), name="blah")
     assert instantiate(store[None, "blah"]) == A(x=A(x=2))

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -24,6 +24,7 @@ from hydra_zen import (
     just,
     make_config,
     store as default_store,
+    to_yaml,
 )
 from tests.custom_strategies import new_stores, store_entries
 
@@ -982,3 +983,11 @@ def test_merge():
     assert s3._queue == {(None, "a"), (None, "b"), (None, "c")}
     assert s3._internal_repo[None, "a"] is not s1._internal_repo[None, "a"]
     assert s3._internal_repo[None, "b"] is not s2._internal_repo[None, "b"]
+
+
+def test_disable_pop_sig_autoconfig():
+    s = ZenStore()
+    s(ZenStore, populate_full_signature=False, name="s")
+    assert len(to_yaml(s).splitlines()) == 1
+    sout = instantiate(s[None, "s"])
+    assert isinstance(sout, ZenStore)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -988,6 +988,7 @@ def test_merge():
 def test_disable_pop_sig_autoconfig():
     s = ZenStore()
     s(ZenStore, populate_full_signature=False, name="s")
-    assert len(to_yaml(s).splitlines()) == 1
+    config = s[None, "s"]
+    assert len(to_yaml(config).splitlines()) == 1
     sout = instantiate(s[None, "s"])
     assert isinstance(sout, ZenStore)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -992,3 +992,10 @@ def test_disable_pop_sig_autoconfig():
     assert len(to_yaml(config).splitlines()) == 1
     sout = instantiate(s[None, "s"])
     assert isinstance(sout, ZenStore)
+
+    s2 = ZenStore()
+    s2(ZenStore, name="s")
+    config2 = s2[None, "s"]
+    assert len(to_yaml(config2).splitlines()) > 1
+    sout2 = instantiate(s2[None, "s"])
+    assert isinstance(sout2, ZenStore)

--- a/tests/test_third_party/test_using_v1_pydantic.py
+++ b/tests/test_third_party/test_using_v1_pydantic.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
 import dataclasses
+import sys
 from typing import Any, List, Optional
 
 import hypothesis.strategies as st
@@ -26,6 +27,12 @@ parametrize_pydantic_fields = pytest.mark.parametrize(
         (AnyUrl, "http://www.pythonlikeyoumeanit.com", "hello"),
     ],
 )
+
+
+def test_BaseModel():
+    _pydantic = sys.modules.get("pydantic")
+    assert _pydantic is not None
+    assert _pydantic.BaseModel is BaseModel
 
 
 @parametrize_pydantic_fields


### PR DESCRIPTION
Fixes bug introduced by #562 where users could no longer specify `populate_full_signature` in the config store's kw

Also make calls to pydantic safer across versions