### PR TITLE
Improve `kwargs_of` annotations

### DIFF
--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -45,6 +45,7 @@ from typing import (
 from omegaconf import DictConfig, ListConfig
 from typing_extensions import (
     Annotated,
+    Concatenate,
     Final,
     Literal,
     ParamSpec,
@@ -3282,6 +3283,53 @@ class BuildsFn(Generic[T]):
             )
 
         return cast(Type[DataClass], out)
+
+    # cover zen_exclude=() -> (1, 2, 3)
+    @overload
+    @classmethod
+    def kwargs_of(
+        cls,
+        __hydra_target: Callable[P, Any],
+        *,
+        zen_dataclass: Optional[DataclassOptions] = ...,
+        zen_exclude: Tuple[()],
+    ) -> Type[BuildsWithSig[Type[Dict[str, Any]], P]]:
+        ...
+
+    @overload
+    @classmethod
+    def kwargs_of(
+        cls,
+        __hydra_target: Callable[Concatenate[Any, P], Any],
+        *,
+        zen_dataclass: Optional[DataclassOptions] = ...,
+        zen_exclude: Tuple[Literal[0]],
+    ) -> Type[BuildsWithSig[Type[Dict[str, Any]], P]]:
+        ...
+
+    @overload
+    @classmethod
+    def kwargs_of(
+        cls,
+        __hydra_target: Callable[Concatenate[Any, Any, P], Any],
+        *,
+        zen_dataclass: Optional[DataclassOptions] = ...,
+        zen_exclude: Tuple[Literal[0], Literal[1]],
+    ) -> Type[BuildsWithSig[Type[Dict[str, Any]], P]]:
+        ...
+
+    @overload
+    @classmethod
+    def kwargs_of(
+        cls,
+        __hydra_target: Callable[Concatenate[Any, Any, Any, P], Any],
+        *,
+        zen_dataclass: Optional[DataclassOptions] = ...,
+        zen_exclude: Tuple[Literal[0], Literal[1], Literal[2]],
+    ) -> Type[BuildsWithSig[Type[Dict[str, Any]], P]]:
+        ...
+
+    # no zen-exclude
 
     @overload
     @classmethod

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -1507,6 +1507,44 @@ def check_kwargs_of():
 
     Conf3 = kwargs_of(foo, x=NotSupported())  # type: ignore
 
+    def bar(x: int, y: str, z: bool):
+        ...
+
+    reveal_type(
+        kwargs_of(bar, zen_exclude=()),
+        expected_text="type[BuildsWithSig[type[Dict[str, Any]], (x: int, y: str, z: bool)]]",
+    )
+
+    reveal_type(
+        kwargs_of(bar, zen_exclude=(0,)),
+        expected_text="type[BuildsWithSig[type[Dict[str, Any]], (y: str, z: bool)]]",
+    )
+
+    reveal_type(
+        kwargs_of(bar, zen_exclude=(0, 1)),
+        expected_text="type[BuildsWithSig[type[Dict[str, Any]], (z: bool)]]",
+    )
+
+    reveal_type(
+        kwargs_of(bar, zen_exclude=(0, 1, 2)),
+        expected_text="type[BuildsWithSig[type[Dict[str, Any]], ()]]",
+    )
+
+    reveal_type(
+        kwargs_of(bar, zen_exclude=(0, 1, 2, 3)),
+        expected_text="type[Builds[type[Dict[str, Any]]]]",
+    )
+
+    reveal_type(
+        kwargs_of(bar, zen_exclude=(1,)),
+        expected_text="type[Builds[type[Dict[str, Any]]]]",
+    )
+
+    reveal_type(
+        kwargs_of(bar, zen_exclude=[0]),
+        expected_text="type[Builds[type[Dict[str, Any]]]]",
+    )
+
 
 def check_CustomConfigType():
     from hydra_zen import BuildsFn

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -1545,6 +1545,11 @@ def check_kwargs_of():
         expected_text="type[Builds[type[Dict[str, Any]]]]",
     )
 
+    reveal_type(
+        kwargs_of(bar, x=1, zen_exclude=(0,)),
+        expected_text="type[Builds[type[Dict[str, Any]]]]",
+    )
+
 
 def check_CustomConfigType():
     from hydra_zen import BuildsFn


### PR DESCRIPTION
E.g.

```python
def bar(x: int, y: str, z: bool):
    ...

kwargs_of(bar, zen_exclude=(0,))  # pyright sees: type[BuildsWithSig[type[Dict[str, Any]], (y: str, z: bool)]]
```