### PR TITLE
Support parameter-indices in zen-exclude

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -65,7 +65,7 @@ For more details and examples, see :pull:`553`.
 Improvements
 ------------
 - :class:`~hydra_zen.BuildsFn` was introduced to permit customizable auto-config and type-refinement support in config-creation functions. See :pull:`553`.
-- :func:`~hydra_zen.builds` and :func:`~hydra_zen.make_custom_builds_fn` now accept a `zen_exclude` field for excluding parameters from auto-population, either by name or by pattern. See :pull:`558`.
+- :func:`~hydra_zen.builds` and :func:`~hydra_zen.make_custom_builds_fn` now accept a `zen_exclude` field for excluding parameters from auto-population, either by name, position-index, or by pattern. See :pull:`558`.
 - :func:`~hydra_zen.builds` and :func:`~hydra_zen.just` can now configure static methods. Previously the incorrect ``_target_`` would be resolved. See :pull:`566`
 - :func:`hydra_zen.zen` now has first class support for running code in an isolated :py:class:`contextvars.Context`. This enables users to safely leverage state via :py:class:`contextvars.ContextVar` in their task functions. See :pull:`583`.
 - Adds formal support for Python 3.12. See :pull:`555`

--- a/tests/test_zen_exclude.py
+++ b/tests/test_zen_exclude.py
@@ -7,7 +7,7 @@ from hydra_zen import builds, instantiate, make_custom_builds_fn
 
 @pytest.mark.parametrize("bad_exclude", ["x", [["x"]]])
 def test_validate_exclude(bad_exclude):
-    with pytest.raises(TypeError, match="must only contain"):
+    with pytest.raises(TypeError):
         builds(dict, zen_exclude=bad_exclude)
 
 

--- a/tests/test_zen_exclude.py
+++ b/tests/test_zen_exclude.py
@@ -5,9 +5,9 @@ import pytest
 from hydra_zen import builds, instantiate, make_custom_builds_fn
 
 
-@pytest.mark.parametrize("bad_exclude", [1, "x"])
+@pytest.mark.parametrize("bad_exclude", ["x", [["x"]]])
 def test_validate_exclude(bad_exclude):
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="must only contain"):
         builds(dict, zen_exclude=bad_exclude)
 
 
@@ -17,7 +17,16 @@ def foo(x=1, _y=2, _z=3):
 
 @pytest.mark.parametrize("partial", [True, False])
 @pytest.mark.parametrize("custom_builds", [True, False])
-@pytest.mark.parametrize("exclude", [["_y", "_z"], lambda x: x.startswith("_")])
+@pytest.mark.parametrize(
+    "exclude",
+    [
+        ["_y", "_z"],
+        lambda x: x.startswith("_"),
+        [1, 2],
+        ["_y", -1],
+        ["_y", 2],
+    ],
+)
 def test_exclude_named(partial: bool, custom_builds: bool, exclude):
     if custom_builds:
         b = make_custom_builds_fn(


### PR DESCRIPTION
E.g.

```python

>>> from hydra_zen import builds, to_yaml
>>> def pyaml(x):
...     # for pretty printing configs
...     print(to_yaml(x))

>>> def bar(x: bool, y: str = 'foo'): return x, y

>>> Conf2 = builds(bar, populate_full_signature=True, zen_exclude=[-1]) # exclude last param
>>> pyaml(Conf2)
_target_: __main__.bar
x: ???
```