### PR TITLE
CI-only: Pin importlib-resources<6.2

### DIFF
--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12]
       fail-fast: false
 
     steps:
@@ -122,7 +122,21 @@ jobs:
     - name: Test with tox
       run: tox -e min-deps
 
-
+  python-38:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox -e v38
+      
   test-against-pre-releases-of-dependencies:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,11 @@ deps = setuptools
        tzdata
 commands = pytest tests/ {posargs: -n auto --maxprocesses=4}
 
+[testenv:py38]
+{[testenv]deps}
+       importlib-resources<6.2.0
+basepython = python3.8
+
 
 [testenv:min-deps]
 description = Runs test suite against minimum supported versions of dependencies.
@@ -161,6 +166,7 @@ deps = hydra-core==1.2.0
        omegaconf==2.2.1
        typing-extensions==4.1.0
        {[testenv]deps}
+       importlib-resources<6.2.0
 basepython = python3.8
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ deps = setuptools
        tzdata
 commands = pytest tests/ {posargs: -n auto --maxprocesses=4}
 
-[testenv:py38]
+[testenv:v38]
 deps = {[testenv]deps}
        importlib-resources<6.2.0
 basepython = python3.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ deps = setuptools
 commands = pytest tests/ {posargs: -n auto --maxprocesses=4}
 
 [testenv:py38]
-{[testenv]deps}
+deps = {[testenv]deps}
        importlib-resources<6.2.0
 basepython = python3.8
 


### PR DESCRIPTION
https://github.com/python/importlib_resources/issues/298 is causing issues in Hydra for Python 3.8. It is most appropriate for Hydra to handle the pinning here as it is the one introducing the dependency. So we are just doing a CI-level pin so that we can keep testing vs Python 3.8.