### PR TITLE
Fixed builds auto-populating example doc

### DIFF
--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -1926,8 +1926,8 @@ class BuildsFn(Generic[T]):
 
         >>> def bar(x: bool, y: str = 'foo'): return x, y
 
-        The following config will have a signature that matches ``f``; the
-        annotations and default values of the parameters of ``f`` are explicitly
+        The following config will have a signature that matches ``bar``; the
+        annotations and default values of the parameters of ``bar`` are explicitly
         incorporated into the config.
 
         >>> # signature: `Builds_bar(x: bool, y: str = 'foo')`


### PR DESCRIPTION
I assume `f` is supposed to be `bar` in this example?