### PR TITLE
Update `CustomConfigType` to support `Partial[T]`

### DIFF
--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -701,6 +701,7 @@ class BuildsFn(Generic[T]):
 
        from typing import Any
        from hydra_zen import BuildsFn
+       from hydra_zen.typing import CustomConfigType, HydraSupportedType
 
        class CustomBuilds(BuildsFn[CustomConfigType[Quaternion]]):
            @classmethod

--- a/src/hydra_zen/typing/_implementations.py
+++ b/src/hydra_zen/typing/_implementations.py
@@ -247,6 +247,7 @@ CustomConfigType: TypeAlias = Union[
     Tuple["CustomConfigType[T2]", ...],
     Sequence["CustomConfigType[T2]"],
     Mapping[Any, "CustomConfigType[T2]"],
+    Partial["CustomConfigType[T2]"],
 ]
 """The type `CustomConfigType[MyType]` describes: `MyType`, all hydra-zen config-compatible types, and all hydra-zen compatible containers containing said types.
 

--- a/tests/annotations/declarations.py
+++ b/tests/annotations/declarations.py
@@ -56,6 +56,7 @@ from hydra_zen.structured_configs._implementations import (
 )
 from hydra_zen.typing import (
     Builds,
+    CustomConfigType,
     HydraPartialBuilds,
     Partial,
     PartialBuilds,
@@ -1511,9 +1512,6 @@ def check_kwargs_of():
 
 
 def check_CustomConfigType():
-    from hydra_zen import BuildsFn
-    from hydra_zen.typing import CustomConfigType
-
     class MyType: ...
 
     class BadType: ...
@@ -1522,6 +1520,9 @@ def check_CustomConfigType():
 
     builds = MyBuilds.builds
 
-    builds(dict, x=MyType(), y=[1, MyType()])
+    builds(dict, x=MyType(), y=[1, MyType()], z={"a": MyType()})
+    builds(dict, x=partial(MyType))
     builds(dict, x=BadType(), y=[1, MyType()])  # type: ignore
     builds(dict, x=MyType(), y=[1, BadType()])  # type: ignore
+    builds(dict, z={"a": BadType()})  # type: ignore
+    builds(dict, x=partial(BadType))  # type: ignore

--- a/tests/test_BuildsFn.py
+++ b/tests/test_BuildsFn.py
@@ -3,7 +3,7 @@
 from collections import deque
 from functools import partial
 from inspect import signature
-from typing import Any, List, Union
+from typing import Any, Union
 
 import pytest
 from typing_extensions import Literal
@@ -20,7 +20,7 @@ from hydra_zen import (
     to_yaml,
 )
 from hydra_zen.errors import HydraZenUnsupportedPrimitiveError
-from hydra_zen.typing import CustomConfigType, DataclassOptions, SupportedPrimitive
+from hydra_zen.typing import CustomConfigType, DataclassOptions
 from hydra_zen.typing._implementations import DataclassOptions
 from hydra_zen.wrapper import default_to_config
 
@@ -43,9 +43,7 @@ class A:
 class B: ...
 
 
-class MyBuildsFn(
-    BuildsFn[Union[SupportedPrimitive, A, List[Union[SupportedPrimitive, A]]]]
-):
+class MyBuildsFn(BuildsFn[CustomConfigType[A]]):
     @classmethod
     def _make_hydra_compatible(
         cls,
@@ -201,3 +199,9 @@ def test_parameterization_example():
 
     builds = MyBuilds.builds
     assert instantiate(builds(dict, x=1)) == dict(x=1)
+
+
+def test_partial_supported():
+    Cfg = MyBuildsFn.builds(dict, x=partial(A, x=2))
+    to_yaml(Cfg)
+    assert instantiate(Cfg)["x"]() == A(x=2)


### PR DESCRIPTION
partials are supported in `CustomConfigType` but we missed this case, leading to a false positive in type checking.