### PR TITLE
Refactor `_StoreCallSig` to inline form

### DIFF
--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -975,7 +975,7 @@ _StoreCallSig = TypedDict("_StoreCallSig", {
     "name": Union[NodeName, Callable[[Any], NodeName]],
     "group": Union[GroupName, Callable[[Any], GroupName]],
     "package": Optional[Union[str, Callable[[Any], str]]],
-    "provider": Optional[str]),
+    "provider": Optional[str],
     "__kw": dict[str, Any],  # kwargs passed to to_config
     "to_config": Callable[[Any], Any],
 })

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -967,18 +967,18 @@ def get_name(target: _HasName) -> str:
     return name
 
 
-class _StoreCallSig(TypedDict):
-    """Arguments for ZenStore.__call__
-
-    This default dict enables us to easily update/merge the default arguments for a
-    specific ZenStore instance, in support of self-partialing behavior."""
-
-    name: Union[NodeName, Callable[[Any], NodeName]]
-    group: Union[GroupName, Callable[[Any], GroupName]]
-    package: Optional[Union[str, Callable[[Any], str]]]
-    provider: Optional[str]
-    __kw: dict[str, Any]  # kwargs passed to to_config
-    to_config: Callable[[Any], Any]
+# Arguments for ZenStore.__call__
+#
+# This default dict enables us to easily update/merge the default arguments for a
+# specific ZenStore instance, in support of self-partialing behavior.
+_StoreCallSig = TypedDict("_StoreCallSig", [
+    ("name", Union[NodeName, Callable[[Any], NodeName]]),
+    ("group", Union[GroupName, Callable[[Any], GroupName]]),
+    ("package", Optional[Union[str, Callable[[Any], str]]]),
+    ("provider", Optional[str]),
+    ("__kw", dict[str, Any]),  # kwargs passed to to_config
+    ("to_config", Callable[[Any], Any]),
+])
 
 
 # TODO: make frozen dict

--- a/src/hydra_zen/wrapper/_implementations.py
+++ b/src/hydra_zen/wrapper/_implementations.py
@@ -971,14 +971,14 @@ def get_name(target: _HasName) -> str:
 #
 # This default dict enables us to easily update/merge the default arguments for a
 # specific ZenStore instance, in support of self-partialing behavior.
-_StoreCallSig = TypedDict("_StoreCallSig", [
-    ("name", Union[NodeName, Callable[[Any], NodeName]]),
-    ("group", Union[GroupName, Callable[[Any], GroupName]]),
-    ("package", Optional[Union[str, Callable[[Any], str]]]),
-    ("provider", Optional[str]),
-    ("__kw", dict[str, Any]),  # kwargs passed to to_config
-    ("to_config", Callable[[Any], Any]),
-])
+_StoreCallSig = TypedDict("_StoreCallSig", {
+    "name": Union[NodeName, Callable[[Any], NodeName]],
+    "group": Union[GroupName, Callable[[Any], GroupName]],
+    "package": Optional[Union[str, Callable[[Any], str]]],
+    "provider": Optional[str]),
+    "__kw": dict[str, Any],  # kwargs passed to to_config
+    "to_config": Callable[[Any], Any],
+})
 
 
 # TODO: make frozen dict


### PR DESCRIPTION
While working on https://github.com/python/mypy/pull/16715 I've noticed that `_StoreCallSig` uses class form, while having `__kw` field. This field will be mangled. This is not something typing users want. See https://github.com/python/cpython/issues/129567