### PR TITLE
Improve `_target_wrapper_` behavior when doing partial instantiation

### DIFF
--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -94,7 +94,7 @@ def _call_target(
 
     if _partial_:
         try:
-            return partial_with_wrapper[Any](
+            return partial_with_wrapper[Any](  # type: ignore
                 cast(Wrappers, (target_wrapper,)), orig_target, *args, **kwargs
             )
         except Exception as e:

--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -62,7 +62,7 @@ def _call_target(
     from hydra.errors import InstantiationException
     from omegaconf import OmegaConf
 
-    from hydra_zen.funcs import partial_with_wrapper, zen_processing
+    from hydra_zen.funcs import Wrappers, partial_with_wrapper, zen_processing
 
     try:
         args, kwargs = _extract_pos_args(args, kwargs)
@@ -94,7 +94,9 @@ def _call_target(
 
     if _partial_:
         try:
-            return partial_with_wrapper((target_wrapper,), orig_target, *args, **kwargs)
+            return partial_with_wrapper(
+                cast(Wrappers, (target_wrapper,)), orig_target, *args, **kwargs
+            )
         except Exception as e:
             msg = (
                 f"Error in creating partial({_convert_target_to_string(orig_target)}, ...) object:"

--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -94,8 +94,10 @@ def _call_target(
 
     if _partial_:
         try:
-            return partial_with_wrapper(
-                cast(Wrappers, (target_wrapper,)), orig_target, *args, **kwargs
+            return (
+                partial_with_wrapper[Any](
+                    cast(Wrappers, (target_wrapper,)), orig_target, *args, **kwargs
+                ),
             )
         except Exception as e:
             msg = (

--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -94,7 +94,7 @@ def _call_target(
 
     if _partial_:
         try:
-            return partial_with_wrapper[Any](  # type: ignore
+            return partial_with_wrapper[Any](
                 cast(Wrappers, (target_wrapper,)), orig_target, *args, **kwargs
             )
         except Exception as e:

--- a/src/hydra_zen/_hydra_overloads.py
+++ b/src/hydra_zen/_hydra_overloads.py
@@ -94,10 +94,8 @@ def _call_target(
 
     if _partial_:
         try:
-            return (
-                partial_with_wrapper[Any](
-                    cast(Wrappers, (target_wrapper,)), orig_target, *args, **kwargs
-                ),
+            return partial_with_wrapper[Any](
+                cast(Wrappers, (target_wrapper,)), orig_target, *args, **kwargs
             )
         except Exception as e:
             msg = (

--- a/src/hydra_zen/funcs.py
+++ b/src/hydra_zen/funcs.py
@@ -45,7 +45,7 @@ class partial_with_wrapper(partial[T]):
         func: Callable[..., T],
         *args: Any,
         **keywords: Any,
-    ):
+    ) -> "partial_with_wrapper":
         if isinstance(func, partial_with_wrapper):
             # unwrap the partial_with_wrapper
             wrappers = func.wrappers + wrappers
@@ -65,7 +65,7 @@ class partial_with_wrapper(partial[T]):
 
         return func(*self.args, *args, **keywords)
 
-    def __reduce__(self):
+    def __reduce__(self) -> _tp.Any:
         return (
             type(self),
             (

--- a/src/hydra_zen/funcs.py
+++ b/src/hydra_zen/funcs.py
@@ -45,7 +45,7 @@ class partial_with_wrapper(partial[T]):
         func: Callable[..., T],
         *args: Any,
         **keywords: Any,
-    ) -> "partial_with_wrapper":
+    ) -> "partial_with_wrapper[T]":
         if isinstance(func, partial_with_wrapper):
             # unwrap the partial_with_wrapper
             wrappers = func.wrappers + wrappers

--- a/src/hydra_zen/funcs.py
+++ b/src/hydra_zen/funcs.py
@@ -7,9 +7,12 @@ that these functions have a legible module-path when they appear in configuratio
 """
 import functools as _functools
 import typing as _tp
+from functools import partial
+from typing import Any, Callable, TypeVar
 
 from hydra._internal import utils as _hydra_internal_utils
 from hydra.utils import log as _log
+from typing_extensions import TypeAlias
 
 from hydra_zen.structured_configs._utils import (
     is_interpolated_string as _is_interpolated_string,
@@ -22,6 +25,80 @@ _T = _tp.TypeVar("_T")
 
 _Wrapper = _tp.Callable[[_tp.Callable[..., _tp.Any]], _tp.Callable[..., _tp.Any]]
 _WrapperConf = _tp.Union[str, _Wrapper]
+
+
+T = TypeVar("T")
+F = TypeVar("F", bound=Callable[..., Any])
+
+Wrappers: TypeAlias = tuple[Callable[[Callable[..., Any]], Callable[..., Any]], ...]
+
+
+class partial_with_wrapper(partial[T]):
+    """`partial` where a wrapper's application is deferred until the call."""
+
+    __slots__ = "wrappers"
+    wrappers: Wrappers
+
+    def __new__(
+        cls,
+        wrappers: Wrappers,
+        func: Callable[..., T],
+        *args: Any,
+        **keywords: Any,
+    ):
+        if isinstance(func, partial_with_wrapper):
+            # unwrap the partial_with_wrapper
+            wrappers = func.wrappers + wrappers
+            keywords = {**func.keywords, **keywords}
+            args = func.args + args
+            func = func.func
+
+        self = super().__new__(cls, func, *args, **keywords)
+        self.wrappers = wrappers
+        return self
+
+    def __call__(self, /, *args: Any, **keywords: Any) -> T:
+        keywords = {**self.keywords, **keywords}
+        func = self.func
+        for wrapper in self.wrappers:
+            func = wrapper(func)
+
+        return func(*self.args, *args, **keywords)
+
+    def __reduce__(self):
+        return (
+            type(self),
+            (
+                self.wrappers,
+                self.func,
+            ),
+            (
+                self.wrappers,
+                self.func,
+                self.args,
+                self.keywords or None,
+                self.__dict__ or None,
+            ),
+        )
+
+    def __setstate__(
+        self,
+        state: tuple[
+            tuple[Callable[..., Any], ...],
+            Callable[..., Any],
+            tuple[Any, ...],
+            dict[str, Any],
+            dict[str, Any],
+        ],
+    ) -> None:
+        if not isinstance(state, tuple):  # pragma: no cover
+            raise TypeError("argument to __setstate__ must be a tuple")
+        if len(state) != 5:  # pragma: no cover
+            raise TypeError(f"expected 4 items in state, got {len(state)}")
+
+        self.wrappers, *substate = state
+        substate = tuple(substate)
+        super().__setstate__(substate)  # type: ignore
 
 
 def partial(
@@ -52,6 +129,7 @@ def zen_processing(
     _zen_target_wrapper: _tp.Union[None, _Wrapper] = None,
     **kwargs: _tp.Any,
 ) -> _tp.Any:
+
     if isinstance(_zen_wrappers, str) or not isinstance(_zen_wrappers, _tp.Sequence):
         unresolved_wrappers: _tp.Sequence[_WrapperConf] = (_zen_wrappers,)
     else:
@@ -83,7 +161,7 @@ def zen_processing(
 
     obj = get_obj(path=_zen_target)
     if _zen_target_wrapper is not None:
-        obj = _zen_target_wrapper(obj)
+        resolved_wrappers = [_zen_target_wrapper] + resolved_wrappers
 
     # first wrapper listed should be called first
     # [f1, f2, f3, ...] ->
@@ -91,15 +169,20 @@ def zen_processing(
     #    target = f2(target)
     #    target = f3(target)
     #    ...
-    for wrapper in resolved_wrappers:
-        obj = wrapper(obj)
 
     if _zen_exclude:
         excluded_set = set(_zen_exclude)
         kwargs = {k: v for k, v in kwargs.items() if k not in excluded_set}
 
     if _zen_partial is True:
-        return _functools.partial(obj, *args, **kwargs)
+        if not resolved_wrappers:
+            return _functools.partial(obj, *args, **kwargs)
+        else:
+            # if we have wrappers, we need to use the partial_with_wrapper
+            # class to ensure that the wrappers are called in the right order
+            return partial_with_wrapper(tuple(resolved_wrappers), obj, *args, **kwargs)
+    for wrapper in resolved_wrappers:
+        obj = wrapper(obj)
     return obj(*args, **kwargs)
 
 

--- a/src/hydra_zen/structured_configs/_implementations.py
+++ b/src/hydra_zen/structured_configs/_implementations.py
@@ -592,6 +592,9 @@ _is_jax_compiled_func = functools.partial(
     _check_instance, "CompiledFunction", "PjitFunction", module="jaxlib.xla_extension"
 )
 
+_is_jax_compiled_func2 = functools.partial(
+    _check_instance, "CompiledFunction", "PjitFunction", module="jaxlib._jax"
+)
 _is_jax_unspecified = functools.partial(
     _check_instance, "UnspecifiedValue", module="jax._src.interpreters.pxla"
 )
@@ -1178,6 +1181,7 @@ class BuildsFn(Generic[T]):
                 or _is_ufunc(value)
                 or _is_numpy_array_func_dispatcher(value=value)
                 or _is_jax_compiled_func(value=value)
+                or _is_jax_compiled_func2(value=value)
                 or _is_jax_ufunc(value=value)
             )
         ):

--- a/tests/test_instantiate.py
+++ b/tests/test_instantiate.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Massachusetts Institute of Technology
 # SPDX-License-Identifier: MIT
+import functools
 from dataclasses import dataclass
 from typing import Any
 
@@ -61,10 +62,13 @@ def test_wrapper_with_various_config_flavors(meta: bool, partial: bool):
 
     cfg = builds(dict, x=22, **kw)
     out = instantiate(cfg, _target_wrapper_=wrapper_tracker)
-    assert wrapper_tracker.num_calls == 1
-    assert wrapper_tracker.funcs[0] is dict
     if partial:
-        out = out()  # type: ignore
+        assert isinstance(out, functools.partial)
+        assert out.func is dict
+        out = out()
+
+    assert wrapper_tracker.funcs[0] is dict
+    assert wrapper_tracker.num_calls == 1
     assert out == dict(x=22)
 
 

--- a/tests/test_third_party/test_using_all_pydantic.py
+++ b/tests/test_third_party/test_using_all_pydantic.py
@@ -153,7 +153,7 @@ def test_roundtrip(
         assert isinstance(inst_out, partial)
         if isinstance(obj.target, partial):
             target = obj.target.func
-        elif obj.target is HasGeneric[int]:
+        elif isinstance(obj.target, (type(HasGeneric[int]), type(HasGeneric))):
             target = HasGeneric
         else:
             target = obj.target

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -492,3 +492,27 @@ def test_partial_with_wrapper(use_pickle: bool):
     assert p2() == 4
     assert p2.func is pfunc
     assert pfunc.__wrapped__ == 3  # type: ignore
+
+
+@given(...)
+def test_partial_parity(
+    args1: List[int], args2: List[int], kwargs1: Dict[str, int], kwargs2: Dict[str, int]
+):
+    def f(*args, **kwargs):
+        return args, kwargs
+
+    pw = partial_with_wrapper((pwrapper,), f, *args1, **kwargs1)
+    p = functools.partial(f, *args1, **kwargs1)
+    assert isinstance(pw, partial_with_wrapper)
+    assert isinstance(p, functools.partial)
+    assert pw.func is p.func
+    assert pw.args == p.args
+    assert pw.keywords == p.keywords
+
+    pw2 = partial_with_wrapper((pwrapper,), pw, *args2, **kwargs2)
+    p2 = functools.partial(p, *args2, **kwargs2)
+    assert isinstance(pw2, partial_with_wrapper)
+    assert isinstance(p2, functools.partial)
+    assert pw2.func is p2.func
+    assert pw2.args == p2.args
+    assert pw2.keywords == p2.keywords

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 import collections.abc as abc
 import enum
+import functools
+import pickle
 import random
 import string
 import sys
@@ -44,6 +46,7 @@ from typing_extensions import (
 
 from hydra_zen import DefaultBuilds, builds, instantiate, mutable_value
 from hydra_zen._compatibility import HYDRA_VERSION, Version, _get_version
+from hydra_zen.funcs import partial_with_wrapper
 from hydra_zen.structured_configs._utils import (
     StrictDataclassOptions,
     field,
@@ -454,3 +457,38 @@ def test_strict_dataclass_options_reflects_current_dataclass_ver():
     actual_keys = set(signature(make_dataclass).parameters)
     actual_keys.remove("fields")
     assert strict_keys == actual_keys
+
+
+def pfunc(x: int, y: int = 1):
+    return x + y
+
+
+def pwrapper(func):
+    if hasattr(func, "__wrapped__"):
+        func.__wrapped__ += 1
+    else:
+        func.__wrapped__ = 1
+    return func
+
+
+@pytest.mark.parametrize("use_pickle", [True, False], ids=["pickle", "no_pickle"])
+def test_partial_with_wrapper(use_pickle: bool):
+    if hasattr(pfunc, "__wrapped__"):
+        del pfunc.__wrapped__  # type: ignore
+    p = partial_with_wrapper((pwrapper,), pfunc, 1, y=2)
+    if use_pickle:
+        p = pickle.loads(pickle.dumps(p))
+    assert isinstance(p, functools.partial)
+    assert not hasattr(pfunc, "__wrapped__")
+    assert p() == 3
+    assert pfunc.__wrapped__ == 1  # type: ignore
+
+    p2 = partial_with_wrapper((pwrapper,), p, y=3)
+    if use_pickle:
+        p2 = pickle.loads(pickle.dumps(p2))
+    assert isinstance(p2, partial_with_wrapper)
+    assert pfunc.__wrapped__ == 1  # type: ignore
+    # wrapper should be applied twice
+    assert p2() == 4
+    assert p2.func is pfunc
+    assert pfunc.__wrapped__ == 3  # type: ignore


### PR DESCRIPTION
Closes https://github.com/mit-ll-responsible-ai/hydra-zen/issues/717 by deferring the wrapping process for partialed outputs. Now a special class -- `partial_with_wrapper` -- is used so that the resulting partial'd object exposes the expected, unwrapped, `.func` object, and is pickle-compatible by storing the wrapper

```python
import pickle

import hydra_zen
import torch.optim
from hydra_zen.third_party.pydantic import pydantic_parser

AdamConfig = hydra_zen.builds(
    torch.optim.Adam,
    populate_full_signature=True,
    zen_partial=True,
    zen_exclude=["params"],
    zen_dataclass={
        "cls_name": "AdamConfig",
        "module": "hydra_zen_issue_debug",
        "frozen": True,
    },
    zen_wrappers=[pydantic_parser],  # comment this out to make it work below.
)

obj = AdamConfig(lr=3e-4)
fn = hydra_zen.instantiate(obj)
restored_fn = pickle.loads(pickle.dumps(fn))  # <--- used to fail


assert restored_fn.func == fn.func
assert restored_fn.args == fn.args
assert restored_fn.keywords == fn.keywords

print("All good.")
```

```
All good.
```