### PR TITLE
Update _get_obj_path to support ClassA.ClassB

### DIFF
--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -992,7 +992,9 @@ class BuildsFn(Generic[T]):
                 and "." in qualname
                 and all(x.isidentifier() for x in qualname.split("."))
             ):
-                # this looks like it is a staticmethod. E.g. qualname: SomeClass.func
+                # This looks like it is a staticmethod or a class defined within
+                # a class namespace. E.g. qualname: SomeClass.func or
+                # SomeClass.NestedClass
                 return f"{module}.{qualname}"
             return f"{module}.{name}"
         else:

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1051,7 +1051,7 @@ class BuildsFn(Generic[T]):
     @classmethod
     def _make_hydra_compatible(
         cls,
-        value: Any,
+        value: object,
         *,
         allow_zen_conversion: bool = True,
         error_prefix: str = "",
@@ -1081,7 +1081,7 @@ class BuildsFn(Generic[T]):
         # We check exhaustively for all Hydra-supported primitives below but seek to
         # speedup checks for common types here.
         if value is None or type(value) in {str, int, bool, float}:
-            return value
+            return cast(Union[None, str, int, float, bool], value)
 
         # non-str collection
         if hasattr(value, "__iter__"):
@@ -1205,7 +1205,7 @@ class BuildsFn(Generic[T]):
                 or isinstance(resolved_value, (Enum, ListConfig, DictConfig))
             )
         ):
-            return resolved_value
+            return resolved_value  # type: ignore
 
         # pydantic objects
         pydantic = sys.modules.get("pydantic")

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -948,6 +948,20 @@ class BuildsFn(Generic[T]):
 
         Override this to control how `builds` determines the _target_ field
         in the configs that it produces."""
+
+        def patched_safe_name(obj: Any, repr_allowed: bool = True):
+            if not hasattr(obj, "__qualname__"):
+                return _utils.safe_name(obj, repr_allowed=repr_allowed)
+
+            name = _utils.safe_name(obj, repr_allowed=repr_allowed)
+            qualname = obj.__qualname__
+            assert isinstance(qualname, str)
+
+            if name != qualname and qualname.endswith("." + name):
+                return qualname
+
+            return name
+
         name = _utils.safe_name(target, repr_allowed=False)
 
         if name == _utils.UNKNOWN_NAME:
@@ -986,7 +1000,7 @@ class BuildsFn(Generic[T]):
 
         if not _utils.is_classmethod(target):
             if (
-                inspect.isfunction(target)
+                (inspect.isfunction(target) or isinstance(target, type))
                 and isinstance(qualname, str)
                 and "." in qualname
                 and all(x.isidentifier() for x in qualname.split("."))

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -949,19 +949,6 @@ class BuildsFn(Generic[T]):
         Override this to control how `builds` determines the _target_ field
         in the configs that it produces."""
 
-        def patched_safe_name(obj: Any, repr_allowed: bool = True):
-            if not hasattr(obj, "__qualname__"):
-                return _utils.safe_name(obj, repr_allowed=repr_allowed)
-
-            name = _utils.safe_name(obj, repr_allowed=repr_allowed)
-            qualname = obj.__qualname__
-            assert isinstance(qualname, str)
-
-            if name != qualname and qualname.endswith("." + name):
-                return qualname
-
-            return name
-
         name = _utils.safe_name(target, repr_allowed=False)
 
         if name == _utils.UNKNOWN_NAME:


### PR DESCRIPTION
Closes #705

Given:

```python
from hydra_zen import builds, instantiate

class Outer:
    class Inner:
        pass

cfg = builds(Outer.Inner)
```

Before:

```python
>>> instantiate(cfg)
InstantiationException: Error locating target '__main__.Inner'
```

After:

```python
>>> instantiate(cfg)
Outer.Inner()
```